### PR TITLE
Disable 10-globally-managed-devices.conf if any device uses NM

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -34,6 +34,7 @@
 static gchar* rootdir;
 static gchar** files;
 static gboolean any_networkd;
+static gboolean any_nm;
 static gchar* mapping_iface;
 
 static GOptionEntry options[] = {
@@ -55,7 +56,8 @@ nd_iterator(gpointer key, gpointer value, gpointer user_data)
 {
     if (write_networkd_conf((net_definition*) value, (const char*) user_data))
         any_networkd = TRUE;
-    write_nm_conf((net_definition*) value, (const char*) user_data);
+    if (write_nm_conf((net_definition*) value, (const char*) user_data))
+        any_nm = TRUE;
 }
 
 
@@ -262,8 +264,8 @@ int main(int argc, char** argv)
     }
 
     /* Disable /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf
-     * (which restricts NM to wifi and wwan) if global renderer is NM */
-    if (get_global_backend() == BACKEND_NM)
+     * (which restricts NM to wifi and wwan) if NM is used as a renderer */
+    if (get_global_backend() == BACKEND_NM || any_nm)
         g_string_free_to_file(g_string_new(NULL), rootdir, "/run/NetworkManager/conf.d/10-globally-managed-devices.conf", NULL);
 
     if (called_as_generator) {

--- a/src/nm.c
+++ b/src/nm.c
@@ -455,12 +455,12 @@ write_nm_conf_access_point(net_definition* def, const char* rootdir, const wifi_
  * @rootdir: If not %NULL, generate configuration in this root directory
  *           (useful for testing).
  */
-void
+gboolean
 write_nm_conf(net_definition* def, const char* rootdir)
 {
     if (def->backend != BACKEND_NM) {
         g_debug("NetworkManager: definition %s is not for us (backend %i)", def->id, def->backend);
-        return;
+        return FALSE;
     }
 
     if (def->match.driver && !def->set_name) {
@@ -481,6 +481,8 @@ write_nm_conf(net_definition* def, const char* rootdir)
         g_assert(def->access_points == NULL);
         write_nm_conf_access_point(def, rootdir, NULL);
     }
+
+    return TRUE;
 }
 
 static void

--- a/src/nm.h
+++ b/src/nm.h
@@ -19,6 +19,6 @@
 
 #include "parse.h"
 
-void write_nm_conf(net_definition* def, const char* rootdir);
+gboolean write_nm_conf(net_definition* def, const char* rootdir);
 void write_nm_conf_finish(const char* rootdir);
 void cleanup_nm_conf(const char* rootdir);


### PR DESCRIPTION
LP: #1753860

I found that specifying NM as the renderer for a single ethernet
device didn't work - 10-globally-managed-devices.conf still stops
NM from managing it.

Disable that file if any interface uses NM.

I am a little concerned that this might lead to different behaviour
if you hotplug a device when any device is using NM - it will be
managed by NM. This already happens if NM is the global renderer, so
I don't think it's a big issue, but something to be aware of.

Signed-off-by: Daniel Axtens <dja@axtens.net>

## Checklist

- [Y] Runs 'make check' successfully.
- [Y] Retains 100% code coverage (make check-coverage).
- [n/a] New/changed keys in YAML format are documented.
- [Y] Closes an open bug in Launchpad.

