### PR TITLE
networkd: restart/reconfigure

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -33,6 +33,8 @@ from netplan.cli.sriov import apply_sriov_config
 from netplan.cli.ovs import apply_ovs_cleanup
 
 
+OVS_CLEANUP_SERVICE = 'netplan-ovs-cleanup.service'
+
 
 class NetplanApply(utils.NetplanCommand):
 
@@ -149,7 +151,7 @@ class NetplanApply(utils.NetplanCommand):
 
         # stop backends
         if restart_networkd:
-            logging.debug('netplan generated networkd configuration changed, restarting networkd')
+            logging.debug('netplan generated networkd configuration changed, reloading networkd')
             # Running 'systemctl daemon-reload' will re-run the netplan systemd generator,
             # so let's make sure we only run it iff we're willing to run 'netplan generate'
             if run_generate:
@@ -161,7 +163,7 @@ class NetplanApply(utils.NetplanCommand):
             # upgraded system, we need to make sure to stop those.
             if utils.systemctl_is_active('netplan-wpa@*.service'):
                 wpa_services.insert(0, 'netplan-wpa@*.service')
-            utils.systemctl_networkd('stop', sync=sync, extra_services=wpa_services)
+            utils.systemctl('stop', wpa_services, sync=sync)
         else:
             logging.debug('no netplan generated networkd configuration exists')
 
@@ -230,10 +232,16 @@ class NetplanApply(utils.NetplanCommand):
         # (re)start backends
         if restart_networkd:
             netplan_wpa = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-wpa-*.service')]
-            netplan_ovs = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-ovs-*.service')]
+            # exclude the special 'netplan-ovs-cleanup.service' unit
+            netplan_ovs = [os.path.basename(f) for f in glob.glob('/run/systemd/system/*.wants/netplan-ovs-*.service')
+                           if not f.endswith('/' + OVS_CLEANUP_SERVICE)]
             # Run 'systemctl start' command synchronously, to avoid race conditions
             # with 'oneshot' systemd service units, e.g. netplan-ovs-*.service.
-            utils.systemctl_networkd('start', sync=True, extra_services=netplan_wpa + netplan_ovs)
+            utils.networkctl_reconfigure(utils.networkd_interfaces())
+            # 1st: execute OVS cleanup, to avoid races while applying OVS config
+            utils.systemctl('start', [OVS_CLEANUP_SERVICE], sync=True)
+            # 2nd: start all other services
+            utils.systemctl('start', netplan_wpa + netplan_ovs, sync=True)
         if restart_nm:
             # Flush all IP addresses of NM managed interfaces, to avoid NM creating
             # new, non netplan-* connection profiles, using the existing IPs.

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -25,13 +25,13 @@ import sys
 import glob
 import subprocess
 import shutil
+import netifaces
 
 import netplan.cli.utils as utils
 from netplan.configmanager import ConfigManager, ConfigurationError
 from netplan.cli.sriov import apply_sriov_config
 from netplan.cli.ovs import apply_ovs_cleanup
 
-import netifaces
 
 
 class NetplanApply(utils.NetplanCommand):

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -100,21 +100,12 @@ def nm_interfaces(paths, devices):
     return interfaces
 
 
-def systemctl_network_manager(action, sync=False):  # pragma: nocover (covered in autopkgtest)
-    service_name = NM_SERVICE_NAME
-
-    command = ['systemctl', action]
-    if not sync:
-        command.append('--no-block')
-
+def systemctl_network_manager(action, sync=False):
     # If the network-manager snap is installed use its service
     # name rather than the one of the deb packaged NetworkManager
     if is_nm_snap_enabled():
-        service_name = NM_SNAP_SERVICE_NAME
-
-    command.append(service_name)
-
-    subprocess.check_call(command)
+        return systemctl(action, [NM_SNAP_SERVICE_NAME], sync)
+    return systemctl(action, [NM_SERVICE_NAME], sync)  # pragma: nocover (covered in autopkgtest)
 
 
 def systemctl(action, services, sync=False):

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -115,8 +115,7 @@ def systemctl(action, services, sync=False):
         if not sync:
             command.append('--no-block')
 
-        for service in services:
-            command.append(service)
+        command.extend(services)
 
         subprocess.check_call(command)
 

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -63,7 +63,7 @@ def get_generator_path():
     return os.environ.get('NETPLAN_GENERATE_PATH', '/lib/netplan/generate')
 
 
-def is_nm_snap_enabled():  # pragma: nocover (covered in autopkgtest)
+def is_nm_snap_enabled():
     return subprocess.call(['systemctl', '--quiet', 'is-enabled', NM_SNAP_SERVICE_NAME], stderr=subprocess.DEVNULL) == 0
 
 
@@ -137,19 +137,19 @@ def networkctl_reconfigure(interfaces):
         subprocess.check_call(['networkctl', 'reconfigure'] + list(interfaces))
 
 
-def systemctl_is_active(unit_pattern):  # pragma: nocover (covered in autopkgtest)
+def systemctl_is_active(unit_pattern):
     '''Return True if at least one matching unit is running'''
     if subprocess.call(['systemctl', '--quiet', 'is-active', unit_pattern]) == 0:
         return True
     return False
 
 
-def systemctl_daemon_reload():  # pragma: nocover (covered in autopkgtest)
+def systemctl_daemon_reload():
     '''Reload systemd unit files from disk and re-calculate its dependencies'''
     subprocess.check_call(['systemctl', 'daemon-reload'])
 
 
-def ip_addr_flush(iface):  # pragma: nocover (covered in autopkgtest)
+def ip_addr_flush(iface):
     '''Flush all IP addresses of a given interface via iproute2'''
     subprocess.check_call(['ip', 'addr', 'flush', iface], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 


### PR DESCRIPTION
## Description
Replace the calls of `systemctl stop/start systemd-networkd.service` with `networkctl reload && networkctl reconfigure ...` during the execution of `netplan apply`. The devices to be reconfigured are currently all interfaces managed by systemd-networkd, as read from `networkctl`. This makes the whole restart/apply process quicker and avoids network interruptions for netplan's networkd backend.

The reload & reconfigure commands are available as of **systemd v244**.

In addition to the Apply-CLI changes, corresponding methods in `utils.py` are updated/refactored and the unit-test coverage is being improved.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

