### PR TITLE
Add dummy interfaces

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -883,6 +883,11 @@ Examples:
 :    netplan ID of the underlying device definition on which this VLAN gets
      created.
 
+## Properties for device type ``dummies:``
+
+    None.
+
+
 Example:
 
     ethernets:

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -280,6 +280,10 @@ write_netdev_file(net_definition* def, const char* rootdir, const char* path)
             g_string_append_printf(s, "Kind=vlan\n\n[VLAN]\nId=%u\n", def->vlan_id);
             break;
 
+        case ND_DUMMY:
+            g_string_append_printf(s, "Kind=dummy\n");
+            break;
+
         case ND_TUNNEL:
             switch(def->tunnel.mode) {
                 case TUNNEL_MODE_GRE:

--- a/src/nm.c
+++ b/src/nm.c
@@ -87,6 +87,8 @@ type_str(netdef_type type)
             return "bond";
         case ND_VLAN:
             return "vlan";
+        case ND_DUMMY:
+            return "dummy";
         case ND_TUNNEL:
             return "ip-tunnel";
         // LCOV_EXCL_START

--- a/src/parse.c
+++ b/src/parse.c
@@ -1613,6 +1613,11 @@ const mapping_entry_handler vlan_def_handlers[] = {
     {NULL}
 };
 
+const mapping_entry_handler dummy_def_handlers[] = {
+    COMMON_LINK_HANDLERS,
+    {NULL}
+};
+
 const mapping_entry_handler tunnel_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     {"mode", YAML_SCALAR_NODE, handle_tunnel_mode},
@@ -1738,6 +1743,7 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
             case ND_TUNNEL: handlers = tunnel_def_handlers; break;
             case ND_VLAN: handlers = vlan_def_handlers; break;
             case ND_WIFI: handlers = wifi_def_handlers; break;
+            case ND_DUMMY: handlers = dummy_def_handlers; break;
             default: g_assert_not_reached(); // LCOV_EXCL_LINE
         }
         if (!process_mapping(doc, value, handlers, error))
@@ -1765,6 +1771,7 @@ const mapping_entry_handler network_handlers[] = {
     {"version", YAML_SCALAR_NODE, handle_network_version},
     {"vlans", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(ND_VLAN)},
     {"wifis", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(ND_WIFI)},
+    {"dummies", YAML_MAPPING_NODE, handle_network_type, NULL, GUINT_TO_POINTER(ND_DUMMY)},
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -48,6 +48,7 @@ typedef enum {
     ND_BRIDGE = ND_VIRTUAL,
     ND_BOND,
     ND_VLAN,
+    ND_DUMMY,
     ND_TUNNEL,
 } netdef_type;
 


### PR DESCRIPTION
## Description

Split from #82 

This is more like a place to discuss how to put dummy interfaces in netplan rather than a straight PR.
Besides, I'm not sure with what exactly to bring code coverage back to 100%
Let's maybe work on this? I'm using this code to force bridge intefaces up when they don't have any other interfaces added on configuration time. This is a real use case.


## Checklist

- [x] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

