### PR TITLE
Fix NM unmanaged-devices (changes behavior)

### DIFF
--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -163,7 +163,7 @@ LinkLocalAddressing=ipv6
         self.assert_networkd_udev({'def1.rules': (UDEV_MAC_RULE % ('?*', '11:22:33:44:55:66', 'lom1'))})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
-unmanaged-devices+=mac:11:22:33:44:55:66,''')
+unmanaged-devices+=mac:11:22:33:44:55:66,interface-name:lom1,''')
         self.assert_nm_udev(None)
 
     def test_eth_implicit_name_match_dhcp4(self):
@@ -305,7 +305,7 @@ UseMTU=true
 '''})
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
-unmanaged-devices+=mac:00:11:22:33:44:55,''')
+unmanaged-devices+=mac:00:11:22:33:44:55,interface-name:en1s*,''')
 
 
 class TestNetworkManager(TestBase):

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -139,7 +139,7 @@ MTUBytes=9000
 
         self.assert_nm(None, '''[keyfile]
 # devices managed by networkd
-unmanaged-devices+=mac:11:22:33:44:55:66,interface-name:vlan20,''')
+unmanaged-devices+=mac:11:22:33:44:55:66,interface-name:lan,interface-name:vlan20,''')
         self.assert_nm_udev(None)
 
 


### PR DESCRIPTION
## Description
* nm: fix ignoring of multiple match conditions (like `interface-name:` AND `mac:`, instead of defaulting to MAC if available)
  * Some interfaces (e.g. bond members) might change their MAC and be picked up ny NM, interfering the tests, cf. `test_bond_mac/Networkd`

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

