### PR TITLE
Fix parsing of OVS values with colons (LP: #1913906)

### DIFF
--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -52,6 +52,7 @@ def _del_dict(type, iface, column, key, value):
     # removes the exact value only if it was set by netplan
     subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, column, key, _escape_colon(value)])
 
+
 # for ovsdb remove: column key's value can not contain bare ':', need to escape with '\'
 def _escape_colon(literal):
     return re.sub(r'([^\\]):', r'\g<1>\:', literal)

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -18,6 +18,7 @@
 import logging
 import os
 import subprocess
+import re
 
 OPENVSWITCH_OVS_VSCTL = '/usr/bin/ovs-vsctl'
 # Defaults for non-optional settings, as defined here:
@@ -49,7 +50,11 @@ def _del_col(type, iface, column, value):
 def _del_dict(type, iface, column, key, value):
     """Cleanup values from a dictionary (i.e. "column:key=value")"""
     # removes the exact value only if it was set by netplan
-    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, column, key, value])
+    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, column, key, _escape_colon(value)])
+
+# for ovsdb remove: column key's value can not contain bare ':', need to escape with '\'
+def _escape_colon(literal):
+    return re.sub(r'([^\\]):', r'\g<1>\:', literal)
 
 
 def _del_global(type, iface, key, value):

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -432,7 +432,7 @@ class _CommonTests():
       certificate: /another/cert.pem
       private-key: /private/key.pem
     external-ids:
-      somekey: somevalue
+      somekey: 55:44:33:22:11:00
     other-config:
       key: value
   ethernets:
@@ -466,6 +466,7 @@ class _CommonTests():
           iface-id: myhostname
         other-config:
           disable-in-band: true
+          hwaddr: aa:bb:cc:dd:ee:ff
     ovs1:
       openvswitch:
         # Add ovs1 as rstp cannot be used if bridge contains a bond interface
@@ -526,13 +527,15 @@ class _CommonTests():
         # Verify other-config
         self.assertIn(b'key=value', before['other-config-Open_vSwitch'])
         self.assertNotIn(b'key=value', after['other-config-Open_vSwitch'])
-        self.assertIn(b'ovs0,disable-in-band=true\n', before['other-config-Bridge'])
+        self.assertIn(b'hwaddr=aa:bb:cc:dd:ee:ff', before['other-config-Bridge'])
+        self.assertNotIn(b'hwaddr=aa:bb:cc:dd:ee:ff', after['other-config-Bridge'])
+        self.assertIn(b'ovs0,disable-in-band=true', before['other-config-Bridge'])
         self.assertIn(b'ovs0,\n', after['other-config-Bridge'])
         self.assertIn(b'eth42,disable-in-band=false\n', before['other-config-Interface'])
         self.assertIn(b'eth42,\n', after['other-config-Interface'])
         # Verify external-ids
-        self.assertIn(b'somekey=somevalue', before['external-ids-Open_vSwitch'])
-        self.assertNotIn(b'somekey=somevalue', after['external-ids-Open_vSwitch'])
+        self.assertIn(b'somekey=55:44:33:22:11:00', before['external-ids-Open_vSwitch'])
+        self.assertNotIn(b'somekey=55:44:33:22:11:00', after['external-ids-Open_vSwitch'])
         self.assertIn(b'iface-id=myhostname', before['external-ids-Bridge'])
         self.assertNotIn(b'iface-id=myhostname', after['external-ids-Bridge'])
         self.assertIn(b'iface-id=mylocaliface', before['external-ids-Interface'])

--- a/tests/test_ovs.py
+++ b/tests/test_ovs.py
@@ -110,7 +110,7 @@ Bootstrap: false'''
 
     @patch('subprocess.check_call')
     def test_clear_dict_colon(self, mock):
-        ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key','fa:16:3e:4b:19:3a')
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key', 'fa:16:3e:4b:19:3a')
         mock.assert_has_calls([
             call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key', 'fa\:16\:3e\:4b\:19\:3a']),
             call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])

--- a/tests/test_ovs.py
+++ b/tests/test_ovs.py
@@ -108,6 +108,15 @@ Bootstrap: false'''
             call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/rstp_enable'])
         ])
 
+    @patch('subprocess.check_call')
+    def test_clear_dict_colon(self, mock):
+        ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key','fa:16:3e:4b:19:3a')
+        mock.assert_has_calls([
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key', 'fa\:16\:3e\:4b\:19\:3a']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
+        ])
+        mock.mock_calls
+
     def test_is_ovs_interface(self):
         interfaces = dict()
         interfaces['ovs0'] = {'openvswitch': {'set-fail-mode': 'secure'}}

--- a/tests/test_ovs.py
+++ b/tests/test_ovs.py
@@ -112,7 +112,7 @@ Bootstrap: false'''
     def test_clear_dict_colon(self, mock):
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key', 'fa:16:3e:4b:19:3a')
         mock.assert_has_calls([
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key', 'fa\:16\:3e\:4b\:19\:3a']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key', r'fa\:16\:3e\:4b\:19\:3a']),
             call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
         ])
         mock.mock_calls


### PR DESCRIPTION
## Description
Bug fix for https://bugs.launchpad.net/netplan/+bug/1918197 and https://bugs.launchpad.net/netplan/+bug/1913906

Fixes the parse error for dict values that include ":"

`make check-coverage` errors out with less than 100% but so does the tip of master.

No new or changed keys.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

