### PR TITLE
Prevent duplicate ARPIPTargets in NetDev files (LP: #1915837)

### DIFF
--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -392,16 +392,29 @@ Label=ip6
 
     def test_bond_arp_ip_targets_multi_pass(self):
         self.generate('''network:
-  version: 2
-  ethernets:
-    eno1: {}
   bonds:
     bond0:
-      interfaces: [eno1]
+      interfaces:
+      - eno1
+      - eno49
       parameters:
         arp-ip-targets:
           - 10.10.10.10
-          - 20.20.20.20''')
+          - 20.20.20.20
+    bond1:
+      interfaces:
+      - eno2
+      - eno50
+      parameters:
+        arp-ip-targets:
+          - 10.10.10.10
+          - 20.20.20.20
+  ethernets:
+    eno1: {}
+    eno2: {}
+    eno49: {}
+    eno50: {}
+  version: 2''')
         self.assert_networkd({'bond0.netdev': '''[NetDev]
 Name=bond0
 Kind=bond
@@ -416,12 +429,47 @@ Name=bond0
 LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 ''',
+                              'bond1.netdev': '''[NetDev]
+Name=bond1
+Kind=bond
+
+[Bond]
+ARPIPTargets=10.10.10.10 20.20.20.20
+''',
+                              'bond1.network': '''[Match]
+Name=bond1
+
+[Network]
+LinkLocalAddressing=ipv6
+ConfigureWithoutCarrier=yes
+''',
                               'eno1.network': '''[Match]
 Name=eno1
 
 [Network]
 LinkLocalAddressing=no
 Bond=bond0
+''',
+                              'eno2.network': '''[Match]
+Name=eno2
+
+[Network]
+LinkLocalAddressing=no
+Bond=bond1
+''',
+                              'eno49.network': '''[Match]
+Name=eno49
+
+[Network]
+LinkLocalAddressing=no
+Bond=bond0
+''',
+                              'eno50.network': '''[Match]
+Name=eno50
+
+[Network]
+LinkLocalAddressing=no
+Bond=bond1
 '''})
 
     def test_dhcp_critical_true(self):

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -390,6 +390,40 @@ Label=ip6
             'br0.network': ND_EMPTY % ('br0', 'ipv6'),
             'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n'})
 
+    def test_bond_arp_ip_targets_multi_pass(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    eno1: {}
+  bonds:
+    bond0:
+      interfaces: [eno1]
+      parameters:
+        arp-ip-targets:
+          - 10.10.10.10
+          - 20.20.20.20''')
+        self.assert_networkd({'bond0.netdev': '''[NetDev]
+Name=bond0
+Kind=bond
+
+[Bond]
+ARPIPTargets=10.10.10.10 20.20.20.20
+''',
+                              'bond0.network': '''[Match]
+Name=bond0
+
+[Network]
+LinkLocalAddressing=ipv6
+ConfigureWithoutCarrier=yes
+''',
+                              'eno1.network': '''[Match]
+Name=eno1
+
+[Network]
+LinkLocalAddressing=no
+Bond=bond0
+'''})
+
     def test_dhcp_critical_true(self):
         self.generate('''network:
   version: 2

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -396,24 +396,12 @@ Label=ip6
     bond0:
       interfaces:
       - eno1
-      - eno49
-      parameters:
-        arp-ip-targets:
-          - 10.10.10.10
-          - 20.20.20.20
-    bond1:
-      interfaces:
-      - eno2
-      - eno50
       parameters:
         arp-ip-targets:
           - 10.10.10.10
           - 20.20.20.20
   ethernets:
     eno1: {}
-    eno2: {}
-    eno49: {}
-    eno50: {}
   version: 2''')
         self.assert_networkd({'bond0.netdev': '''[NetDev]
 Name=bond0
@@ -429,47 +417,12 @@ Name=bond0
 LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 ''',
-                              'bond1.netdev': '''[NetDev]
-Name=bond1
-Kind=bond
-
-[Bond]
-ARPIPTargets=10.10.10.10 20.20.20.20
-''',
-                              'bond1.network': '''[Match]
-Name=bond1
-
-[Network]
-LinkLocalAddressing=ipv6
-ConfigureWithoutCarrier=yes
-''',
                               'eno1.network': '''[Match]
 Name=eno1
 
 [Network]
 LinkLocalAddressing=no
 Bond=bond0
-''',
-                              'eno2.network': '''[Match]
-Name=eno2
-
-[Network]
-LinkLocalAddressing=no
-Bond=bond1
-''',
-                              'eno49.network': '''[Match]
-Name=eno49
-
-[Network]
-LinkLocalAddressing=no
-Bond=bond0
-''',
-                              'eno50.network': '''[Match]
-Name=eno50
-
-[Network]
-LinkLocalAddressing=no
-Bond=bond1
 '''})
 
     def test_dhcp_critical_true(self):


### PR DESCRIPTION
…(LP: #1915837)

https://bugs.launchpad.net/netplan/+bug/1915837

## Description

Using arp-ip-targets as below is generating 10-netplan-bond0.netdev file which contains ARPIPTargets property with duplicated values;

> arp-ip-targets:
>         - 10.10.10.10
>         - 20.20.20.20

> ARPIPTargets=10.10.10.10 20.20.20.20 10.10.10.10 20.20.20.20

Duplicate values in ARPIPTargets prevents systemd-networkd to process the netdev file due to a validation error in Ubuntu 18.04LTS.

## Checklist

- [x] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad: https://bugs.launchpad.net/netplan/+bug/1915837

