### PR TITLE
fix wrong filter for restart wpa units

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -152,7 +152,7 @@ class NetplanApply(utils.NetplanCommand):
                 utils.systemctl_daemon_reload()
             # Clean up any old netplan related OVS ports/bonds/bridges, if applicable
             NetplanApply.process_ovs_cleanup(config_manager, old_files_ovs, restart_ovs, exit_on_error)
-            wpa_services = '"netplan-wpa-*.service"'
+            wpa_services = ['"netplan-wpa-*.service"']
             # Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
             # upgraded system, we need to make sure to stop those.
             if utils.systemctl_is_active('netplan-wpa@*.service'):

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -152,7 +152,7 @@ class NetplanApply(utils.NetplanCommand):
                 utils.systemctl_daemon_reload()
             # Clean up any old netplan related OVS ports/bonds/bridges, if applicable
             NetplanApply.process_ovs_cleanup(config_manager, old_files_ovs, restart_ovs, exit_on_error)
-            wpa_services = ['netplan-wpa-{}.service'.format(iface) for iface in os.listdir('/sys/class/net/') if iface != 'lo']
+            wpa_services = '"netplan-wpa-*.service"'
             # Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
             # upgraded system, we need to make sure to stop those.
             if utils.systemctl_is_active('netplan-wpa@*.service'):

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -152,7 +152,7 @@ class NetplanApply(utils.NetplanCommand):
                 utils.systemctl_daemon_reload()
             # Clean up any old netplan related OVS ports/bonds/bridges, if applicable
             NetplanApply.process_ovs_cleanup(config_manager, old_files_ovs, restart_ovs, exit_on_error)
-            wpa_services = ['netplan-wpa-*.service']
+            wpa_services = ['netplan-wpa-{}.service'.format(iface) for iface in os.listdir('/sys/class/net/') if iface != 'lo']
             # Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
             # upgraded system, we need to make sure to stop those.
             if utils.systemctl_is_active('netplan-wpa@*.service'):


### PR DESCRIPTION
## Description
Step for reproduced:

```
sudo netplan try
Job for netplan-wpa-wlan0.service canceled.

An error occurred: Command '['systemctl', 'stop', 'systemd-networkd.service', 'netplan-wpa-*.service']' returned non-zero exit status 1.
```

In my shell:
```
sudo systemctl stop netplan-wpa-*.service
zsh: no matches found: netplan-wpa-*.service
``` 
-- returned non-zero exit code.

How does work?
```sudo systemctl stop netplan-wpa-wlan0.service``` -- exit code is 0.