### PR TITLE
Improve integration tests

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -51,13 +51,10 @@ def resolved_in_use():
 class IntegrationTestsBase(unittest.TestCase):
     '''Common functionality for network test cases
 
-    setUp() creates two test wlan devices, one for a simulated access point
-    (self.dev_w_ap), the other for a simulated client device
-    (self.dev_w_client), and two test ethernet devices (self.dev_e_{ap,client}
-    and self.dev_e2_{ap,client}.
+    setUp() creates two test ethernet devices (self.dev_e_{ap,client} and
+    self.dev_e2_{ap,client}.
 
-    Each test should call self.setup_ap() or self.setup_eth() with the desired
-    configuration.
+    Each test should call self.setup_eth() with the desired configuration.
     '''
     @classmethod
     def setUpClass(klass):
@@ -68,22 +65,8 @@ class IntegrationTestsBase(unittest.TestCase):
             f.write('ENV{ID_NET_DRIVER}=="veth", ENV{INTERFACE}=="eth42|eth43", ENV{NM_UNMANAGED}="0"\n')
         subprocess.check_call(['udevadm', 'control', '--reload'])
 
-        # ensure we have this so that iw works
-        try:
-            subprocess.check_call(['modprobe', 'cfg80211'])
-            # set regulatory domain "EU", so that we can use 80211.a 5 GHz channels
-            out = subprocess.check_output(['iw', 'reg', 'get'], universal_newlines=True)
-            m = re.match(r'^(?:global\n)?country (\S+):', out)
-            assert m
-            klass.orig_country = m.group(1)
-            subprocess.check_call(['iw', 'reg', 'set', 'EU'])
-        except Exception:
-            raise unittest.SkipTest("cfg80211 (wireless) is unavailable, can't test")
-
-
     @classmethod
     def tearDownClass(klass):
-        subprocess.check_call(['iw', 'reg', 'set', klass.orig_country])
         try:
             os.remove('/run/NetworkManager/conf.d/test-blacklist.conf')
         except FileNotFoundError:
@@ -110,10 +93,8 @@ class IntegrationTestsBase(unittest.TestCase):
 
     @classmethod
     def create_devices(klass):
-        '''Create Access Point and Client devices with mac80211_hwsim and veth'''
+        '''Create Access Point and Client devices with veth'''
 
-        if os.path.exists('/sys/module/mac80211_hwsim'):
-            raise SystemError('mac80211_hwsim module already loaded')
         if os.path.exists('/sys/class/net/eth42'):
             raise SystemError('eth42 interface already exists')
 
@@ -148,28 +129,6 @@ class IntegrationTestsBase(unittest.TestCase):
         with open('/run/NetworkManager/conf.d/11-globally-managed-devices.conf', 'w') as f:
             f.write('[keyfile]\nunmanaged-devices=')
 
-        # create virtual wlan devs
-        before_wlan = set([c for c in os.listdir('/sys/class/net') if c.startswith('wlan')])
-        subprocess.check_call(['modprobe', 'mac80211_hwsim'])
-        # wait 5 seconds for fake devices to appear
-        timeout = 50
-        while timeout > 0:
-            after_wlan = set([c for c in os.listdir('/sys/class/net') if c.startswith('wlan')])
-            if len(after_wlan) - len(before_wlan) >= 2:
-                break
-            timeout -= 1
-            time.sleep(0.1)
-        else:
-            raise SystemError('timed out waiting for fake devices to appear')
-
-        devs = list(after_wlan - before_wlan)
-        klass.dev_w_ap = devs[0]
-        klass.dev_w_client = devs[1]
-
-        # don't let NM trample over our fake AP
-        with open('/run/NetworkManager/conf.d/test-blacklist.conf', 'w') as f:
-            f.write('[main]\nplugins=keyfile\n[keyfile]\nunmanaged-devices+=nptestsrv,%s\n' % klass.dev_w_ap)
-
     @classmethod
     def shutdown_devices(klass):
         '''Remove test devices'''
@@ -180,13 +139,9 @@ class IntegrationTestsBase(unittest.TestCase):
         klass.dev_e_client = None
         klass.dev_e2_ap = None
         klass.dev_e2_client = None
-        klass.dev_w_ap = None
-        klass.dev_w_client = None
 
         subprocess.call(['ip', 'link', 'del', 'dev', 'mybr'],
                         stderr=subprocess.PIPE)
-
-        subprocess.check_call(['rmmod', 'mac80211_hwsim'])
 
     def setUp(self):
         '''Create test devices and workdir'''
@@ -202,25 +157,6 @@ class IntegrationTestsBase(unittest.TestCase):
         self.entropy_file = os.path.join(self.workdir, 'entropy')
         with open(self.entropy_file, 'wb') as f:
             f.write(b'012345678901234567890')
-
-    def setup_ap(self, hostapd_conf, ipv6_mode):
-        '''Set up simulated access point
-
-        On self.dev_w_ap, run hostapd with given configuration. Setup dnsmasq
-        according to ipv6_mode, see start_dnsmasq().
-
-        This is torn down automatically at the end of the test.
-        '''
-
-        # give our AP an IP
-        subprocess.check_call(['ip', 'a', 'flush', 'dev', self.dev_w_ap])
-        if ipv6_mode is not None:
-            subprocess.check_call(['ip', 'a', 'add', self.dev_e_ap_ip6, 'dev', self.dev_w_ap])
-        else:
-            subprocess.check_call(['ip', 'a', 'add', self.dev_e_ap_ip4, 'dev', self.dev_w_ap])
-
-        self.start_hostapd(hostapd_conf)
-        self.start_dnsmasq(ipv6_mode, self.dev_w_ap)
 
     def setup_eth(self, ipv6_mode, start_dnsmasq=True):
         '''Set up simulated ethernet router
@@ -273,19 +209,6 @@ class IntegrationTestsBase(unittest.TestCase):
                 time.sleep(0.1)
 
         assert timeout > 0, 'Timed out waiting for "%s":\n------------\n%s\n-------\n' % (string, log)
-
-    def start_hostapd(self, conf):
-        hostapd_conf = os.path.join(self.workdir, 'hostapd.conf')
-        with open(hostapd_conf, 'w') as f:
-            f.write('interface=%s\ndriver=nl80211\n' % self.dev_w_ap)
-            f.write(conf)
-
-        log = os.path.join(self.workdir, 'hostapd.log')
-        p = subprocess.Popen(['hostapd', '-e', self.entropy_file, '-f', log, hostapd_conf],
-                             stdout=subprocess.PIPE)
-        self.addCleanup(p.wait)
-        self.addCleanup(p.terminate)
-        self.poll_text(log, '' + self.dev_w_ap + ': AP-ENABLED', 500)
 
     def start_dnsmasq(self, ipv6_mode, iface):
         '''Start dnsmasq.
@@ -348,12 +271,6 @@ class IntegrationTestsBase(unittest.TestCase):
         if 'bond' not in iface:
             self.assertIn('state UP', out)
 
-        if iface == self.dev_w_client:
-            out = subprocess.check_output(['iw', 'dev', iface, 'link'],
-                                          universal_newlines=True)
-            # self.assertIn('Connected to ' + self.mac_w_ap, out)
-            self.assertIn('SSID: fake net', out)
-
     def generate_and_settle(self):
         '''Generate config, launch and settle NM and networkd'''
 
@@ -413,3 +330,110 @@ class IntegrationTestsBase(unittest.TestCase):
         p = subprocess.Popen(['systemctl', 'is-active', unit], stdout=subprocess.PIPE)
         out = p.communicate()[0]
         return p.returncode == 0 or out.startswith(b'activating')
+
+
+class IntegrationTestsWifi(IntegrationTestsBase):
+    '''Common functionality for network test cases
+
+    setUp() creates two test wlan devices, one for a simulated access point
+    (self.dev_w_ap), the other for a simulated client device
+    (self.dev_w_client), and two test ethernet devices (self.dev_e_{ap,client}
+    and self.dev_e2_{ap,client}.
+
+    Each test should call self.setup_ap() or self.setup_eth() with the desired
+    configuration.
+    '''
+    @classmethod
+    def setUpClass(klass):
+        super().setUpClass()
+        # ensure we have this so that iw works
+        try:
+            subprocess.check_call(['modprobe', 'cfg80211'])
+            # set regulatory domain "EU", so that we can use 80211.a 5 GHz channels
+            out = subprocess.check_output(['iw', 'reg', 'get'], universal_newlines=True)
+            m = re.match(r'^(?:global\n)?country (\S+):', out)
+            assert m
+            klass.orig_country = m.group(1)
+            subprocess.check_call(['iw', 'reg', 'set', 'EU'])
+        except Exception:
+            raise unittest.SkipTest("cfg80211 (wireless) is unavailable, can't test")
+
+    @classmethod
+    def tearDownClass(klass):
+        subprocess.check_call(['iw', 'reg', 'set', klass.orig_country])
+        super().tearDownClass()
+
+    @classmethod
+    def create_devices(klass):
+        '''Create Access Point and Client devices with mac80211_hwsim and veth'''
+        if os.path.exists('/sys/module/mac80211_hwsim'):
+            raise SystemError('mac80211_hwsim module already loaded')
+        super().create_devices()
+        # create virtual wlan devs
+        before_wlan = set([c for c in os.listdir('/sys/class/net') if c.startswith('wlan')])
+        subprocess.check_call(['modprobe', 'mac80211_hwsim'])
+        # wait 5 seconds for fake devices to appear
+        timeout = 50
+        while timeout > 0:
+            after_wlan = set([c for c in os.listdir('/sys/class/net') if c.startswith('wlan')])
+            if len(after_wlan) - len(before_wlan) >= 2:
+                break
+            timeout -= 1
+            time.sleep(0.1)
+        else:
+            raise SystemError('timed out waiting for fake devices to appear')
+
+        devs = list(after_wlan - before_wlan)
+        klass.dev_w_ap = devs[0]
+        klass.dev_w_client = devs[1]
+
+        # don't let NM trample over our fake AP
+        with open('/run/NetworkManager/conf.d/test-blacklist.conf', 'w') as f:
+            f.write('[main]\nplugins=keyfile\n[keyfile]\nunmanaged-devices+=nptestsrv,%s\n' % klass.dev_w_ap)
+
+    @classmethod
+    def shutdown_devices(klass):
+        '''Remove test devices'''
+        super().shutdown_devices()
+        klass.dev_w_ap = None
+        klass.dev_w_client = None
+        subprocess.check_call(['rmmod', 'mac80211_hwsim'])
+
+    def start_hostapd(self, conf):
+        hostapd_conf = os.path.join(self.workdir, 'hostapd.conf')
+        with open(hostapd_conf, 'w') as f:
+            f.write('interface=%s\ndriver=nl80211\n' % self.dev_w_ap)
+            f.write(conf)
+
+        log = os.path.join(self.workdir, 'hostapd.log')
+        p = subprocess.Popen(['hostapd', '-e', self.entropy_file, '-f', log, hostapd_conf],
+                             stdout=subprocess.PIPE)
+        self.addCleanup(p.wait)
+        self.addCleanup(p.terminate)
+        self.poll_text(log, '' + self.dev_w_ap + ': AP-ENABLED', 500)
+
+    def setup_ap(self, hostapd_conf, ipv6_mode):
+        '''Set up simulated access point
+
+        On self.dev_w_ap, run hostapd with given configuration. Setup dnsmasq
+        according to ipv6_mode, see start_dnsmasq().
+
+        This is torn down automatically at the end of the test.
+        '''
+        # give our AP an IP
+        subprocess.check_call(['ip', 'a', 'flush', 'dev', self.dev_w_ap])
+        if ipv6_mode is not None:
+            subprocess.check_call(['ip', 'a', 'add', self.dev_e_ap_ip6, 'dev', self.dev_w_ap])
+        else:
+            subprocess.check_call(['ip', 'a', 'add', self.dev_e_ap_ip4, 'dev', self.dev_w_ap])
+        self.start_hostapd(hostapd_conf)
+        self.start_dnsmasq(ipv6_mode, self.dev_w_ap)
+
+    def assert_iface_up(self, iface, expected_ip_a=None, unexpected_ip_a=None):
+        '''Assert that client interface is up'''
+        super().assert_iface_up(iface, expected_ip_a, unexpected_ip_a)
+        if iface == self.dev_w_client:
+            out = subprocess.check_output(['iw', 'dev', iface, 'link'],
+                                          universal_newlines=True)
+            # self.assertIn('Connected to ' + self.mac_w_ap, out)
+            self.assertIn('SSID: fake net', out)

--- a/tests/integration/wifi.py
+++ b/tests/integration/wifi.py
@@ -24,7 +24,7 @@ import sys
 import subprocess
 import unittest
 
-from base import IntegrationTestsBase, test_backends
+from base import IntegrationTestsWifi, test_backends
 
 
 class _CommonTests():
@@ -125,13 +125,13 @@ wpa_passphrase=12345678
 
 @unittest.skipIf("networkd" not in test_backends,
                      "skipping as networkd backend tests are disabled")
-class TestNetworkd(IntegrationTestsBase, _CommonTests):
+class TestNetworkd(IntegrationTestsWifi, _CommonTests):
     backend = 'networkd'
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
                      "skipping as NetworkManager backend tests are disabled")
-class TestNetworkManager(IntegrationTestsBase, _CommonTests):
+class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
     backend = 'NetworkManager'
 
     def test_wifi_ap_open(self):


### PR DESCRIPTION
## Description
* Encapsulate wifi tests into own test class (requiring `modprobe`, i.e. isolation-machine level).
* Make sure the management always stays up an connected (incl. DNS), independently of netplan

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

