### PR TITLE
Added TTL option for tunnels (LP: #1846783)

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -1087,6 +1087,10 @@ more general information about tunnels.
 
 :   Defines the address of the remote endpoint of the tunnel.
 
+``ttl`` (scalar)
+
+:   Defines the TTL of the tunnel.
+
 ``key``  (scalar or mapping)
 
 :   Define keys to use for the tunnel. The key can be a number or a dotted

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -1087,7 +1087,7 @@ more general information about tunnels.
 
 :   Defines the address of the remote endpoint of the tunnel.
 
-``ttl`` (scalar)
+``ttl`` (scalar) – since **0.102**
 
 :   Defines the TTL of the tunnel.
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -142,6 +142,8 @@ write_tunnel_params(GString* s, const NetplanNetDefinition* def)
         g_string_append_printf(params, "Mode=%s\n", tunnel_mode_to_string(def->tunnel.mode));
     g_string_append_printf(params, "Local=%s\n", def->tunnel.local_ip);
     g_string_append_printf(params, "Remote=%s\n", def->tunnel.remote_ip);
+    if (def->tunnel.ttl)
+        g_string_append_printf(params, "TTL=%u\n", def->tunnel.ttl);
     if (def->tunnel.input_key)
         g_string_append_printf(params, "InputKey=%s\n", def->tunnel.input_key);
     if (def->tunnel.output_key)

--- a/src/nm.c
+++ b/src/nm.c
@@ -401,6 +401,8 @@ write_tunnel_params(const NetplanNetDefinition* def, GString *s)
     g_string_append_printf(s, "mode=%d\n", def->tunnel.mode);
     g_string_append_printf(s, "local=%s\n", def->tunnel.local_ip);
     g_string_append_printf(s, "remote=%s\n", def->tunnel.remote_ip);
+    if (def->tunnel.ttl)
+        g_string_append_printf(s, "ttl=%u\n", def->tunnel.ttl);
 
     if (def->tunnel.input_key)
         g_string_append_printf(s, "input-key=%s\n", def->tunnel.input_key);

--- a/src/nm.c
+++ b/src/nm.c
@@ -403,7 +403,6 @@ write_tunnel_params(const NetplanNetDefinition* def, GString *s)
     g_string_append_printf(s, "remote=%s\n", def->tunnel.remote_ip);
     if (def->tunnel.ttl)
         g_string_append_printf(s, "ttl=%u\n", def->tunnel.ttl);
-
     if (def->tunnel.input_key)
         g_string_append_printf(s, "input-key=%s\n", def->tunnel.input_key);
     if (def->tunnel.output_key)

--- a/src/parse.c
+++ b/src/parse.c
@@ -2242,6 +2242,7 @@ static const mapping_entry_handler tunnel_def_handlers[] = {
     {"mode", YAML_SCALAR_NODE, handle_tunnel_mode},
     {"local", YAML_SCALAR_NODE, handle_tunnel_addr, NULL, netdef_offset(tunnel.local_ip)},
     {"remote", YAML_SCALAR_NODE, handle_tunnel_addr, NULL, netdef_offset(tunnel.remote_ip)},
+    {"ttl", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(tunnel.ttl)},
 
     /* Handle key/keys for clarity in config: this can be either a scalar or
      * mapping of multiple keys (input and output)

--- a/src/parse.h
+++ b/src/parse.h
@@ -359,7 +359,7 @@ struct net_definition {
         char *private_key; /* used for wireguard */
         guint fwmark;
         guint port;
-	guint ttl;
+        guint ttl;
     } tunnel;
 
     NetplanAuthenticationSettings auth;

--- a/src/parse.h
+++ b/src/parse.h
@@ -359,6 +359,7 @@ struct net_definition {
         char *private_key; /* used for wireguard */
         guint fwmark;
         guint port;
+	guint ttl;
     } tunnel;
 
     NetplanAuthenticationSettings auth;

--- a/src/validation.c
+++ b/src/validation.c
@@ -205,11 +205,8 @@ validate_tunnel_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** er
         return yaml_error(node, error, "%s: missing 'local' property for tunnel", nd->id);
     if (!nd->tunnel.remote_ip)
         return yaml_error(node, error, "%s: missing 'remote' property for tunnel", nd->id);
-
-    if (nd->tunnel.ttl) {
-	if ((nd->tunnel.ttl) < 1 || (nd->tunnel.ttl) > 255)
-            return yaml_error(node, error, "%s: 'ttl' property for tunnel must be in range [1...255]", nd->id);
-    }
+    if (nd->tunnel.ttl && nd->tunnel.ttl > 255)
+        return yaml_error(node, error, "%s: 'ttl' property for tunnel must be in range [1...255]", nd->id);
 
     switch(nd->tunnel.mode) {
         case NETPLAN_TUNNEL_MODE_IPIP6:

--- a/src/validation.c
+++ b/src/validation.c
@@ -206,6 +206,11 @@ validate_tunnel_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** er
     if (!nd->tunnel.remote_ip)
         return yaml_error(node, error, "%s: missing 'remote' property for tunnel", nd->id);
 
+    if (nd->tunnel.ttl) {
+	if ((nd->tunnel.ttl) < 1 || (nd->tunnel.ttl) > 255)
+            return yaml_error(node, error, "%s: 'ttl' property for tunnel must be in range [1...255]", nd->id, nd->tunnel.ttl);
+    }
+
     switch(nd->tunnel.mode) {
         case NETPLAN_TUNNEL_MODE_IPIP6:
         case NETPLAN_TUNNEL_MODE_IP6IP6:

--- a/src/validation.c
+++ b/src/validation.c
@@ -208,7 +208,7 @@ validate_tunnel_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** er
 
     if (nd->tunnel.ttl) {
 	if ((nd->tunnel.ttl) < 1 || (nd->tunnel.ttl) > 255)
-            return yaml_error(node, error, "%s: 'ttl' property for tunnel must be in range [1...255]", nd->id, nd->tunnel.ttl);
+            return yaml_error(node, error, "%s: 'ttl' property for tunnel must be in range [1...255]", nd->id);
     }
 
     switch(nd->tunnel.mode) {

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -42,6 +42,7 @@ def prepare_config_for_mode(renderer, mode, key=None):
       mode: {}
       local: {}
       remote: {}
+      ttl: 64
       addresses: [ 15.15.15.15/24 ]
       gateway4: 20.20.20.21
 """.format(mode, local_ip, remote_ip)
@@ -754,6 +755,7 @@ Kind=ipip
 Independent=true
 Local=10.10.10.10
 Remote=20.20.20.20
+TTL=64
 ''',
                               'tun0.network': '''[Match]
 Name=tun0

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -1262,6 +1262,20 @@ class TestConfigErrors(TestBase):
         out = self.generate(config, expect_fail=True)
         self.assertIn("Error in network definition: tun0: missing 'remote' property for tunnel", out)
 
+    def test_invalid_ttl(self):
+        """Fail if TTL not in range [1...255]"""
+        config = '''network:
+  version: 2
+  tunnels:
+    tun0:
+      mode: ipip
+      local: 20.20.20.20
+      remote: 10.10.10.10
+      ttl: 300
+'''
+        out = self.generate(config, expect_fail=True)
+        self.assertIn("Error in network definition: tun0: 'ttl' property for tunnel must be in range [1...255]", out)
+
     def test_wrong_local_ip_for_mode_v4(self):
         """Show an error when an IPv6 local addr is used for an IPv4 tunnel mode"""
         config = '''network:

--- a/tests/integration/tunnels.py
+++ b/tests/integration/tunnels.py
@@ -67,6 +67,7 @@ class _CommonTests():
       mode: ipip
       local: 192.168.5.1
       remote: 99.99.99.99
+      ttl: 64
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.generate_and_settle()
         self.assert_iface('tun0', ['tun0@NONE', 'link.* 192.168.5.1 peer 99.99.99.99'])


### PR DESCRIPTION
## Description (Re-open of #139)
Some protocols set the TTL field of the packet to 1; when passing through the tunnel, the packet is discarded. To solve the problem, the tunnel has the TTL option, but it was not in netplan.

According to https://bugs.launchpad.net/netplan/+bug/1846783 this is required for IPIP/SIT/GRE tunnels.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad: https://bugs.launchpad.net/netplan/+bug/1846783