### PR TITLE
Improvements for the NetworkManager YAML backend integration

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -232,11 +232,11 @@ int main(int argc, char** argv)
         return find_interface(mapping_iface);
 
     /* Generate backend specific configuration files from merged data. */
+    write_ovs_conf_finish(rootdir); // OVS cleanup unit is always written
     if (netdefs) {
         g_debug("Generating output files..");
         g_list_foreach (netdefs_ordered, nd_iterator_list, rootdir);
         write_nm_conf_finish(rootdir);
-        write_ovs_conf_finish(rootdir);
         if (any_sriov) write_sriov_conf_finish(rootdir);
         /* We may have written .rules & .link files, thus we must
          * invalidate udevd cache of its config as by default it only

--- a/src/nm-keyfile.c
+++ b/src/nm-keyfile.c
@@ -177,14 +177,15 @@ netplan_render_yaml_from_nm_keyfile(GKeyFile* kf, const char* rootdir)
 
     /* Handle match: Netplan usually defines a connection per interface, while
      * NM connection profiles are usually applied to any interface of matching
-     * type (like wifi/ethernet/...). Therefore, we match the interface on '*'
-     * if not specified. */
-    nd->match.original_name = g_key_file_get_string(kf, "connection", "interface-name", NULL);
-    if (nd->match.original_name)
-        g_key_file_remove_key(kf, "connection", "interface-name", NULL);
-    else
-        nd->match.original_name = g_strdup("*");
-    nd->has_match = TRUE;
+     * type (like wifi/ethernet/...). */
+    if (nd->type < NETPLAN_DEF_TYPE_VIRTUAL) {
+        nd->match.original_name = g_key_file_get_string(kf, "connection", "interface-name", NULL);
+        if (nd->match.original_name)
+            _kf_clear_key(kf, "connection", "interface-name");
+        /* Set match, even if it is empty, so the NM renderer will not force
+         * the netdef ID as interface-name */
+        nd->has_match = TRUE;
+    }
 
     /* Modem parameters to detect GSM vs CDMA connections */
     nd->modem_params.auto_config = g_key_file_get_boolean(kf, "gsm", "auto-config", NULL);

--- a/src/nm-keyfile.c
+++ b/src/nm-keyfile.c
@@ -182,6 +182,16 @@ netplan_render_yaml_from_nm_keyfile(GKeyFile* kf, const char* rootdir)
         nd->match.original_name = g_strdup("*");
     nd->has_match = TRUE;
 
+    /* wake-on-lan, do not clear passthrough as we do not fully support this setting */
+    if (g_key_file_has_group(kf, "ethernet")) {
+        if (!g_key_file_has_key(kf, "ethernet", "wake-on-lan", NULL)) {
+            nd->wake_on_lan = TRUE; //NM's default is "1"
+        } else {
+            //XXX: fix delta between options in NM (0x1, 0x2, 0x4, ...) and netplan (bool)
+            nd->wake_on_lan = g_key_file_get_uint64(kf, "ethernet", "wake-on-lan", NULL) > 0;
+        }
+    }
+
     /* Special handling for WiFi "access-points:" mapping */
     if (nd->type == NETPLAN_DEF_TYPE_WIFI) {
         ap = g_new0(NetplanWifiAccessPoint, 1);

--- a/src/nm-keyfile.c
+++ b/src/nm-keyfile.c
@@ -81,7 +81,11 @@ read_passthrough(GKeyFile* kf, GHashTable** out_map)
         for (unsigned i = 0; i < glen; ++i) {
             klen = 0;
             keys = g_key_file_get_keys(kf, groups[i], &klen, NULL);
-            if (!keys) continue; // empty group
+            if (klen == 0) {
+                /* empty group */
+                g_datalist_set_data_full(list, g_strconcat(groups[i], ".", NETPLAN_NM_EMPTY_GROUP, NULL), g_strdup(""), g_free);
+                continue;
+            }
             for (unsigned j = 0; j < klen; ++j) {
                 value = g_key_file_get_string(kf, groups[i], keys[j], NULL);
                 if (!value) {

--- a/src/nm-keyfile.c
+++ b/src/nm-keyfile.c
@@ -191,7 +191,11 @@ netplan_render_yaml_from_nm_keyfile(GKeyFile* kf, const char* netdef_id, const c
         nd->has_match = TRUE;
     }
 
-    /* Modem parameters to detect GSM vs CDMA connections */
+    /* Modem parameters
+     * NM differentiates between GSM and CDMA connections, while netplan
+     * combines them as "modems". We need to parse a basic set of parameters
+     * to enable the generator (in nm.c) to detect GSM vs CDMA connections,
+     * using its modem_is_gsm() util. */
     nd->modem_params.auto_config = g_key_file_get_boolean(kf, "gsm", "auto-config", NULL);
     _kf_clear_key(kf, "gsm", "auto-config");
     nd->modem_params.apn = g_key_file_get_string(kf, "gsm", "apn", NULL);

--- a/src/nm-keyfile.c
+++ b/src/nm-keyfile.c
@@ -182,6 +182,28 @@ netplan_render_yaml_from_nm_keyfile(GKeyFile* kf, const char* rootdir)
         nd->match.original_name = g_strdup("*");
     nd->has_match = TRUE;
 
+    /* Modem parameters to detect GSM vs CDMA connections */
+    nd->modem_params.auto_config = g_key_file_get_boolean(kf, "gsm", "auto-config", NULL);
+    _kf_clear_key(kf, "gsm", "auto-config");
+    nd->modem_params.apn = g_key_file_get_string(kf, "gsm", "apn", NULL);
+    if (nd->modem_params.apn)
+        _kf_clear_key(kf, "gsm", "apn");
+    nd->modem_params.device_id = g_key_file_get_string(kf, "gsm", "device-id", NULL);
+    if (nd->modem_params.device_id)
+        _kf_clear_key(kf, "gsm", "device-id");
+    nd->modem_params.network_id = g_key_file_get_string(kf, "gsm", "network-id", NULL);
+    if (nd->modem_params.network_id)
+        _kf_clear_key(kf, "gsm", "network-id");
+    nd->modem_params.pin = g_key_file_get_string(kf, "gsm", "pin", NULL);
+    if (nd->modem_params.pin)
+        _kf_clear_key(kf, "gsm", "pin");
+    nd->modem_params.sim_id = g_key_file_get_string(kf, "gsm", "sim-id", NULL);
+    if (nd->modem_params.sim_id)
+        _kf_clear_key(kf, "gsm", "sim-id");
+    nd->modem_params.sim_operator_id = g_key_file_get_string(kf, "gsm", "sim-operator-id", NULL);
+    if (nd->modem_params.sim_operator_id)
+        _kf_clear_key(kf, "gsm", "sim-operator-id");
+
     /* wake-on-lan, do not clear passthrough as we do not fully support this setting */
     if (g_key_file_has_group(kf, "ethernet")) {
         if (!g_key_file_has_key(kf, "ethernet", "wake-on-lan", NULL)) {

--- a/src/nm-keyfile.c
+++ b/src/nm-keyfile.c
@@ -65,7 +65,7 @@ ap_type_from_str(const char* type_str)
 
 /* Read the key-value pairs from the keyfile and pass them through to a map */
 static void
-read_passthrough(GKeyFile* kf, GHashTable** out_map)
+read_passthrough(GKeyFile* kf, GData** list)
 {
     gchar **groups = NULL;
     gchar **keys = NULL;
@@ -74,8 +74,8 @@ read_passthrough(GKeyFile* kf, GHashTable** out_map)
     gsize klen = 0;
     gsize glen = 0;
 
-    if (!*out_map)
-        *out_map = g_hash_table_new(g_str_hash, g_str_equal);
+    if (!*list)
+        g_datalist_init(list);
     groups = g_key_file_get_groups(kf, &glen);
     if (groups) {
         for (unsigned i = 0; i < glen; ++i) {
@@ -95,8 +95,8 @@ read_passthrough(GKeyFile* kf, GHashTable** out_map)
                     // LCOV_EXCL_STOP
                 }
                 group_key = g_strconcat(groups[i], ".", keys[j], NULL);
-                g_hash_table_insert(*out_map, group_key, value);
-                /* no need to free group_key and value: they stay in the map */
+                g_datalist_set_data_full(list, group_key, value, g_free);
+                /* no need to free group_key and value: they stay in the list */
             }
             g_strfreev(keys);
         }

--- a/src/nm-keyfile.h
+++ b/src/nm-keyfile.h
@@ -17,5 +17,7 @@
 
 #pragma once
 
+#define NETPLAN_NM_EMPTY_GROUP "_"
+
 gboolean netplan_render_yaml_from_nm_keyfile(GKeyFile* kf, const char* rootdir);
 gchar* netplan_get_id_from_nm_filename(const char* filename, const char* ssid);

--- a/src/nm-keyfile.h
+++ b/src/nm-keyfile.h
@@ -19,5 +19,5 @@
 
 #define NETPLAN_NM_EMPTY_GROUP "_"
 
-gboolean netplan_render_yaml_from_nm_keyfile(GKeyFile* kf, const char* rootdir);
+gboolean netplan_render_yaml_from_nm_keyfile(GKeyFile* kf, const char* netdef_id, const char* rootdir);
 gchar* netplan_get_id_from_nm_filename(const char* filename, const char* ssid);

--- a/src/nm.c
+++ b/src/nm.c
@@ -827,7 +827,8 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         conf_path = g_strjoin(NULL, "run/NetworkManager/system-connections/netplan-", def->id, "-", escaped_ssid, ".nmconnection", NULL);
 
         g_key_file_set_string(kf, "wifi", "ssid", ap->ssid);
-        g_key_file_set_string(kf, "wifi", "mode", wifi_mode_str(ap->mode));
+        if (ap->mode < NETPLAN_WIFI_MODE_OTHER)
+            g_key_file_set_string(kf, "wifi", "mode", wifi_mode_str(ap->mode));
         if (ap->bssid)
             g_key_file_set_string(kf, "wifi", "bssid", ap->bssid);
         if (ap->hidden)

--- a/src/nm.c
+++ b/src/nm.c
@@ -583,6 +583,10 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         g_key_file_set_comment(kf, "connection", "type", "Netplan: Unsupported connection.type setting, overridden by passthrough", NULL);
     }
 
+    if (ap && ap->backend_settings.nm.uuid)
+        g_key_file_set_string(kf, "connection", "uuid", ap->backend_settings.nm.uuid);
+    else if (def->backend_settings.nm.uuid)
+        g_key_file_set_string(kf, "connection", "uuid", def->backend_settings.nm.uuid);
     /* VLAN devices refer to us as their parent; if our ID is not a name but we
      * have matches, parent= must be the connection UUID, so put it into the
      * connection */

--- a/src/nm.c
+++ b/src/nm.c
@@ -80,10 +80,13 @@ g_string_append_netdef_match(GString* s, const NetplanNetDefinition* def)
 static const gboolean
 modem_is_gsm(const NetplanNetDefinition* def)
 {
-    if (def->type == NETPLAN_DEF_TYPE_MODEM && (def->modem_params.apn ||
-        def->modem_params.auto_config || def->modem_params.device_id ||
-        def->modem_params.network_id || def->modem_params.pin ||
-        def->modem_params.sim_id || def->modem_params.sim_operator_id))
+    if (   def->modem_params.apn
+        || def->modem_params.auto_config
+        || def->modem_params.device_id
+        || def->modem_params.network_id
+        || def->modem_params.pin
+        || def->modem_params.sim_id
+        || def->modem_params.sim_operator_id)
         return TRUE;
 
     return FALSE;

--- a/src/nm.c
+++ b/src/nm.c
@@ -939,7 +939,7 @@ write_nm_conf_finish(const char* rootdir)
     GString *s = NULL;
     gsize len;
 
-    if (g_hash_table_size(netdefs) == 0)
+    if (!netdefs || g_hash_table_size(netdefs) == 0)
         return;
 
     /* Set all devices not managed by us to unmanaged, so that NM does not

--- a/src/nm.c
+++ b/src/nm.c
@@ -575,13 +575,6 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
     nm_type = type_str(def);
     if (nm_type)
         g_key_file_set_string(kf, "connection", "type", nm_type);
-    else {
-        /* This case is checked in validation.c and should never happen */
-        if (!def->backend_settings.nm.passthrough || !g_datalist_get_data(&def->backend_settings.nm.passthrough, "connection.type"))
-            g_assert_not_reached(); // LCOV_EXCL_LINE
-        g_key_file_set_string(kf, "connection", "type", g_datalist_get_data(&def->backend_settings.nm.passthrough, "connection.type"));
-        g_key_file_set_comment(kf, "connection", "type", "Netplan: Unsupported connection.type setting, overridden by passthrough", NULL);
-    }
 
     if (ap && ap->backend_settings.nm.uuid)
         g_key_file_set_string(kf, "connection", "uuid", ap->backend_settings.nm.uuid);

--- a/src/nm.c
+++ b/src/nm.c
@@ -30,6 +30,7 @@
 #include "parse.h"
 #include "util.h"
 #include "validation.h"
+#include "nm-keyfile.h"
 
 GString* udev_rules;
 
@@ -497,6 +498,9 @@ write_fallback_key_value(gpointer key, gpointer value, gpointer user_data)
     }
     g_key_file_set_string(kf, group, k, val);
     g_strfreev(group_key);
+    /* delete the dummy key, if this was just an empty group */
+    if (!g_strcmp0(k, NETPLAN_NM_EMPTY_GROUP))
+        g_key_file_remove_key(kf, group, k, NULL);
 }
 
 /**

--- a/src/nm.c
+++ b/src/nm.c
@@ -609,7 +609,10 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         /* else matches on something other than the name, do not restrict interface-name */
     } else {
         /* virtual (created) devices set a name */
-        g_key_file_set_string(kf, "connection", "interface-name", def->id);
+        if (strlen(def->id) > 15)
+            g_debug("interface-name longer than 15 characters is not supported");
+        else
+            g_key_file_set_string(kf, "connection", "interface-name", def->id);
 
         if (def->type == NETPLAN_DEF_TYPE_BRIDGE)
             write_bridge_params(def, kf);

--- a/src/nm.c
+++ b/src/nm.c
@@ -665,7 +665,8 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
     }
 
     if (def->type < NETPLAN_DEF_TYPE_VIRTUAL) {
-        g_key_file_set_integer(kf, "ethernet", "wake-on-lan", def->wake_on_lan ? 1 : 0);
+        if (def->type == NETPLAN_DEF_TYPE_ETHERNET)
+            g_key_file_set_integer(kf, "ethernet", "wake-on-lan", def->wake_on_lan ? 1 : 0);
 
         const char* con_type = NULL;
         switch (def->type) {

--- a/src/parse.c
+++ b/src/parse.c
@@ -240,6 +240,8 @@ netplan_netdef_new(const char* id, NetplanDefType type, NetplanBackend backend)
     /* OpenVSwitch defaults */
     initialize_ovs_settings(&cur_netdef->ovs_settings);
 
+    if (!netdefs)
+        netdefs = g_hash_table_new(g_str_hash, g_str_equal);
     g_hash_table_insert(netdefs, cur_netdef->id, cur_netdef);
     netdefs_ordered = g_list_append(netdefs_ordered, cur_netdef);
     return cur_netdef;
@@ -2681,7 +2683,12 @@ netplan_clear_netdefs()
         /* FIXME: make sure that any dynamically allocated netdef data is freed */
         if (n > 0)
             g_hash_table_remove_all(netdefs);
+        netdefs = NULL;
 	}
+    if(netdefs_ordered) {
+        g_clear_list(&netdefs_ordered, g_free);
+        netdefs_ordered = NULL;
+    }
     return n;
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -2290,6 +2290,7 @@ static const mapping_entry_handler vlan_def_handlers[] = {
 static const mapping_entry_handler modem_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     COMMON_BACKEND_HANDLERS,
+    PHYSICAL_LINK_HANDLERS,
     {"apn", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(modem_params.apn)},
     {"auto-config", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(modem_params.auto_config)},
     {"device-id", YAML_SCALAR_NODE, handle_netdef_str, NULL, netdef_offset(modem_params.device_id)},

--- a/src/parse.c
+++ b/src/parse.c
@@ -2485,7 +2485,7 @@ handle_network_type(yaml_document_t* doc, yaml_node_t* node, const void* data, G
         /* convenience shortcut: physical device without match: means match
          * name on ID */
         if (cur_netdef->type < NETPLAN_DEF_TYPE_VIRTUAL && !cur_netdef->has_match)
-            cur_netdef->match.original_name = cur_netdef->id;
+            cur_netdef->match.original_name = g_strdup(cur_netdef->id);
     }
     backend_cur_type = NETPLAN_BACKEND_NONE;
     return TRUE;

--- a/src/parse.h
+++ b/src/parse.h
@@ -241,7 +241,7 @@ typedef union {
         char *uuid;
         char *stable_id;
         char *device;
-        GHashTable* passthrough;
+        GData* passthrough;
     } nm;
     struct NetplanNetworkdSettings {
         char *unit;

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -134,14 +134,12 @@ netplan_render_netdef(NetplanNetDefinition* nd, const char* yaml_path)
     YAML_SCALAR_PLAIN(event, emitter, "network");
     YAML_MAPPING_OPEN(event, emitter);
     // TODO: global backend/renderer
-    YAML_SCALAR_PLAIN(event, emitter, "version");
-    YAML_SCALAR_PLAIN(event, emitter, "2");
+    YAML_STRING_PLAIN(event, emitter, "version", "2");
     YAML_SCALAR_PLAIN(event, emitter, netplan_def_type_to_str[nd->type]);
     YAML_MAPPING_OPEN(event, emitter);
     YAML_SCALAR_PLAIN(event, emitter, nd->id);
     YAML_MAPPING_OPEN(event, emitter);
-    YAML_SCALAR_PLAIN(event, emitter, "renderer");
-    YAML_SCALAR_PLAIN(event, emitter, netplan_backend_to_name[nd->backend]);
+    YAML_STRING_PLAIN(event, emitter, "renderer", netplan_backend_to_name[nd->backend])
 
     if (nd->has_match)
         write_match(event, emitter, nd);
@@ -149,6 +147,16 @@ netplan_render_netdef(NetplanNetDefinition* nd, const char* yaml_path)
     /* wake-on-lan */
     if (nd->wake_on_lan)
         YAML_STRING_PLAIN(event, emitter, "wakeonlan", "true");
+
+    /* some modem settings to auto-detect GSM vs CDMA connections */
+    if (nd->modem_params.auto_config)
+        YAML_STRING_PLAIN(event, emitter, "auto-config", "true");
+    YAML_STRING(event, emitter, "apn", nd->modem_params.apn);
+    YAML_STRING(event, emitter, "device-id", nd->modem_params.device_id);
+    YAML_STRING(event, emitter, "network-id", nd->modem_params.network_id);
+    YAML_STRING(event, emitter, "pin", nd->modem_params.pin);
+    YAML_STRING(event, emitter, "sim-id", nd->modem_params.sim_id);
+    YAML_STRING(event, emitter, "sim-operator-id", nd->modem_params.sim_operator_id);
 
     if (nd->type == NETPLAN_DEF_TYPE_WIFI)
         if (!write_access_points(event, emitter, nd)) goto error;

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -24,13 +24,15 @@
 static gboolean
 write_match(yaml_event_t* event, yaml_emitter_t* emitter, NetplanNetDefinition* nd)
 {
-    YAML_SCALAR_PLAIN(event, emitter, "match");
-    YAML_MAPPING_OPEN(event, emitter);
-    if (nd->match.original_name) {
-        YAML_SCALAR_PLAIN(event, emitter, "name");
-        YAML_SCALAR_QUOTED(event, emitter, nd->match.original_name);
+    if (nd->type < NETPLAN_DEF_TYPE_VIRTUAL) {
+        YAML_SCALAR_PLAIN(event, emitter, "match");
+        YAML_MAPPING_OPEN(event, emitter);
+        if (nd->match.original_name) {
+            YAML_SCALAR_PLAIN(event, emitter, "name");
+            YAML_SCALAR_QUOTED(event, emitter, nd->match.original_name);
+        }
+        YAML_MAPPING_CLOSE(event, emitter);
     }
-    YAML_MAPPING_CLOSE(event, emitter);
     return TRUE;
 error: return FALSE; // LCOV_EXCL_LINE
 }

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -141,6 +141,9 @@ netplan_render_netdef(NetplanNetDefinition* nd, const char* yaml_path)
     YAML_MAPPING_OPEN(event, emitter);
     YAML_STRING_PLAIN(event, emitter, "renderer", netplan_backend_to_name[nd->backend])
 
+    if (nd->type == NETPLAN_DEF_TYPE_OTHER)
+        goto only_passthrough; //do not try to handle "unknown" connection types
+
     if (nd->has_match)
         write_match(event, emitter, nd);
 
@@ -160,6 +163,7 @@ netplan_render_netdef(NetplanNetDefinition* nd, const char* yaml_path)
 
     if (nd->type == NETPLAN_DEF_TYPE_WIFI)
         if (!write_access_points(event, emitter, nd)) goto error;
+only_passthrough:
     if (!write_backend_settings(event, emitter, nd->backend_settings)) goto error;
 
     /* Close remaining mappings */

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -24,15 +24,10 @@
 static gboolean
 write_match(yaml_event_t* event, yaml_emitter_t* emitter, NetplanNetDefinition* nd)
 {
-    if (nd->type < NETPLAN_DEF_TYPE_VIRTUAL) {
-        YAML_SCALAR_PLAIN(event, emitter, "match");
-        YAML_MAPPING_OPEN(event, emitter);
-        if (nd->match.original_name) {
-            YAML_SCALAR_PLAIN(event, emitter, "name");
-            YAML_SCALAR_QUOTED(event, emitter, nd->match.original_name);
-        }
-        YAML_MAPPING_CLOSE(event, emitter);
-    }
+    YAML_SCALAR_PLAIN(event, emitter, "match");
+    YAML_MAPPING_OPEN(event, emitter);
+    YAML_STRING(event, emitter, "name", nd->match.original_name);
+    YAML_MAPPING_CLOSE(event, emitter);
     return TRUE;
 error: return FALSE; // LCOV_EXCL_LINE
 }

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -145,6 +145,11 @@ netplan_render_netdef(NetplanNetDefinition* nd, const char* yaml_path)
 
     if (nd->has_match)
         write_match(event, emitter, nd);
+
+    /* wake-on-lan */
+    if (nd->wake_on_lan)
+        YAML_STRING_PLAIN(event, emitter, "wakeonlan", "true");
+
     if (nd->type == NETPLAN_DEF_TYPE_WIFI)
         if (!write_access_points(event, emitter, nd)) goto error;
     if (!write_backend_settings(event, emitter, nd->backend_settings)) goto error;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -40,6 +40,20 @@
     yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t *)YAML_STR_TAG, (yaml_char_t *)scalar, strlen(scalar), 1, 1, YAML_DOUBLE_QUOTED_SCALAR_STYLE); \
     if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto error; \
 }
+#define YAML_STRING(event_ptr, emitter_ptr, key, value_ptr) \
+{ \
+    if (value_ptr) { \
+        YAML_SCALAR_PLAIN(event, emitter, key); \
+        YAML_SCALAR_QUOTED(event, emitter, value_ptr); \
+    } \
+}
+#define YAML_STRING_PLAIN(event_ptr, emitter_ptr, key, value_ptr) \
+{ \
+    if (value_ptr) { \
+        YAML_SCALAR_PLAIN(event, emitter, key); \
+        YAML_SCALAR_PLAIN(event, emitter, value_ptr); \
+    } \
+}
 /* open YAML emitter, document, stream and initial mapping */
 #define YAML_OUT_START(event_ptr, emitter_ptr, file) \
 { \

--- a/src/util.c
+++ b/src/util.c
@@ -52,10 +52,12 @@ safe_mkdir_p_dir(const char* file_path)
 void g_string_free_to_file(GString* s, const char* rootdir, const char* path, const char* suffix)
 {
     g_autofree char* full_path = NULL;
+    g_autofree char* path_suffix = NULL;
     g_autofree char* contents = g_string_free(s, FALSE);
     GError* error = NULL;
 
-    full_path = g_strjoin(NULL, rootdir ?: "", G_DIR_SEPARATOR_S, path, suffix, NULL);
+    path_suffix = g_strjoin(NULL, path, suffix, NULL);
+    full_path = g_build_path(G_DIR_SEPARATOR_S, rootdir ?: "", path_suffix, NULL);
     safe_mkdir_p_dir(full_path);
     if (!g_file_set_contents(full_path, contents, -1, &error)) {
         /* the mkdir() just succeeded, there is no sensible

--- a/src/validation.c
+++ b/src/validation.c
@@ -340,7 +340,7 @@ validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** er
         // LCOV_EXCL_STOP
     }
 
-    if (nd->type == NETPLAN_DEF_TYPE_OTHER && (!nd->backend_settings.nm.passthrough || !g_hash_table_lookup(nd->backend_settings.nm.passthrough, "connection.type")))
+    if (nd->type == NETPLAN_DEF_TYPE_OTHER && (!nd->backend_settings.nm.passthrough || !g_datalist_get_data(&nd->backend_settings.nm.passthrough, "connection.type")))
         return yaml_error(node, error, "%s: network type 'others:' needs to provide a 'connection.type' via passthrough", nd->id);
 
     valid = TRUE;

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -72,7 +72,7 @@ class TestGenerate(unittest.TestCase):
                              stderr=subprocess.PIPE)
         (out, err) = p.communicate()
         self.assertEqual(out, b'')
-        self.assertEqual(os.listdir(self.workdir.name), [])
+        self.assertEqual(os.listdir(self.workdir.name), ['run'])
 
     def test_with_empty_config(self):
         c = os.path.join(self.workdir.name, 'etc', 'netplan')

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -27,7 +27,7 @@ class TestConfigArgs(TestBase):
 
     def test_no_files(self):
         subprocess.check_call([exe_generate, '--root-dir', self.workdir.name])
-        self.assertEqual(os.listdir(self.workdir.name), [])
+        self.assertEqual(os.listdir(self.workdir.name), ['run'])
         self.assert_nm_udev(None)
 
     def test_no_configs(self):
@@ -113,7 +113,8 @@ class TestConfigArgs(TestBase):
     eth0:
       dhcp4: true''')
         err = self.generate('', extra_args=['--root-dir', '/proc/foo', conf], expect_fail=True)
-        self.assertIn('cannot create directory /proc/foo/run/systemd/network', err)
+        # can be /proc/foor/run/systemd/{network,system}
+        self.assertIn('cannot create directory /proc/foo/run/systemd/', err)
 
     def test_systemd_generator(self):
         conf = os.path.join(self.confdir, 'a.yaml')

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -291,9 +291,6 @@ id=netplan-wl0-Joe's Home
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=auto
 
@@ -313,9 +310,6 @@ id=netplan-wl0-Luke's Home
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=auto
 
@@ -334,9 +328,6 @@ psk=4lsos3kr1t
 id=netplan-wl0-workplace
 type=wifi
 interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=auto
@@ -362,9 +353,6 @@ id=netplan-wl0-workplace2
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=auto
 
@@ -389,9 +377,6 @@ id=netplan-wl0-workplacehashed
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=auto
 
@@ -415,9 +400,6 @@ password=hash:9db1636cedc5948537e7bee0cc1e9590
 id=netplan-wl0-customernet
 type=wifi
 interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=auto
@@ -447,9 +429,6 @@ id=netplan-wl0-opennet
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=auto
 
@@ -464,9 +443,6 @@ mode=infrastructure
 id=netplan-wl0-peer2peer
 type=wifi
 interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=auto

--- a/tests/generator/test_modems.py
+++ b/tests/generator/test_modems.py
@@ -59,9 +59,6 @@ password=s0s3kr1t
 username=test-user
 number=#666
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=link-local
 
@@ -85,9 +82,6 @@ interface-name=mobilephone
 
 [gsm]
 auto-config=true
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=link-local
@@ -118,9 +112,6 @@ mtu=1600
 number=*99#
 pin=1234
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=link-local
 
@@ -144,9 +135,6 @@ interface-name=mobilephone
 
 [gsm]
 apn=internet
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=link-local
@@ -176,9 +164,6 @@ apn=internet
 password=some-pass
 username=some-user
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=link-local
 
@@ -203,9 +188,6 @@ interface-name=mobilephone
 [gsm]
 auto-config=true
 device-id=test
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=link-local
@@ -232,9 +214,6 @@ interface-name=mobilephone
 auto-config=true
 network-id=test
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=link-local
 
@@ -259,9 +238,6 @@ interface-name=mobilephone
 [gsm]
 auto-config=true
 pin=1234
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=link-local
@@ -288,9 +264,6 @@ interface-name=mobilephone
 auto-config=true
 sim-id=test
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=link-local
 
@@ -315,9 +288,6 @@ interface-name=mobilephone
 [gsm]
 auto-config=true
 sim-operator-id=test
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=link-local
@@ -361,9 +331,6 @@ pin=2345
 sim-id=89148000000060671234
 sim-operator-id=310260
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=link-local
 
@@ -389,9 +356,6 @@ interface-name=mobilephone
 
 [gsm]
 auto-config=true
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=link-local

--- a/tests/generator/test_modems.py
+++ b/tests/generator/test_modems.py
@@ -366,3 +366,60 @@ method=ignore
 '''})
         self.assert_networkd({})
         self.assert_nm_udev(None)
+
+    def test_modem_nm_integration_gsm_cdma(self):
+        self.generate('''network:
+  version: 2
+  modems:
+    NM-a08c5805-7cf5-43f7-afb9-12cb30f6eca3:
+      renderer: NetworkManager
+      match: {}
+      apn: internet2.voicestream.com
+      networkmanager:
+        uuid: a08c5805-7cf5-43f7-afb9-12cb30f6eca3
+        name: "T-Mobile Funkadelic 2"
+        passthrough:
+          connection.type: "bluetooth"
+          gsm.apn: "internet2.voicestream.com"
+          gsm.device-id: "da812de91eec16620b06cd0ca5cbc7ea25245222"
+          gsm.username: "george.clinton.again"
+          gsm.sim-operator-id: "310260"
+          gsm.pin: "123456"
+          gsm.sim-id: "89148000000060671234"
+          gsm.password: "parliament2"
+          gsm.network-id: "254098"
+          ipv4.method: "auto"
+          ipv6.method: "auto"''')
+        self.assert_nm({'NM-a08c5805-7cf5-43f7-afb9-12cb30f6eca3': '''[connection]
+id=T-Mobile Funkadelic 2
+#Netplan: passthrough override
+type=bluetooth
+uuid=a08c5805-7cf5-43f7-afb9-12cb30f6eca3
+
+[gsm]
+apn=internet2.voicestream.com
+#Netplan: passthrough setting
+device-id=da812de91eec16620b06cd0ca5cbc7ea25245222
+#Netplan: passthrough setting
+username=george.clinton.again
+#Netplan: passthrough setting
+sim-operator-id=310260
+#Netplan: passthrough setting
+pin=123456
+#Netplan: passthrough setting
+sim-id=89148000000060671234
+#Netplan: passthrough setting
+password=parliament2
+#Netplan: passthrough setting
+network-id=254098
+
+[ipv4]
+#Netplan: passthrough override
+method=auto
+
+[ipv6]
+#Netplan: passthrough override
+method=auto
+'''})
+        self.assert_networkd({})
+        self.assert_nm_udev(None)

--- a/tests/generator/test_modems.py
+++ b/tests/generator/test_modems.py
@@ -352,6 +352,7 @@ method=ignore
         self.assert_nm({'mobilephone': '''[connection]
 id=netplan-mobilephone
 type=gsm
+uuid=b22d8f0f-3f34-46bd-ac28-801fa87f1eb6
 interface-name=mobilephone
 
 [gsm]

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -700,7 +700,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
 ''', expect_fail=True)
         self.assertIn("ERROR: openvswitch bridge controller target 'ssl:10.10.10.1' needs SSL configuration, but global \
 'openvswitch.ssl' settings are not set", err)
-        self.assert_ovs({})
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({})
 
     def test_global_ports(self):
@@ -711,7 +711,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
       - [patch0-1, patch1-0]
 ''', expect_fail=True)
         self.assertIn('patch0-1: OpenVSwitch patch port needs to be assigned to a bridge/bond', err)
-        self.assert_ovs({})
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({})
 
     def test_few_ports(self):
@@ -987,7 +987,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
             openvswitch: {}
 ''', expect_fail=True)
         self.assertIn('eth0: This device type is not supported with the OpenVSwitch backend', err)
-        self.assert_ovs({})
+        self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({})
 
     def test_bridge_non_ovs_bond(self):

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -70,8 +70,6 @@ method=ignore
             uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
             name: myid with spaces
             passthrough:
-              connection.id: myid with spaces
-              connection.uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
               connection.permissions:
               wifi.ssid: SOME-SSID
         "OTHER-SSID":

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -88,9 +88,6 @@ type=wifi
 uuid=87749f1d-334f-40b2-98d4-55db58965f5f
 permissions=
 
-[ethernet]
-wake-on-lan=0
-
 [match]
 interface-name=*;
 
@@ -107,9 +104,6 @@ mode=infrastructure
                         'NM-87749f1d-334f-40b2-98d4-55db58965f5f-OTHER-SSID': '''[connection]
 id=netplan-NM-87749f1d-334f-40b2-98d4-55db58965f5f-OTHER-SSID
 type=wifi
-
-[ethernet]
-wake-on-lan=0
 
 [match]
 interface-name=*;
@@ -196,9 +190,6 @@ endpoint=1.2.3.4
         self.assert_nm({'test-SOME-SSID': '''[connection]
 id=netplan-test-SOME-SSID
 type=wifi
-
-[ethernet]
-wake-on-lan=0
 
 [match]
 interface-name=*;

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -248,3 +248,38 @@ method=ignore
 
 [proxy]
 '''})
+
+    def test_passthrough_interface_rename_existing_id(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    # This is the original  netdef, generating "netplan-eth0.nmconnection"
+    eth0:
+      dhcp4: true
+    # This is the override netdef, modifying match.original_name (i.e. interface-name)
+    # it should still generate a "netplan-eth0.nmconnection" file (not netplan-eth33.nmconnection).
+    eth0:
+      renderer: NetworkManager
+      match:
+        name: "eth33"
+      networkmanager:
+        uuid: 626dd384-8b3d-3690-9511-192b2c79b3fd
+        name: "netplan-eth0"
+''')
+
+        self.assert_nm({'eth0': '''[connection]
+id=netplan-eth0
+type=ethernet
+uuid=626dd384-8b3d-3690-9511-192b2c79b3fd
+interface-name=eth33
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+'''})

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -32,8 +32,7 @@ class TestNetworkManager(TestBase):
   ethernets:
     NM-87749f1d-334f-40b2-98d4-55db58965f5f:
       renderer: NetworkManager
-      match:
-        name: "*"
+      match: {}
       networkmanager:
         uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
         name: some NM id
@@ -51,9 +50,6 @@ permissions=
 [ethernet]
 wake-on-lan=0
 
-[match]
-interface-name=*;
-
 [ipv4]
 method=link-local
 
@@ -67,8 +63,7 @@ method=ignore
   wifis:
     NM-87749f1d-334f-40b2-98d4-55db58965f5f:
       renderer: NetworkManager
-      match:
-        name: "*"
+      match: {}
       access-points:
         "SOME-SSID":
           networkmanager:
@@ -88,9 +83,6 @@ type=wifi
 uuid=87749f1d-334f-40b2-98d4-55db58965f5f
 permissions=
 
-[match]
-interface-name=*;
-
 [ipv4]
 method=link-local
 
@@ -104,9 +96,6 @@ mode=infrastructure
                         'NM-87749f1d-334f-40b2-98d4-55db58965f5f-OTHER-SSID': '''[connection]
 id=netplan-NM-87749f1d-334f-40b2-98d4-55db58965f5f-OTHER-SSID
 type=wifi
-
-[match]
-interface-name=*;
 
 [ipv4]
 method=link-local
@@ -125,8 +114,7 @@ hidden=true
   others:
     NM-87749f1d-334f-40b2-98d4-55db58965f5f:
       renderer: NetworkManager
-      match:
-        name: "*"
+      match: {}
       networkmanager:
         passthrough:
           connection.uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
@@ -136,7 +124,6 @@ hidden=true
 id=netplan-NM-87749f1d-334f-40b2-98d4-55db58965f5f
 #Netplan: Unsupported connection.type setting, overridden by passthrough
 type=dummy
-interface-name=NM-87749f1d-334f-40b2-98d4-55db58965f5f
 uuid=87749f1d-334f-40b2-98d4-55db58965f5f
 
 [ipv4]
@@ -151,8 +138,7 @@ method=ignore
   others:
     dotted-group-test:
       renderer: NetworkManager
-      match:
-        name: "*"
+      match: {}
       networkmanager:
         passthrough:
           connection.type: "wireguard"
@@ -162,7 +148,6 @@ method=ignore
 id=netplan-dotted-group-test
 #Netplan: Unsupported connection.type setting, overridden by passthrough
 type=wireguard
-interface-name=dotted-group-test
 
 [ipv4]
 method=link-local
@@ -179,8 +164,7 @@ endpoint=1.2.3.4
   wifis:
     test:
       renderer: NetworkManager
-      match:
-        name: "*"
+      match: {}
       access-points:
         "SOME-SSID": # implicit "mode: infrasturcutre"
           networkmanager:
@@ -190,9 +174,6 @@ endpoint=1.2.3.4
         self.assert_nm({'test-SOME-SSID': '''[connection]
 id=netplan-test-SOME-SSID
 type=wifi
-
-[match]
-interface-name=*;
 
 [ipv4]
 method=link-local

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -382,9 +382,6 @@ id=netplan-wl0-Joe's Home
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=auto
 
@@ -406,9 +403,6 @@ psk=s0s3kr1t
 id=netplan-wl0-workplace
 type=wifi
 interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=auto
@@ -432,9 +426,6 @@ id=netplan-wl0-hidden-y
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=auto
 
@@ -455,9 +446,6 @@ id=netplan-wl0-hidden-n
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=auto
 
@@ -477,9 +465,6 @@ id=netplan-wl0-channel-no-band
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=auto
 
@@ -494,9 +479,6 @@ mode=infrastructure
 id=netplan-wl0-band-no-channel
 type=wifi
 interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=auto
@@ -527,9 +509,6 @@ band=a
 id=netplan-all-workplace
 type=wifi
 
-[ethernet]
-wake-on-lan=0
-
 [wifi]
 mac-address=11:22:33:44:55:66
 ssid=workplace
@@ -555,9 +534,6 @@ method=ignore
         self.assert_nm({'all-workplace': '''[connection]
 id=netplan-all-workplace
 type=wifi
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=link-local
@@ -585,9 +561,6 @@ mode=infrastructure
 id=netplan-wl0-homenet
 type=wifi
 interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=shared
@@ -621,9 +594,6 @@ id=netplan-wl0-homenet
 type=wifi
 interface-name=wl0
 
-[ethernet]
-wake-on-lan=0
-
 [ipv4]
 method=link-local
 
@@ -649,9 +619,6 @@ mode=adhoc
 id=netplan-wl0-homenet
 type=wifi
 interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
 
 [wifi]
 wake-on-wlan=330
@@ -679,9 +646,6 @@ method=ignore
 id=netplan-wl0-homenet
 type=wifi
 interface-name=wl0
-
-[ethernet]
-wake-on-lan=0
 
 [ipv4]
 method=link-local

--- a/tests/test_nm_backend.py
+++ b/tests/test_nm_backend.py
@@ -113,7 +113,124 @@ class TestNetworkManagerBackend(TestBase):
         with open(FILENAME, 'r') as f:
             self.assertEquals(f.read(), 'network:\n  ethernets:\n    other-id:\n      dhcp6: true\n')
 
-    def _template_render_keyfile(self, nd_type, nm_type, supported=True):
+    def test_serialize_gsm(self):
+        self.maxDiff = None
+        UUID = 'a08c5805-7cf5-43f7-afb9-12cb30f6eca3'
+        file = '''[connection]
+id=T-Mobile Funkadelic 2
+uuid=a08c5805-7cf5-43f7-afb9-12cb30f6eca3
+type=gsm
+
+[gsm]
+apn=internet2.voicestream.com
+device-id=da812de91eec16620b06cd0ca5cbc7ea25245222
+home-only=true
+network-id=254098
+password=parliament2
+pin=123456
+sim-id=89148000000060671234
+sim-operator-id=310260
+username=george.clinton.again
+
+[ipv4]
+dns-search=
+method=auto
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=auto
+'''
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
+        with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
+            self.assertEqual(f.read(), '''network:
+  version: 2
+  modems:
+    NM-{}:
+      renderer: NetworkManager
+      match: {{}}
+      apn: "internet2.voicestream.com"
+      device-id: "da812de91eec16620b06cd0ca5cbc7ea25245222"
+      network-id: "254098"
+      pin: "123456"
+      sim-id: "89148000000060671234"
+      sim-operator-id: "310260"
+      networkmanager:
+        uuid: {}
+        name: "T-Mobile Funkadelic 2"
+        passthrough:
+          gsm.home-only: "true"
+          gsm.password: "parliament2"
+          gsm.username: "george.clinton.again"
+          ipv4.dns-search: ""
+          ipv4.method: "auto"
+          ipv6.addr-gen-mode: "stable-privacy"
+          ipv6.dns-search: ""
+          ipv6.method: "auto"
+'''.format(UUID, UUID))
+
+    def test_serialize_gsm_via_bluetooth(self):
+        self.maxDiff = None
+        UUID = 'a08c5805-7cf5-43f7-afb9-12cb30f6eca3'
+        file = '''[connection]
+id=T-Mobile Funkadelic 2
+uuid=a08c5805-7cf5-43f7-afb9-12cb30f6eca3
+type=bluetooth
+
+[gsm]
+apn=internet2.voicestream.com
+device-id=da812de91eec16620b06cd0ca5cbc7ea25245222
+home-only=true
+network-id=254098
+password=parliament2
+pin=123456
+sim-id=89148000000060671234
+sim-operator-id=310260
+username=george.clinton.again
+
+[ipv4]
+dns-search=
+method=auto
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=auto
+
+[proxy]
+'''
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
+        with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
+            self.assertEqual(f.read(), '''network:
+  version: 2
+  others:
+    NM-{}:
+      renderer: NetworkManager
+      networkmanager:
+        uuid: {}
+        name: "T-Mobile Funkadelic 2"
+        passthrough:
+          connection.type: "bluetooth"
+          gsm.apn: "internet2.voicestream.com"
+          gsm.device-id: "da812de91eec16620b06cd0ca5cbc7ea25245222"
+          gsm.home-only: "true"
+          gsm.network-id: "254098"
+          gsm.password: "parliament2"
+          gsm.pin: "123456"
+          gsm.sim-id: "89148000000060671234"
+          gsm.sim-operator-id: "310260"
+          gsm.username: "george.clinton.again"
+          ipv4.dns-search: ""
+          ipv4.method: "auto"
+          ipv6.addr-gen-mode: "stable-privacy"
+          ipv6.dns-search: ""
+          ipv6.method: "auto"
+          proxy._: ""
+'''.format(UUID, UUID))
+
+    def _template_serialize_keyfile(self, nd_type, nm_type, supported=True):
         self.maxDiff = None
         UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
         file = '[connection]\ntype={}\nuuid={}'.format(nm_type, UUID)
@@ -132,43 +249,43 @@ class TestNetworkManagerBackend(TestBase):
         uuid: {}{}
 '''.format(nd_type, UUID, match, UUID, t))
 
-    def test_render_keyfile_ethernet(self):
-        self._template_render_keyfile('ethernets', 'ethernet')
+    def test_serialize_keyfile_ethernet(self):
+        self._template_serialize_keyfile('ethernets', 'ethernet')
 
-    def test_render_keyfile_type_modem(self):
-        self._template_render_keyfile('modems', 'gsm', False)
+    def test_serialize_keyfile_type_modem_gsm(self):
+        self._template_serialize_keyfile('modems', 'gsm')
 
-    def test_render_keyfile_type_modem2(self):
-        self._template_render_keyfile('modems', 'cdma', False)
+    def test_serialize_keyfile_type_modem_cdma(self):
+        self._template_serialize_keyfile('modems', 'cdma')
 
-    def test_render_keyfile_type_bridge(self):
-        self._template_render_keyfile('bridges', 'bridge')
+    def test_serialize_keyfile_type_bridge(self):
+        self._template_serialize_keyfile('bridges', 'bridge')
 
-    def test_render_keyfile_type_bond(self):
-        self._template_render_keyfile('bonds', 'bond')
+    def test_serialize_keyfile_type_bond(self):
+        self._template_serialize_keyfile('bonds', 'bond')
 
-    def test_render_keyfile_type_vlan(self):
-        self._template_render_keyfile('vlans', 'vlan')
+    def test_serialize_keyfile_type_vlan(self):
+        self._template_serialize_keyfile('vlans', 'vlan')
 
-    def test_render_keyfile_type_tunnel(self):
-        self._template_render_keyfile('tunnels', 'ip-tunnel', False)
+    def test_serialize_keyfile_type_tunnel(self):
+        self._template_serialize_keyfile('tunnels', 'ip-tunnel', False)
 
-    def test_render_keyfile_type_wireguard(self):
-        self._template_render_keyfile('tunnels', 'wireguard', False)
+    def test_serialize_keyfile_type_wireguard(self):
+        self._template_serialize_keyfile('tunnels', 'wireguard', False)
 
-    def test_render_keyfile_type_other(self):
-        self._template_render_keyfile('others', 'dummy', False)
+    def test_serialize_keyfile_type_other(self):
+        self._template_serialize_keyfile('others', 'dummy', False)
 
-    def test_render_keyfile_missing_uuid(self):
+    def test_serialize_keyfile_missing_uuid(self):
         file = '[connection]\ntype=ethernets'
         self.assertFalse(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
 
-    def test_render_keyfile_missing_type(self):
+    def test_serialize_keyfile_missing_type(self):
         UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
         file = '[connection]\nuuid={}'.format(UUID)
         self.assertFalse(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
 
-    def test_render_keyfile_type_wifi(self):
+    def test_serialize_keyfile_type_wifi(self):
         self.maxDiff = None
         UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
         file = '''[connection]
@@ -204,12 +321,12 @@ dns-search='''.format(UUID)
             uuid: {}
             name: "myid with spaces"
             passthrough:
+              connection.permissions: ""
               ipv4.method: "auto"
               ipv4.dns-search: ""
-              connection.permissions: ""
 '''.format(UUID, UUID))
 
-    def _template_render_keyfile_type_wifi(self, nd_mode, nm_mode):
+    def _template_serialize_keyfile_type_wifi(self, nd_mode, nm_mode):
         self.maxDiff = None
         UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
         file = '''[connection]
@@ -245,18 +362,109 @@ mode={}'''.format(UUID, nm_mode)
               ipv4.method: "auto"{}
 '''.format(UUID, nd_mode, UUID, wifi_mode))
 
-    def test_render_keyfile_type_wifi_ap(self):
-        self._template_render_keyfile_type_wifi('ap', 'ap')
+    def test_serialize_keyfile_type_wifi_ap(self):
+        self._template_serialize_keyfile_type_wifi('ap', 'ap')
 
-    def test_render_keyfile_type_wifi_adhoc(self):
-        self._template_render_keyfile_type_wifi('adhoc', 'adhoc')
+    def test_serialize_keyfile_type_wifi_adhoc(self):
+        self._template_serialize_keyfile_type_wifi('adhoc', 'adhoc')
 
-    def test_render_keyfile_type_wifi_unkonwn(self):
-        self._template_render_keyfile_type_wifi('infrastructure', 'mesh')
+    def test_serialize_keyfile_type_wifi_unkonwn(self):
+        self._template_serialize_keyfile_type_wifi('infrastructure', 'mesh')
 
-    def test_render_keyfile_type_wifi_missing_ssid(self):
+    def test_serialize_keyfile_type_wifi_missing_ssid(self):
         self.maxDiff = None
         UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
         file = '''[connection]\ntype=wifi\nuuid={}\nid=myid with spaces'''.format(UUID)
         self.assertFalse(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
         self.assertFalse(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
+
+    def test_serialize_keyfile_wake_on_lan(self):
+        self.maxDiff = None
+        UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
+        file = '''[connection]
+type=ethernet
+uuid={}
+id=myid with spaces
+
+[ethernet]
+wake-on-lan=2
+
+[ipv4]
+method=auto'''.format(UUID)
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
+        with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
+            self.assertEqual(f.read(), '''network:
+  version: 2
+  ethernets:
+    NM-{}:
+      renderer: NetworkManager
+      match: {{}}
+      wakeonlan: true
+      networkmanager:
+        uuid: {}
+        name: "myid with spaces"
+        passthrough:
+          ethernet.wake-on-lan: "2"
+          ipv4.method: "auto"
+'''.format(UUID, UUID))
+
+    def test_serialize_keyfile_wake_on_lan_nm_default(self):
+        self.maxDiff = None
+        UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
+        file = '''[connection]
+type=ethernet
+uuid={}
+id=myid with spaces
+
+[ethernet]
+
+[ipv4]
+method=auto'''.format(UUID)
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
+        with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
+            self.assertEqual(f.read(), '''network:
+  version: 2
+  ethernets:
+    NM-{}:
+      renderer: NetworkManager
+      match: {{}}
+      wakeonlan: true
+      networkmanager:
+        uuid: {}
+        name: "myid with spaces"
+        passthrough:
+          ethernet._: ""
+          ipv4.method: "auto"
+'''.format(UUID, UUID))
+
+    def test_serialize_keyfile_modem_gsm(self):
+        self.maxDiff = None
+        UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
+        file = '''[connection]
+type=gsm
+uuid={}
+id=myid with spaces
+
+[ipv4]
+method=auto
+
+[gsm]
+auto-config=true'''.format(UUID)
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
+        with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
+            self.assertEqual(f.read(), '''network:
+  version: 2
+  modems:
+    NM-{}:
+      renderer: NetworkManager
+      match: {{}}
+      auto-config: true
+      networkmanager:
+        uuid: {}
+        name: "myid with spaces"
+        passthrough:
+          ipv4.method: "auto"
+'''.format(UUID, UUID))

--- a/tests/test_nm_backend.py
+++ b/tests/test_nm_backend.py
@@ -120,9 +120,7 @@ class TestNetworkManagerBackend(TestBase):
         self.assertEqual(lib.netplan_clear_netdefs(), 0)
         self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
-        t = ''
-        if not supported:
-            t = '\n        passthrough:\n          connection.type: "{}"'.format(nm_type)
+        t = '\n        passthrough:\n          connection.type: "{}"'.format(nm_type) if not supported else ''
         match = '\n      match: {}' if nd_type in ['ethernets', 'modems', 'wifis'] else ''
         with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
             self.assertEqual(f.read(), '''network:

--- a/tests/test_nm_backend.py
+++ b/tests/test_nm_backend.py
@@ -141,7 +141,7 @@ addr-gen-mode=stable-privacy
 dns-search=
 method=auto
 '''
-        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
             self.assertEqual(f.read(), '''network:
@@ -200,7 +200,7 @@ method=auto
 
 [proxy]
 '''
-        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
             self.assertEqual(f.read(), '''network:
@@ -235,7 +235,7 @@ method=auto
         UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
         file = '[connection]\ntype={}\nuuid={}'.format(nm_type, UUID)
         self.assertEqual(lib.netplan_clear_netdefs(), 0)
-        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         t = '\n        passthrough:\n          connection.type: "{}"'.format(nm_type) if not supported else ''
         match = '\n      match: {}' if nd_type in ['ethernets', 'modems', 'wifis'] else ''
@@ -278,12 +278,12 @@ method=auto
 
     def test_serialize_keyfile_missing_uuid(self):
         file = '[connection]\ntype=ethernets'
-        self.assertFalse(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertFalse(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
 
     def test_serialize_keyfile_missing_type(self):
         UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
         file = '[connection]\nuuid={}'.format(UUID)
-        self.assertFalse(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertFalse(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
 
     def test_serialize_keyfile_type_wifi(self):
         self.maxDiff = None
@@ -303,7 +303,7 @@ hidden=true
 [ipv4]
 method=auto
 dns-search='''.format(UUID)
-        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
             self.assertEqual(f.read(), '''network:
@@ -340,7 +340,7 @@ method=auto
 [wifi]
 ssid=SOME-SSID
 mode={}'''.format(UUID, nm_mode)
-        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         wifi_mode = ''
         if nm_mode != nd_mode:
@@ -375,7 +375,7 @@ mode={}'''.format(UUID, nm_mode)
         self.maxDiff = None
         UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
         file = '''[connection]\ntype=wifi\nuuid={}\nid=myid with spaces'''.format(UUID)
-        self.assertFalse(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertFalse(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
         self.assertFalse(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
 
     def test_serialize_keyfile_wake_on_lan(self):
@@ -391,7 +391,7 @@ wake-on-lan=2
 
 [ipv4]
 method=auto'''.format(UUID)
-        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
             self.assertEqual(f.read(), '''network:
@@ -421,7 +421,7 @@ id=myid with spaces
 
 [ipv4]
 method=auto'''.format(UUID)
-        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
             self.assertEqual(f.read(), '''network:
@@ -452,7 +452,7 @@ method=auto
 
 [gsm]
 auto-config=true'''.format(UUID)
-        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), None, self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
             self.assertEqual(f.read(), '''network:
@@ -468,3 +468,28 @@ auto-config=true'''.format(UUID)
         passthrough:
           ipv4.method: "auto"
 '''.format(UUID, UUID))
+
+    def test_serialize_keyfile_existing_id(self):
+        self.maxDiff = None
+        UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
+        file = '''[connection]
+type=bridge
+uuid={}
+id=renamed netplan bridge
+
+[ipv4]
+method=auto'''.format(UUID)
+        self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), "mybr".encode(), self.workdir.name.encode()))
+        self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
+        with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
+            self.assertEqual(f.read(), '''network:
+  version: 2
+  bridges:
+    mybr:
+      renderer: NetworkManager
+      networkmanager:
+        uuid: {}
+        name: "renamed netplan bridge"
+        passthrough:
+          ipv4.method: "auto"
+'''.format(UUID))

--- a/tests/test_nm_backend.py
+++ b/tests/test_nm_backend.py
@@ -117,6 +117,7 @@ class TestNetworkManagerBackend(TestBase):
         self.maxDiff = None
         UUID = '87749f1d-334f-40b2-98d4-55db58965f5f'
         file = '[connection]\ntype={}\nuuid={}'.format(nm_type, UUID)
+        self.assertEqual(lib.netplan_clear_netdefs(), 0)
         self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         t = ''

--- a/tests/test_nm_backend.py
+++ b/tests/test_nm_backend.py
@@ -217,12 +217,12 @@ type=wifi
 uuid={}
 id=myid with spaces
 
+[ipv4]
+method=auto
+
 [wifi]
 ssid=SOME-SSID
-mode={}
-
-[ipv4]
-method=auto'''.format(UUID, nm_mode)
+mode={}'''.format(UUID, nm_mode)
         self.assertTrue(lib._netplan_render_yaml_from_nm_keyfile_str(file.encode(), self.workdir.name.encode()))
         self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         wifi_mode = ''

--- a/tests/test_nm_backend.py
+++ b/tests/test_nm_backend.py
@@ -123,17 +123,16 @@ class TestNetworkManagerBackend(TestBase):
         t = ''
         if not supported:
             t = '\n        passthrough:\n          connection.type: "{}"'.format(nm_type)
+        match = '\n      match: {}' if nd_type in ['ethernets', 'modems', 'wifis'] else ''
         with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID)), 'r') as f:
             self.assertEqual(f.read(), '''network:
   version: 2
   {}:
     NM-{}:
-      renderer: NetworkManager
-      match:
-        name: "*"
+      renderer: NetworkManager{}
       networkmanager:
         uuid: {}{}
-'''.format(nd_type, UUID, UUID, t))
+'''.format(nd_type, UUID, match, UUID, t))
 
     def test_render_keyfile_ethernet(self):
         self._template_render_keyfile('ethernets', 'ethernet')
@@ -237,8 +236,7 @@ method=auto'''.format(UUID, nm_mode)
   wifis:
     NM-{}:
       renderer: NetworkManager
-      match:
-        name: "*"
+      match: {{}}
       access-points:
         "SOME-SSID":
           mode: {}


### PR DESCRIPTION
## Description
This PR is 6th in a series of pull requests to prepare for the NetworkManager YAML backend. It builds upon #183 and contains a few improvements and fixes, enabling the NetworkManager test-suite (i.e. `make check`) to fully pass, especially the tests in the patched keyfile plugin (`src/settings/plugins/keyfile/tests/test-keyfile-settings`).

It implements the following functionality:
* Adding some basic support for the `modems` YAML schema, to allow matching of (physical) modem interfaces and enable the detection of GSM vs CDMA connections, which are distinct in NM while using the same definition in Netplan.
* Switching the `passthrough` key-value pairs to a DataList (instead of HashTable), to keep order of the keyfile elements, which is relevant in some cases (e.g. for `tc.qdiscs`)
* Avoid parsing and serialization of type `other` connections, as they might not contain the relevant handlers. Use full passthrough mode for those connections, to avoid parsing failures.
* Allow independent modification of Netdef ID & match.name, to enable changing the `connection.interface-name` from `nmcli`, while keeping the netdef ID equal to a previously existing ID. This enables overriding of existing netdef ID by 90-NM-... YAML file, keeping the same Netdef ID.
* Implement handling of keyfile UUIDs for each NM connection profile
* Implement handling of empty keyfile groups (i.e. relevant for `[bridge]`)

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

