### PR TITLE
bridges: implement vlans & port-vlans options for NM backend

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -667,6 +667,12 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           a number between ``0`` and ``63``. This metric is used in the
           designated port and root port selection algorithms.
 
+     ``port-vlans`` (sequence of scalars)
+     :    Array of bridge VLAN objects. The VLAN list can be specified with the
+          following syntax: $vid [pvid] [untagged] [, $vid [pvid] [untagged]]..
+          where $vid is either a single id between 1 and 4094 or a range,
+          represented as a couple of ids separated by a dash.
+
      ``forward-delay`` (scalar)
      :    Specify the period of time the bridge will remain in Listening and
           Learning states before getting to the Forwarding state. This field
@@ -698,6 +704,11 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           default value is "true", which means that Spanning Tree should be
           used.
 
+     ``vlans`` (sequence of scalars)
+     :    Array of bridge VLAN objects. The VLAN list can be specified with the
+          following syntax: $vid [pvid] [untagged] [, $vid [pvid] [untagged]]..
+          where $vid is either a single id between 1 and 4094 or a range,
+          represented as a couple of ids separated by a dash.
 
 ## Properties for device type ``bonds:``
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -96,6 +96,11 @@ write_bridge_params(GString* s, const NetplanNetDefinition* def)
         if (def->bridge_params.max_age)
             g_string_append_printf(params, "MaxAgeSec=%s\n", def->bridge_params.max_age);
         g_string_append_printf(params, "STP=%s\n", def->bridge_params.stp ? "true" : "false");
+        if (def->bridge_params.vlans) {
+            // TODO: research and implement bridge vlans for networkd
+            g_fprintf(stderr, "ERROR: %s: networkd does not support bridge vlans\n", def->id);
+            exit(1);
+        }
 
         g_string_append_printf(s, "\n[Bridge]\n%s", params->str);
 
@@ -526,6 +531,11 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
             g_string_append_printf(network, "Cost=%u\n", def->bridge_params.path_cost);
         if (def->bridge_params.port_priority)
             g_string_append_printf(network, "Priority=%u\n", def->bridge_params.port_priority);
+        if (def->bridge_params.port_vlans) {
+            // TODO: research and implement bridge port-vlans for networkd
+            g_fprintf(stderr, "ERROR: %s: networkd does not support bridge port-vlans\n", def->id);
+            exit(1);
+        }
     }
     if (def->bond) {
         g_string_append_printf(network, "Bond=%s\n", def->bond);

--- a/src/nm.c
+++ b/src/nm.c
@@ -298,6 +298,7 @@ write_bridge_params(const NetplanNetDefinition* def, GString *s)
             g_string_append_printf(params, "max-age=%s\n", def->bridge_params.max_age);
         g_string_append_printf(params, "stp=%s\n", def->bridge_params.stp ? "true" : "false");
         if (def->bridge_params.vlans) {
+            g_string_append(params, "vlan-filtering=true\n");
             g_string_append(params, "vlans=");
             for (unsigned i = 0; i < def->bridge_params.vlans->len; ++i) {
                 if (i > 0)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1199,6 +1199,108 @@ handle_bridge_port_priority(yaml_document_t* doc, yaml_node_t* node, const void*
     return TRUE;
 }
 
+static gboolean
+handle_generic_vlans(yaml_document_t* doc, yaml_node_t* node, GArray** entryptr, const void* data, GError** error)
+{
+    static regex_t re;
+    static gboolean re_inited = FALSE;
+
+    if (!re_inited) {
+        g_assert(regcomp(&re, "^([0-9]+)(-([0-9]+))?( (pvid))?( (untagged))?$", REG_EXTENDED) == 0);
+        re_inited = TRUE;
+    }
+
+    for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
+        g_autofree char* vlan = NULL;
+        yaml_node_t *entry = yaml_document_get_node(doc, *i);
+        assert_type(entry, YAML_SCALAR_NODE);
+
+        vlan = g_strdup(scalar(entry));
+
+        size_t maxGroups = 7+1;
+        regmatch_t groups[maxGroups];
+        /* does it match the vlans= definition? */
+        if (regexec(&re, vlan, maxGroups, groups, 0) == 0) {
+            NetplanBridgeVlan* data = g_new0(NetplanBridgeVlan, 1);
+            for (unsigned g = 1; g < maxGroups; g = g+2) {
+                if (groups[g].rm_so == (size_t)-1)
+                    continue; // Invalid group
+
+                char cursorCopy[strlen(vlan) + 1];
+                strcpy(cursorCopy, vlan);
+                cursorCopy[groups[g].rm_eo] = 0;
+                guint v = 0;
+                switch (g) {
+                    case 1:
+                        v = g_ascii_strtoull(cursorCopy + groups[g].rm_so, NULL, 10);
+                        if (v < 1 || v > 4094)
+                            return yaml_error(node, error, "malformed vlan vid '%u', must be in range [1..4094]", v);
+                        data->vid = v;
+                        break;
+                    case 3:
+                        v = g_ascii_strtoull(cursorCopy + groups[g].rm_so, NULL, 10);
+                        if (v < 1 || v > 4094)
+                            return yaml_error(node, error, "malformed vlan vid '%u', must be in range [1..4094]", v);
+                        else if (v <= data->vid)
+                            return yaml_error(node, error, "malformed vlan vid range '%s': %u > %u!", scalar(entry), data->vid, v);
+                        data->vid_to = v;
+                        break;
+                    case 5:
+                        data->pvid = TRUE;
+                        break;
+                    case 7:
+                        data->untagged = TRUE;
+                        break;
+                    default: g_assert_not_reached(); // LCOV_EXCL_LINE
+                }
+            }
+            if (!*entryptr)
+                *entryptr = g_array_new(FALSE, FALSE, sizeof(NetplanBridgeVlan*));
+            g_array_append_val(*entryptr, data);
+            continue;
+        }
+
+        return yaml_error(node, error, "malformed vlan '%s', must be: $vid [pvid] [untagged] [, $vid [pvid] [untagged]]", scalar(entry));
+    }
+
+    return TRUE;
+}
+
+static gboolean
+handle_bridge_vlans(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    return handle_generic_vlans(doc, node, &(cur_netdef->bridge_params.vlans), data, error);
+}
+
+static gboolean
+handle_bridge_port_vlans(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
+{
+    for (yaml_node_pair_t* entry = node->data.mapping.pairs.start; entry < node->data.mapping.pairs.top; entry++) {
+        yaml_node_t* key, *value;
+        NetplanNetDefinition *component;
+        GArray** ref_ptr;
+
+        key = yaml_document_get_node(doc, entry->key);
+        assert_type(key, YAML_SCALAR_NODE);
+        value = yaml_document_get_node(doc, entry->value);
+        assert_type(value, YAML_SEQUENCE_NODE);
+
+        component = g_hash_table_lookup(netdefs, scalar(key));
+        if (!component) {
+            add_missing_node(key);
+        } else {
+            ref_ptr = &(component->bridge_params.port_vlans);
+            if (*ref_ptr)
+                return yaml_error(node, error, "%s: interface '%s' already has port vlans",
+                                  cur_netdef->id, scalar(key));
+
+            if (!handle_generic_vlans(doc, value, ref_ptr, data, error))
+                return FALSE;
+        }
+    }
+    return TRUE;
+}
+
 static const mapping_entry_handler bridge_params_handlers[] = {
     {"ageing-time", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bridge_params.ageing_time)},
     {"forward-delay", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bridge_params.forward_delay)},
@@ -1206,8 +1308,10 @@ static const mapping_entry_handler bridge_params_handlers[] = {
     {"max-age", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(bridge_params.max_age)},
     {"path-cost", YAML_MAPPING_NODE, handle_bridge_path_cost, NULL, netdef_offset(bridge_params.path_cost)},
     {"port-priority", YAML_MAPPING_NODE, handle_bridge_port_priority, NULL, netdef_offset(bridge_params.port_priority)},
+    {"port-vlans", YAML_MAPPING_NODE, handle_bridge_port_vlans},
     {"priority", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(bridge_params.priority)},
     {"stp", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(bridge_params.stp)},
+    {"vlans", YAML_SEQUENCE_NODE, handle_bridge_vlans},
     {NULL}
 };
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -293,6 +293,8 @@ struct net_definition {
         char* max_age;
         guint path_cost;
         gboolean stp;
+        GArray* vlans;
+        GArray* port_vlans;
     } bridge_params;
     gboolean custom_bridging;
 
@@ -319,6 +321,13 @@ struct net_definition {
         } networkd;
     } backend_settings;
 };
+
+typedef struct {
+    guint vid; //[1..4094]
+    guint vid_to; //set iff vid range defined
+    gboolean pvid;
+    gboolean untagged;
+} NetplanBridgeVlan;
 
 typedef enum {
     NETPLAN_WIFI_MODE_INFRASTRUCTURE,

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -621,6 +621,7 @@ interface-name=br0
 
 [bridge]
 stp=true
+vlan-filtering=true
 vlans=1-100 pvid untagged, 42 untagged, 13, 1 pvid, 2-100 pvid untagged
 
 [ipv4]


### PR DESCRIPTION
## Description
Implements the `vlans` & `port-vlans` option keys for bridges, as required by the "NetworkManager readwrite plugin" spec. Currently only supports the `nm` backend. I need to further research the `networkd` backend...

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

