### PR TITLE
cli:set: write to existing YAML file, if available

### DIFF
--- a/doc/netplan-set.md
+++ b/doc/netplan-set.md
@@ -35,7 +35,7 @@ For details of the configuration file format, see **netplan**(5).
 :    Write YAML files into this root instead of /
 
   --origin-hint
-:    Specify the name of the overwrite YAML file, e.g.: ``70-netplan-set`` => ``/etc/netplan/70-netplan-set.yaml``
+:    Specify a name for the config file, e.g.: ``70-netplan-set`` => ``/etc/netplan/70-netplan-set.yaml``
 
 # SEE ALSO
 

--- a/netplan/cli/commands/get.py
+++ b/netplan/cli/commands/get.py
@@ -48,7 +48,7 @@ class NetplanGet(utils.NetplanCommand):
 
         if self.key != 'all':
             # The 'network.' prefix is optional for netsted keys, its always assumed to be there
-            if not self.key.startswith('network.'):
+            if not self.key.startswith('network.') and not self.key == 'network':
                 self.key = 'network.' + self.key
             # Split at '.' but not at '\.' via negative lookbehind expression
             for k in re.split(r'(?<!\\)\.', self.key):

--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -70,7 +70,7 @@ class NetplanSet(utils.NetplanCommand):
         # Merge GLOBAL_KEYS into one of the available subtrees
         # Write to same file (if only one hint/subtree is available)
         # Write to FALLBACK_HINT if multiple hints/subtrees are available, as we do not know where it is supposed to go
-        if network.get('renderer') is not None or network.get('version') is not None:
+        if any(network.get(key) for key in GLOBAL_KEYS):
             # Write to the same file, if we have only one file-hint or to FALLBACK_HINT otherwise
             hint = list(subtrees)[0] if len(subtrees) == 1 else FALLBACK_HINT
             for key in GLOBAL_KEYS:

--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -26,6 +26,9 @@ import logging
 import netplan.cli.utils as utils
 from netplan.configmanager import ConfigManager
 
+FALLBACK_HINT = '70-netplan-set'
+GLOBAL_KEYS = ['renderer', 'version']
+
 
 class NetplanSet(utils.NetplanCommand):
 
@@ -49,13 +52,11 @@ class NetplanSet(utils.NetplanCommand):
         self.run_command()
 
     def split_tree_by_hint(self, set_tree) -> (str, dict):
-        FALLBACK_HINT = '70-netplan-set'
         network = set_tree.get('network', {})
         # A mapping of 'origin-hint' -> YAML tree (one subtree per netdef)
         subtrees = dict()
-        global_keys = ['renderer', 'version']
         for devtype in network:
-            if devtype in global_keys:
+            if devtype in GLOBAL_KEYS:
                 continue  # special handling of global keys down below
             for netdef in network.get(devtype, []):
                 hint = FALLBACK_HINT
@@ -66,14 +67,14 @@ class NetplanSet(utils.NetplanCommand):
                 # Merge all netdef trees which are going to be written to the same file/hint
                 subtrees[hint] = self.merge(subtrees.get(hint, {}), netdef_tree)
 
-        # Merge global_keys into one of the available subtrees
+        # Merge GLOBAL_KEYS into one of the available subtrees
         # Write to same file (if only one hint/subtree is available)
         # Write to FALLBACK_HINT if multiple hints/subtrees are available, as we do not know where it is supposed to go
         if network.get('renderer') is not None or network.get('version') is not None:
             # Write to the same file, if we have only one file-hint or to FALLBACK_HINT otherwise
             hint = list(subtrees)[0] if len(subtrees) == 1 else FALLBACK_HINT
-            for var in global_keys:
-                tree = {'network': {var: network.get(var)}}
+            for key in GLOBAL_KEYS:
+                tree = {'network': {key: network.get(key)}}
                 subtrees[hint] = self.merge(subtrees.get(hint, {}), tree)
 
         # return a list of (str:hint, dict:subtree) tuples

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -38,6 +38,7 @@ class _GError(ctypes.Structure):
 
 lib = ctypes.CDLL(ctypes.util.find_library('netplan'))
 lib.netplan_parse_yaml.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.POINTER(_GError))]
+lib.netplan_get_filename_by_id.restype = ctypes.c_char_p
 
 
 def netplan_parse(path):
@@ -51,6 +52,11 @@ def netplan_parse(path):
     if err:
         raise Exception(err.contents.message.decode('utf-8'))
     return True
+
+
+def netplan_get_filename_by_id(netdef_id, rootdir):
+    res = lib.netplan_get_filename_by_id(netdef_id.encode(), rootdir.encode())
+    return res.decode('utf-8') if res else None
 
 
 def get_generator_path():

--- a/src/util.c
+++ b/src/util.c
@@ -289,3 +289,26 @@ netplan_get_id_from_nm_filename(const char* filename, const char* ssid)
     id_len = end - start;
     return g_strndup(start, id_len);
 }
+
+/**
+ * Get the filename from which the given netdef has been parsed.
+ * @rootdir: ID of the netdef to be looked up
+ * @rootdir: parse files from this root directory
+ */
+gchar*
+netplan_get_filename_by_id(const char* netdef_id, const char* rootdir)
+{
+    gchar* filename = NULL;
+    netplan_clear_netdefs();
+    if (!process_yaml_hierarchy(rootdir))
+        return NULL; // LCOV_EXCL_LINE
+    GHashTable* netdefs = netplan_finish_parse(NULL);
+    if (!netdefs)
+        return NULL;
+    NetplanNetDefinition* nd = g_hash_table_lookup(netdefs, netdef_id);
+    if (!nd)
+        return NULL;
+    filename = g_strdup(nd->filename);
+    netplan_clear_netdefs();
+    return filename;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -34,5 +34,6 @@ gchar* systemd_escape(char* string);
 gboolean netplan_delete_connection(const char* id, const char* rootdir);
 gboolean netplan_generate(const char* rootdir);
 gchar* netplan_get_id_from_nm_filename(const char* filename, const char* ssid);
+gchar* netplan_get_filename_by_id(const char* netdef_id, const char* rootdir);
 
 #define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -242,13 +242,14 @@ class TestNetplanDBus(unittest.TestCase):
             "io.netplan.Netplan",
             "/io/netplan/Netplan/config/{}".format(cid),
             "io.netplan.Netplan.Config",
-            "Set", "ss", "ethernets.eth42.dhcp6=true", "testfile",
+            "Set", "ss", "ethernets.eth42.dhcp6=true", "",
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
+        print(self.mock_netplan_cmd.calls(), flush=True)
         self.assertEquals(self.mock_netplan_cmd.calls(), [[
             "netplan", "set", "ethernets.eth42.dhcp6=true",
-            "--origin-hint=testfile", "--root-dir={}".format(tmpdir)
+            "--root-dir={}".format(tmpdir)
         ]])
 
     def test_netplan_dbus_config_get(self):

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -236,33 +236,33 @@ class TestSet(unittest.TestCase):
         self.assertEquals('Invalid input: {\'network\': {\'ethernets\': {\'eth0\': {\'dhcp4:false\': None}}}}', str(err))
 
     def test_set_override_existing_file(self):
-        OVERRIDE = os.path.join(self.workdir.name, 'etc', 'netplan', 'some-file.yaml')
-        with open(OVERRIDE, 'w') as f:
+        override = os.path.join(self.workdir.name, 'etc', 'netplan', 'some-file.yaml')
+        with open(override, 'w') as f:
             f.write(r'network: {ethernets: {eth0: {dhcp4: true}, eth1: {dhcp6: false}}}')
         self._set([r'ethernets.eth0.dhcp4=false'])
         self.assertFalse(os.path.isfile(self.path))
-        self.assertTrue(os.path.isfile(OVERRIDE))
-        with open(OVERRIDE, 'r') as f:
+        self.assertTrue(os.path.isfile(override))
+        with open(override, 'r') as f:
             out = f.read()
             self.assertIn('network:\n  ethernets:\n    eth0:\n      dhcp4: false', out)  # new
             self.assertIn('eth1:\n      dhcp6: false', out)  # old
 
     def test_set_override_existing_file_escaped_dot(self):
-        OVERRIDE = os.path.join(self.workdir.name, 'etc', 'netplan', 'some-file.yaml')
-        with open(OVERRIDE, 'w') as f:
+        override = os.path.join(self.workdir.name, 'etc', 'netplan', 'some-file.yaml')
+        with open(override, 'w') as f:
             f.write(r'network: {ethernets: {eth0.123: {dhcp4: true}}}')
         self._set([r'ethernets.eth0\.123.dhcp4=false'])
         self.assertFalse(os.path.isfile(self.path))
-        self.assertTrue(os.path.isfile(OVERRIDE))
-        with open(OVERRIDE, 'r') as f:
+        self.assertTrue(os.path.isfile(override))
+        with open(override, 'r') as f:
             self.assertIn('network:\n  ethernets:\n    eth0.123:\n      dhcp4: false', f.read())
 
     def test_set_override_multiple_existing_files(self):
-        FILE1 = os.path.join(self.workdir.name, 'etc', 'netplan', 'eth0.yaml')
-        with open(FILE1, 'w') as f:
+        file1 = os.path.join(self.workdir.name, 'etc', 'netplan', 'eth0.yaml')
+        with open(file1, 'w') as f:
             f.write(r'network: {ethernets: {eth0.1: {dhcp4: true}, eth0.2: {dhcp4: true}}}')
-        FILE2 = os.path.join(self.workdir.name, 'etc', 'netplan', 'eth1.yaml')
-        with open(FILE2, 'w') as f:
+        file2 = os.path.join(self.workdir.name, 'etc', 'netplan', 'eth1.yaml')
+        with open(file2, 'w') as f:
             f.write(r'network: {ethernets: {eth1: {dhcp4: true}}}')
         self._set([(r'network={renderer: NetworkManager, version: 2,'
                     r'ethernets:{'
@@ -271,11 +271,11 @@ class TestSet(unittest.TestCase):
                     r'eth0.2:{dhcp4: false}},'
                     r'bridges:{'
                     r'br99:{dhcp4: false}}}')])
-        self.assertTrue(os.path.isfile(FILE1))
-        with open(FILE1, 'r') as f:
+        self.assertTrue(os.path.isfile(file1))
+        with open(file1, 'r') as f:
             self.assertIn('network:\n  ethernets:\n    eth0.1:\n      dhcp4: false', f.read())
-        self.assertTrue(os.path.isfile(FILE2))
-        with open(FILE2, 'r') as f:
+        self.assertTrue(os.path.isfile(file2))
+        with open(file2, 'r') as f:
             self.assertIn('network:\n  ethernets:\n    eth1:\n      dhcp4: false', f.read())
         self.assertTrue(os.path.isfile(self.path))
         with open(self.path, 'r') as f:

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -184,7 +184,7 @@ class TestSet(unittest.TestCase):
             f.write('''network:\n  version: 2\n  renderer: NetworkManager
   ethernets:
     ens3: {dhcp4: yes, dhcp6: yes}
-    eth0: {addresses: [1.2.3.4]}''')
+    eth0: {addresses: [1.2.3.4/24]}''')
         self._set(['ethernets.eth0.addresses=NULL'])
         self._set(['ethernets.ens3.dhcp6=null'])
         self.assertTrue(os.path.isfile(self.path))

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -331,3 +331,9 @@ pin: 1234''', out)
     eth0:
       dhcp4: true
   version: 2\n''', out)
+
+    def test_get_network(self):
+        with open(self.path, 'w') as f:
+            f.write('network:\n  version: 2\n  renderer: NetworkManager')
+        out = self._get(['network'])
+        self.assertEquals('renderer: NetworkManager\nversion: 2\n', out)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,3 +164,32 @@ class TestUtils(unittest.TestCase):
     def test_interface_macaddress_empty(self, ifaddr):
         ifaddr.side_effect = lambda _: {}
         self.assertEqual(utils.get_interface_macaddress('eth42'), '')
+
+    def test_netplan_get_filename_by_id(self):
+        FILE_A = os.path.join(self.workdir.name, 'etc/netplan/a.yaml')
+        FILE_B = os.path.join(self.workdir.name, 'etc/netplan/b.yaml')
+        with open(FILE_A, 'w') as f:
+            f.write('network:\n  ethernets:\n    id_a:\n      dhcp4: true')
+        with open(FILE_B, 'w') as f:
+            f.write('network:\n  ethernets:\n    id_b:\n      dhcp4: true\n    id_a:\n      dhcp4: true')
+        # netdef:b can only be found in b.yaml
+        basename = os.path.basename(utils.netplan_get_filename_by_id('id_b', self.workdir.name))
+        self.assertEqual(basename, 'b.yaml')
+        # netdef:a is defined in a.yaml, overriden by b.yaml
+        basename = os.path.basename(utils.netplan_get_filename_by_id('id_a', self.workdir.name))
+        self.assertEqual(basename, 'b.yaml')
+
+    def test_netplan_get_filename_by_id_no_files(self):
+        self.assertIsNone(utils.netplan_get_filename_by_id('some-id', self.workdir.name))
+
+    def test_netplan_get_filename_by_id_invalid(self):
+        FILE = os.path.join(self.workdir.name, 'etc/netplan/a.yaml')
+        with open(FILE, 'w') as f:
+            f.write('''network:
+  tunnels:
+    id_a:
+      mode: sit
+      local: 0.0.0.0
+      remote: 0.0.0.0
+      key: 0.0.0.0''')
+        self.assertIsNone(utils.netplan_get_filename_by_id('some-id', self.workdir.name))


### PR DESCRIPTION
## Description
This PR builds upon some functionality from #193, so that one should be merged first. It extends the existing CLI functionality of `netplan set` to auto-detect the filename of the corresponding YAML config which contains the original definition of this netdef. If, for example, there is a config file `/etc/netplan/00-my-manual-config.yaml` containing a definition for `eth0` and we're calling `netplan set network.ethernets.eth0.dhcp4=false`, that setting will be overridden in **00-my-manual-config.yaml** instead of masking it via **70-netplan-set.yaml**.

If the **set** command contains multiple netdefs (e.g. `netplan set network="{ethernets:{eth0:{dhcp4: true}}, bridges:{br0:{dhcp6: true}}}"`), each will be checked individually and written to its corresponding file. If there is no prior definition of a given netdef, it will be written to `70-netplan-set.yaml` by default.

Additionally, this PR introduces a small bug-fix to make `netplan get network` work, returning the full YAML tree, except for the top level `network` key.

In the C library `libnetplan` a new `netplan_get_filename_by_id()` API is introduced, parsing the current set of YAML configs and checking the resulting hashtable for the filename of the highest priority netdef.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

