### PR TITLE
LP: #1746842 - No network devices configured if YAML error in any file

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -290,7 +290,7 @@ write_network_file(net_definition* def, const char* rootdir, const char* path)
         net_definition* nd;
         g_hash_table_iter_init(&i, netdefs);
         while (g_hash_table_iter_next (&i, NULL, (gpointer*) &nd))
-            if (nd->vlan_link == def)
+            if (g_strcmp0(nd->vlan_link_id, def->id) == 0)
                 g_string_append_printf(s, "VLAN=%s\n", nd->id);
     }
     if (def->routes != NULL) {

--- a/src/nm.c
+++ b/src/nm.c
@@ -360,18 +360,21 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
     }
 
     if (def->type == ND_VLAN) {
+        net_definition *vlan_link;
         g_assert(def->vlan_id < G_MAXUINT);
-        g_assert(def->vlan_link != NULL);
+        g_assert(def->vlan_link_id != NULL);
+        vlan_link = g_hash_table_lookup(netdefs, def->vlan_link_id);
+        g_assert(vlan_link != NULL);
         g_string_append_printf(s, "\n[vlan]\nid=%u\nparent=", def->vlan_id);
-        if (def->vlan_link->has_match) {
+        if (vlan_link->has_match) {
             /* we need to refer to the parent's UUID as we don't have an
              * interface name with match: */
-            maybe_generate_uuid(def->vlan_link);
-            uuid_unparse(def->vlan_link->uuid, uuidstr);
+            maybe_generate_uuid(vlan_link);
+            uuid_unparse(vlan_link->uuid, uuidstr);
             g_string_append_printf(s, "%s\n", uuidstr);
         } else {
             /* if we have an interface name, use that as parent */
-            g_string_append_printf(s, "%s\n", def->vlan_link->id);
+            g_string_append_printf(s, "%s\n", vlan_link->id);
         }
     }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1303,6 +1303,23 @@ process_document(yaml_document_t* doc, GError** error)
     return ret;
 }
 
+#if !GLIB_CHECK_VERSION(2, 54, 0)
+static gboolean g_ptr_array_find(GPtrArray *haystack,
+                                 gconstpointer needle,
+                                 guint *index)
+{
+    guint i;
+    /* we exclue the found case from coverage, because if we hit
+     * it we're about to throw an assert */
+    for (i = 0; i < haystack->len; i++) {
+        if (g_ptr_array_index(haystack, i) == needle)
+            return TRUE; /* LCOV_EXCL_LINE */
+    }
+
+    return FALSE;
+}
+#endif
+
 /*
  * Validate that all the pointers in all netdefs are unique
  * to that netdef - that is, that there are no inter-netdef

--- a/src/parse.h
+++ b/src/parse.h
@@ -86,7 +86,7 @@ typedef struct net_definition {
 
     /* vlan */
     guint vlan_id;
-    struct net_definition* vlan_link;
+    char* vlan_link_id;
     gboolean has_vlans;
 
     /* Configured custom MAC address */

--- a/src/parse.h
+++ b/src/parse.h
@@ -178,6 +178,7 @@ extern GHashTable* netdefs;
  * Functions
  ****************************************************/
 
+GHashTable* duplicate_netdefs();
 gboolean parse_yaml(const char* filename, GError** error);
 gboolean finish_parse(GError** error);
 netdef_backend get_global_backend();


### PR DESCRIPTION
- Start a VM with a network interface created by cloud-init (say ens3), and assume you have no physical console (e.g. cloud VM)
- Add another network interface (say ens7)
- Create another YAML file to configure ens7, but make a small error. This file need not reference ens3 at all!
- Reboot machine

- Observe the following message on boot
systemd[332]: /lib/systemd/systemd-generators/netplan failed with error code 1.

- Observe that you can no longer SSH in to the machine because the error in the new yaml file prevents all generation, so ens3 is not configured.

This renders the system entirely unusable unless there is an alternative way to get in.

This fixes that - with 2 caveats:

1) It only helps if the error occurs in the parse phase rather than the generate phase.

2) If you have settings for a device spread out over multiple files, you can potentially end up in an unexpected state. This is probably still better than having no configuration at all, which is arguably the ultimate unexpected state.

Overall, I think it's a massive usability win, and it brings us more in line with how ifupdown works.

[Old behaviour can be retained by passing `--strict` to generate.]