### PR TITLE
Improve integration tests interface-ready waiting logic (LP: #1922126)

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -289,7 +289,7 @@ class IntegrationTestsBase(unittest.TestCase):
     def assert_iface_up(self, iface, expected_ip_a=None, unexpected_ip_a=None):
         '''Assert that client interface is up'''
 
-        out = self.assert_iface(iface, expected_ip_a=None, unexpected_ip_a=None)
+        out = self.assert_iface(iface, expected_ip_a, unexpected_ip_a)
         if 'bond' not in iface:
             self.assertIn('state UP', out)
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -4,10 +4,10 @@
 # Wifi (mac80211-hwsim). These need to be run in a VM and do change the system
 # configuration.
 #
-# Copyright (C) 2018-2020 Canonical, Ltd.
+# Copyright (C) 2018-2021 Canonical, Ltd.
 # Author: Martin Pitt <martin.pitt@ubuntu.com>
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
-# Author: Lukas Märdian <lukas.maerdian@canonical.com>
+# Author: Lukas Märdian <slyon@ubuntu.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -308,9 +308,9 @@ class IntegrationTestsBase(unittest.TestCase):
         for iface in ifaces:
             print(iface, end=' ', flush=True)
             if self.backend == 'NetworkManager':
-                self.nm_wait_connected(iface, 30)
+                self.nm_wait_connected(iface, 60)
             else:
-                self.networkd_wait_connected(iface, 30)
+                self.networkd_wait_connected(iface, 60)
 
     def nm_online_full(self, iface, timeout=60):
         '''Wait for NetworkManager connection to be completed (incl. IP4 & DHCP)'''

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -189,6 +189,7 @@ class IntegrationTestsBase(unittest.TestCase):
         '''
         # give our router an IP
         subprocess.check_call(['ip', 'a', 'flush', 'dev', self.dev_e_ap])
+        subprocess.check_call(['ip', 'a', 'flush', 'dev', self.dev_e2_ap])
         if ipv6_mode is not None:
             subprocess.check_call(['ip', 'a', 'add', self.dev_e_ap_ip6, 'dev', self.dev_e_ap])
             subprocess.check_call(['ip', 'a', 'add', self.dev_e2_ap_ip6, 'dev', self.dev_e2_ap])
@@ -252,11 +253,11 @@ class IntegrationTestsBase(unittest.TestCase):
             if ipv6_mode:
                 dhcp_range += ',' + ipv6_mode
 
-        self.dnsmasq_log = os.path.join(self.workdir, 'dnsmasq-%s.log' % iface)
+        dnsmasq_log = os.path.join(self.workdir, 'dnsmasq-%s.log' % iface)
         lease_file = os.path.join(self.workdir, 'dnsmasq-%s.leases' % iface)
 
         p = subprocess.Popen(['dnsmasq', '--keep-in-foreground', '--log-queries',
-                              '--log-facility=' + self.dnsmasq_log,
+                              '--log-facility=' + dnsmasq_log,
                               '--conf-file=/dev/null',
                               '--dhcp-leasefile=' + lease_file,
                               '--bind-interfaces',
@@ -264,13 +265,12 @@ class IntegrationTestsBase(unittest.TestCase):
                               '--except-interface=lo',
                               '--enable-ra',
                               '--dhcp-range=' + dhcp_range])
-        self.addCleanup(p.wait)
-        self.addCleanup(p.terminate)
+        self.addCleanup(p.kill)
 
         if ipv6_mode is not None:
-            self.poll_text(self.dnsmasq_log, 'IPv6 router advertisement enabled')
+            self.poll_text(dnsmasq_log, 'IPv6 router advertisement enabled')
         else:
-            self.poll_text(self.dnsmasq_log, 'DHCP, IP range')
+            self.poll_text(dnsmasq_log, 'DHCP, IP range')
 
     def assert_iface(self, iface, expected_ip_a=None, unexpected_ip_a=None):
         '''Assert that client interface has been created'''

--- a/tests/integration/bonds.py
+++ b/tests/integration/bonds.py
@@ -5,8 +5,9 @@
 # These need to be run in a VM and do change the system
 # configuration.
 #
-# Copyright (C) 2018 Canonical, Ltd.
+# Copyright (C) 2018-2021 Canonical, Ltd.
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+# Author: Lukas Märdian <slyon@ubuntu.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,17 +39,13 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
 
@@ -68,12 +65,10 @@ class _CommonTests():
         mode: active-backup
         primary: %(ec)s
       addresses: [ '10.10.10.1/24' ]''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 10.10.10.1/24'])
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 10.10.10.1/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             result = f.read().strip()
             self.assertIn(self.dev_e_client, result)
@@ -90,19 +85,15 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
       parameters:
         all-slaves-active: true
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/all_slaves_active') as f:
@@ -117,19 +108,15 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       parameters:
         mode: 802.3ad
       interfaces: [ethbn]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
@@ -144,20 +131,16 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       parameters:
         mode: 802.3ad
         ad-select: bandwidth
       interfaces: [ethbn]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/ad_select') as f:
@@ -172,20 +155,16 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       parameters:
         mode: 802.3ad
         lacp-rate: fast
       interfaces: [ethbn]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/lacp_rate') as f:
@@ -200,20 +179,16 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       parameters:
         mode: active-backup
         fail-over-mac-policy: follow
       interfaces: [ethbn]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
@@ -230,19 +205,15 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       parameters:
         mode: balance-xor
       interfaces: [ethbn]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
@@ -257,19 +228,15 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       parameters:
         mode: balance-rr
       interfaces: [ethbn]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
@@ -284,20 +251,16 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       parameters:
         mode: balance-rr
         packets-per-slave: 15
       interfaces: [ethbn]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
@@ -325,10 +288,9 @@ class _CommonTests():
         mii-monitor-interval: 50s
         resend-igmp: 100
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.9.9/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             result = f.read().strip()
@@ -354,20 +316,16 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       match:
         name: %(ec)s
         macaddress: %(ec_mac)s
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
       macaddress: 00:01:02:03:04:05
       dhcp4: yes''' % {'r': self.backend,
                        'ec': self.dev_e_client,
-                       'e2c': self.dev_e2_client,
                        'ec_mac': self.dev_e_client_mac})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24', '00:01:02:03:04:05'])
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24', '00:01:02:03:04:05'])
 
     def test_bond_down_delay(self):
         self.setup_eth(None)
@@ -378,7 +336,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -386,13 +343,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         mode: active-backup
         mii-monitor-interval: 5
         down-delay: 10s
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/downdelay') as f:
@@ -407,7 +361,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -415,13 +368,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         mode: active-backup
         mii-monitor-interval: 5
         up-delay: 10000
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/updelay') as f:
@@ -436,7 +386,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -444,13 +393,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         mode: balance-xor
         arp-ip-targets: [ 192.168.5.1 ]
         arp-interval: 50s
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_interval') as f:
@@ -465,7 +411,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -473,13 +418,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         mode: balance-xor
         arp-interval: 50000
         arp-ip-targets: [ 192.168.5.1 ]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_ip_target') as f:
@@ -494,7 +436,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -502,13 +443,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         mode: balance-xor
         arp-interval: 50000
         arp-ip-targets: [ 192.168.5.1, 192.168.5.34 ]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_ip_target') as f:
@@ -525,7 +463,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -535,13 +472,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-interval: 50000
         arp-all-targets: all
         arp-validate: all
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_all_targets') as f:
@@ -556,7 +490,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -565,13 +498,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-ip-targets: [192.168.5.1]
         arp-interval: 50000
         arp-validate: all
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_validate') as f:
@@ -596,7 +526,6 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -604,13 +533,10 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         mode: active-backup
         mii-monitor-interval: 5
         down-delay: 10000
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/downdelay') as f:
@@ -625,7 +551,6 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -633,13 +558,10 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         mode: active-backup
         mii-monitor-interval: 5
         up-delay: 10000
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/updelay') as f:
@@ -654,7 +576,6 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -662,13 +583,10 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         mode: balance-xor
         arp-ip-targets: [ 192.168.5.1 ]
         arp-interval: 50000
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_interval') as f:
@@ -683,7 +601,6 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -691,13 +608,10 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         mode: balance-xor
         arp-interval: 50000
         arp-ip-targets: [ 192.168.5.1 ]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_ip_target') as f:
@@ -712,7 +626,6 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       interfaces: [ethbn]
@@ -722,13 +635,10 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         arp-interval: 50000
         arp-all-targets: all
         arp-validate: all
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_all_targets') as f:
@@ -743,7 +653,6 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   bonds:
     mybond:
       parameters:
@@ -751,13 +660,10 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         mii-monitor-interval: 5
         learn-packet-interval: 15
       interfaces: [ethbn]
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master mybond'],
-                             ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:

--- a/tests/integration/bonds.py
+++ b/tests/integration/bonds.py
@@ -43,7 +43,7 @@ class _CommonTests():
     mybond:
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -91,7 +91,7 @@ class _CommonTests():
       parameters:
         all-slaves-active: true
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -114,7 +114,7 @@ class _CommonTests():
         mode: 802.3ad
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -138,7 +138,7 @@ class _CommonTests():
         ad-select: bandwidth
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -162,7 +162,7 @@ class _CommonTests():
         lacp-rate: fast
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -186,7 +186,7 @@ class _CommonTests():
         fail-over-mac-policy: follow
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -211,7 +211,7 @@ class _CommonTests():
         mode: balance-xor
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -234,7 +234,7 @@ class _CommonTests():
         mode: balance-rr
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -258,7 +258,7 @@ class _CommonTests():
         packets-per-slave: 15
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -323,7 +323,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       dhcp4: yes''' % {'r': self.backend,
                        'ec': self.dev_e_client,
                        'ec_mac': self.dev_e_client_mac})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24', '00:01:02:03:04:05'])
 
@@ -344,7 +344,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         mii-monitor-interval: 5
         down-delay: 10s
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -369,7 +369,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         mii-monitor-interval: 5
         up-delay: 10000
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -394,7 +394,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-ip-targets: [ 192.168.5.1 ]
         arp-interval: 50s
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -419,7 +419,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-interval: 50000
         arp-ip-targets: [ 192.168.5.1 ]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -444,7 +444,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-interval: 50000
         arp-ip-targets: [ 192.168.5.1, 192.168.5.34 ]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -473,7 +473,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-all-targets: all
         arp-validate: all
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -499,7 +499,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-interval: 50000
         arp-validate: all
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -534,7 +534,7 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         mii-monitor-interval: 5
         down-delay: 10000
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -559,7 +559,7 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         mii-monitor-interval: 5
         up-delay: 10000
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -584,7 +584,7 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         arp-ip-targets: [ 192.168.5.1 ]
         arp-interval: 50000
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -609,7 +609,7 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         arp-interval: 50000
         arp-ip-targets: [ 192.168.5.1 ]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -636,7 +636,7 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         arp-all-targets: all
         arp-validate: all
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
@@ -661,7 +661,7 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         learn-packet-interval: 15
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'mybond'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:

--- a/tests/integration/bridges.py
+++ b/tests/integration/bridges.py
@@ -45,7 +45,9 @@ class _CommonTests():
     mybr:
       interfaces: [ethbr]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'mybr'])
+        self.generate_and_settle([self.state_dhcp4(self.dev_e_client),
+                                  self.dev_e2_client,
+                                  self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.[0-9]+/24'])
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
@@ -77,7 +79,7 @@ class _CommonTests():
           ethbr: 50
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
@@ -103,7 +105,7 @@ class _CommonTests():
         ageing-time: 21
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
@@ -129,7 +131,7 @@ class _CommonTests():
         max-age: 12
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
@@ -155,7 +157,7 @@ class _CommonTests():
         hello-time: 1
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
@@ -181,7 +183,7 @@ class _CommonTests():
         forward-delay: 10
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
@@ -208,7 +210,7 @@ class _CommonTests():
         max-age: 100000
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
@@ -235,7 +237,7 @@ class _CommonTests():
           ethbr: 42
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
@@ -269,7 +271,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       dhcp4: yes''' % {'r': self.backend,
                        'ec': self.dev_e_client,
                        'ec_mac': self.dev_e_client_mac})
-        self.generate_and_settle([self.dev_e_client, 'br0'])
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4('br0')])
         self.assert_iface_up(self.dev_e_client, ['master br0'], ['inet '])
         self.assert_iface_up('br0', ['inet 192.168.5.[0-9]+/24', 'ether 00:01:02:03:04:05'])
 
@@ -332,7 +334,7 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         priority: 16384
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],

--- a/tests/integration/bridges.py
+++ b/tests/integration/bridges.py
@@ -5,8 +5,9 @@
 # These need to be run in a VM and do change the system
 # configuration.
 #
-# Copyright (C) 2018 Canonical, Ltd.
+# Copyright (C) 2018-2021 Canonical, Ltd.
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+# Author: Lukas Märdian <slyon@ubuntu.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,7 +23,6 @@
 
 import sys
 import subprocess
-import time
 import unittest
 
 from base import IntegrationTestsBase, test_backends
@@ -45,15 +45,10 @@ class _CommonTests():
     mybr:
       interfaces: [ethbr]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.[0-9]+/24'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
@@ -81,16 +76,10 @@ class _CommonTests():
         path-cost:
           ethbr: 50
         stp: false
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
@@ -113,16 +102,10 @@ class _CommonTests():
       parameters:
         ageing-time: 21
         stp: false
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
@@ -145,16 +128,10 @@ class _CommonTests():
       parameters:
         max-age: 12
         stp: false
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
@@ -177,16 +154,10 @@ class _CommonTests():
       parameters:
         hello-time: 1
         stp: false
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
@@ -209,16 +180,10 @@ class _CommonTests():
       parameters:
         forward-delay: 10
         stp: false
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
@@ -242,22 +207,43 @@ class _CommonTests():
         hello-time: 100000
         max-age: 100000
         stp: false
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/bridge/stp_state') as f:
             self.assertEqual(f.read().strip(), '0')
+
+    def test_bridge_port_priority(self):
+        self.setup_eth(None)
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'mybr'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    ethbr:
+      match: {name: %(e2c)s}
+  bridges:
+    mybr:
+      interfaces: [ethbr]
+      parameters:
+        port-priority:
+          ethbr: 42
+        stp: false
+      dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
+        lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
+                                        universal_newlines=True).splitlines()
+        self.assertEqual(len(lines), 1, lines)
+        self.assertIn(self.dev_e2_client, lines[0])
+        with open('/sys/class/net/mybr/brif/%s/priority' % self.dev_e2_client) as f:
+            self.assertEqual(f.read().strip(), '42')
 
 
 @unittest.skipIf("networkd" not in test_backends,
@@ -276,20 +262,16 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       match:
         name: %(ec)s
         macaddress: %(ec_mac)s
-    %(e2c)s: {}
   bridges:
     br0:
       interfaces: [ethbr]
-      macaddress: 00:01:02:03:04:05
+      macaddress: "00:01:02:03:04:05"
       dhcp4: yes''' % {'r': self.backend,
                        'ec': self.dev_e_client,
-                       'e2c': self.dev_e2_client,
                        'ec_mac': self.dev_e_client_mac})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['master br0'], ['inet'])
-        self.assert_iface_up('br0',
-                             ['inet 192.168.5.[0-9]+/24', '00:01:02:03:04:05'])
+        self.generate_and_settle([self.dev_e_client, 'br0'])
+        self.assert_iface_up(self.dev_e_client, ['master br0'], ['inet '])
+        self.assert_iface_up('br0', ['inet 192.168.5.[0-9]+/24', 'ether 00:01:02:03:04:05'])
 
     def test_bridge_anonymous(self):
         self.setup_eth(None)
@@ -302,17 +284,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       match: {name: %(e2c)s}
   bridges:
     mybr:
-      interfaces: [ethbr]''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             [],
-                             ['inet 192.168.6.[0-9]+/24'])
+      interfaces: [ethbr]''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', [], ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
@@ -324,51 +299,12 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         with open(self.config, 'w') as f:
             f.write('''network:
   renderer: %(r)s
-  ethernets:
-    ethbr:
-      match: {name: %(e2c)s}
   bridges:
     mybr:
       interfaces: []
-      addresses: [10.10.10.10/24]''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        subprocess.check_call(['netplan', 'apply'])
-        time.sleep(1)
-        out = subprocess.check_output(['ip', 'a', 'show', 'dev', 'mybr'],
-                                      universal_newlines=True)
-        self.assertIn('inet 10.10.10.10/24', out)
-
-    def test_bridge_port_priority(self):
-        self.setup_eth(None)
-        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'mybr'], stderr=subprocess.DEVNULL)
-        with open(self.config, 'w') as f:
-            f.write('''network:
-  renderer: %(r)s
-  ethernets:
-    ethbr:
-      match: {name: %(e2c)s}
-  bridges:
-    mybr:
-      interfaces: [ethbr]
-      parameters:
-        port-priority:
-          ethbr: 42
-        stp: false
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
-        lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
-        self.assertEqual(len(lines), 1, lines)
-        self.assertIn(self.dev_e2_client, lines[0])
-        with open('/sys/class/net/mybr/brif/%s/priority' % self.dev_e2_client) as f:
-            self.assertEqual(f.read().strip(), '42')
+      addresses: [10.10.10.10/24]''' % {'r': self.backend})
+        self.generate_and_settle(['mybr'])
+        self.assert_iface('mybr', ['inet 10.10.10.10/24'])
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
@@ -395,55 +331,16 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
       parameters:
         priority: 16384
         stp: false
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
+      dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'mybr'])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/bridge/priority') as f:
             self.assertEqual(f.read().strip(), '16384')
-
-    def test_bridge_port_priority(self):
-        self.setup_eth(None)
-        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'mybr'], stderr=subprocess.DEVNULL)
-        with open(self.config, 'w') as f:
-            f.write('''network:
-  renderer: %(r)s
-  ethernets:
-    ethbr:
-      match: {name: %(e2c)s}
-  bridges:
-    mybr:
-      interfaces: [ethbr]
-      parameters:
-        port-priority:
-          ethbr: 42
-        stp: false
-      dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'],
-                             ['master'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master mybr'],
-                             ['inet '])
-        self.assert_iface_up('mybr',
-                             ['inet 192.168.6.[0-9]+/24'])
-        lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
-        self.assertEqual(len(lines), 1, lines)
-        self.assertIn(self.dev_e2_client, lines[0])
-        with open('/sys/class/net/mybr/brif/%s/priority' % self.dev_e2_client) as f:
-            self.assertEqual(f.read().strip(), '42')
 
 
 unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -41,7 +41,7 @@ class _CommonTests():
       match: {name: %(e2c)s}
       mtu: 1492
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client])
+        self.generate_and_settle([self.state_dhcp4(self.dev_e2_client)])
         self.assert_iface_up(self.dev_e2_client,
                              ['inet 192.168.6.[0-9]+/24', 'mtu 1492'])
 
@@ -56,7 +56,7 @@ class _CommonTests():
       match: {name: %(e2c)s}
       macaddress: 00:01:02:03:04:05
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client])
+        self.generate_and_settle([self.state_dhcp4(self.dev_e2_client)])
         self.assert_iface_up(self.dev_e2_client,
                              ['inet 192.168.6.[0-9]+/24', 'ether 00:01:02:03:04:05'])
 
@@ -91,7 +91,7 @@ class _CommonTests():
         addresses: [172.1.2.3]
         search: ["fakesuffix"]
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.state_dhcp4(self.dev_e_client), self.dev_e2_client])
         if self.backend == 'NetworkManager':
             self.nm_online_full(self.dev_e_client)
         self.assert_iface_up(self.dev_e_client,
@@ -153,7 +153,7 @@ class _CommonTests():
       addresses: ["172.16.7.2/30", "4321:AAAA::99/80"]
       dhcp4: yes
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client, self.state_dhcp4(self.dev_e2_client)])
         if self.backend == 'NetworkManager':
             self.nm_online_full(self.dev_e2_client)
         self.assert_iface_up(self.dev_e_client,
@@ -186,7 +186,7 @@ class _CommonTests():
     %(ec)s:
       dhcp6: yes
       accept-ra: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client])
+        self.generate_and_settle([self.state_dhcp6(self.dev_e_client)])
         self.assert_iface_up(self.dev_e_client, ['inet6 2600:'], ['inet 192.168'])
 
     def test_ip6_token(self):
@@ -200,7 +200,7 @@ class _CommonTests():
       dhcp6: yes
       accept-ra: yes
       ipv6-address-token: ::42''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client])
+        self.generate_and_settle([self.state_dhcp6(self.dev_e_client)])
         self.assert_iface_up(self.dev_e_client, ['inet6 2600::42/64'])
 
     def test_link_local_all(self):

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -178,7 +178,10 @@ class _CommonTests():
         br-%(ec)s.100:
             id: 100
             link: br-%(ec)s''' % {'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client, 'br-eth42', 'br-data', 'br-eth42.100'])
+        self.generate_and_settle([self.dev_e_client,
+                                  self.state_dhcp4('br-eth42'),
+                                  'br-data',
+                                  'br-eth42.100'])
         # Basic verification that the interfaces/ports are set up in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])
         self.assertIn(b'    Bridge br-%b' % self.dev_e_client.encode(), out)

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -5,8 +5,8 @@
 # These need to be run in a VM and do change the system
 # configuration.
 #
-# Copyright (C) 2020 Canonical, Ltd.
-# Author: Lukas Märdian <lukas.maerdian@canonical.com>
+# Copyright (C) 2020-2021 Canonical, Ltd.
+# Author: Lukas Märdian <slyon@ubuntu.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -73,19 +73,13 @@ class _CommonTests():
         self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch1-0'])
         with open(self.config, 'w') as f:
             f.write('''network:
-  ethernets:
-    # Add a normal interface, to avoid networkd-wait-online.service timeout.
-    # If we have just OVS interfaces/ports networkd/networkctl will not be
-    # aware that our network is ready.
-    %(ec)s: {addresses: [10.10.10.20/24]}
-    %(e2c)s: {addresses: [10.10.10.30/24]}
   openvswitch:
     ports:
       - [patch0-1, patch1-0]
   bridges:
     ovs0: {interfaces: [patch0-1]}
-    ovs1: {interfaces: [patch1-0]}''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+    ovs1: {interfaces: [patch1-0]}''')
+        self.generate_and_settle(['ovs0', 'ovs1'])
         # Basic verification that the bridges/ports/interfaces are there in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])
         self.assertIn(b'    Bridge ovs0', out)
@@ -98,7 +92,7 @@ class _CommonTests():
             f.write('''network:
   ethernets:
     %(ec)s: {addresses: ['1.2.3.4/24']}''' % {'ec': self.dev_e_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client])
         # Verify that the netplan=true tagged bridges/ports have been cleaned up
         out = subprocess.check_output(['ovs-vsctl', 'show'])
         self.assertNotIn(b'Bridge ovs0', out)
@@ -120,14 +114,13 @@ class _CommonTests():
             f.write('''network:
   ethernets:
     %(ec)s: {addresses: [10.10.10.20/24]}
-    %(e2c)s: {addresses: [10.10.10.30/24]}
   openvswitch:
     ports: [[patch0-1, patch1-0]]
   bonds:
     bond0: {interfaces: [patch1-0, %(ec)s]}
   bridges:
-    ovs0: {interfaces: [patch0-1, bond0]}''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+    ovs0: {interfaces: [patch0-1, bond0]}''' % {'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'ovs0'])
         # Basic verification that the bridges/ports/interfaces are there in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])
         self.assertIn(b'    Bridge ovs0', out)
@@ -139,14 +132,13 @@ class _CommonTests():
             f.write('''network:
   ethernets:
     %(ec)s: {addresses: [10.10.10.20/24]}
-    %(ec)s: {addresses: [10.10.10.30/24]}
   openvswitch:
     ports: [[patchx, patchy]]
   bonds:
     bond0: {interfaces: [patchx, %(ec)s]}
   bridges:
     ovs1: {interfaces: [patchy, bond0]}''' % {'ec': self.dev_e_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client, 'ovs1'])
         # Verify that the netplan=true tagged patch ports have been cleaned up
         # even though the containing bond0 port still exists (with new patch ports)
         out = subprocess.check_output(['ovs-vsctl', 'show'])
@@ -186,7 +178,7 @@ class _CommonTests():
         br-%(ec)s.100:
             id: 100
             link: br-%(ec)s''' % {'ec': self.dev_e_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client, 'br-eth42', 'br-data', 'br-eth42.100'])
         # Basic verification that the interfaces/ports are set up in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])
         self.assertIn(b'    Bridge br-%b' % self.dev_e_client.encode(), out)
@@ -230,7 +222,7 @@ class _CommonTests():
         controller:
           addresses: [tcp:127.0.0.1, "pssl:1337:[::1]", unix:/some/socket]
 ''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'ovsbr'])
         # Basic verification that the interfaces/ports are in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])
         self.assertIn(b'    Bridge ovsbr', out)
@@ -266,7 +258,7 @@ class _CommonTests():
     ovsbr:
       addresses: [192.170.1.1/24]
       interfaces: [mybond]''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'ovsbr'])
         # Basic verification that the interfaces/ports are in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])
         self.assertIn(b'    Bridge ovsbr', out)
@@ -303,7 +295,7 @@ class _CommonTests():
     br1:
       addresses: [192.168.2.1/24]
       interfaces: [patch1-0]''')
-        self.generate_and_settle()
+        self.generate_and_settle(['br0', 'br1'])
         # Basic verification that the interfaces/ports are set up in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'])
         self.assertIn(b'    Bridge br0', out)
@@ -336,7 +328,7 @@ class _CommonTests():
         ovs-br:
             interfaces: [non-ovs-bond]
             openvswitch: {}''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'ovs-br', 'non-ovs-bond'])
         # Basic verification that the interfaces/ports are set up in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'], universal_newlines=True)
         self.assertIn('    Bridge ovs-br', out)
@@ -377,13 +369,12 @@ class _CommonTests():
             nameservers:
                 addresses: [10.5.32.99]
                 search: [maas]
-        %(e2c)s: {}
     vlans:
         %(ec)s.21:
             id: 21
             link: %(ec)s
-            mtu: 1500''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+            mtu: 1500''' % {'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'ovs0', 'eth42.21'])
         # Basic verification that the interfaces/ports are set up in OVS
         out = subprocess.check_output(['ovs-vsctl', 'show'], universal_newlines=True)
         self.assertIn('    Bridge ovs0', out)
@@ -473,7 +464,7 @@ class _CommonTests():
         rstp: true
 
 ''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'ovs0', 'ovs1'])
         before = self._collect_ovs_settings('ovs0')
         subprocess.check_call(['netplan', 'apply', '--only-ovs-cleanup'])
         after = self._collect_ovs_settings('ovs0')

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -5,8 +5,9 @@
 # These need to be run in a VM and do change the system
 # configuration.
 #
-# Copyright (C) 2018 Canonical, Ltd.
+# Copyright (C) 2018-2021 Canonical, Ltd.
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+# Author: Lukas Märdian <slyon@ubuntu.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,7 +33,7 @@ class _CommonTests():
     def test_empty_yaml_lp1795343(self):
         with open(self.config, 'w') as f:
             f.write('''''')
-        self.generate_and_settle()
+        self.generate_and_settle([])
 
 
 @unittest.skipIf("networkd" not in test_backends,
@@ -68,15 +69,14 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         transmit-hash-policy: layer3+4
         up-delay: 0
       ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'mybond'])
         self.assert_iface_up(self.dev_e_client,
                              ['master mybond', '00:0a:f7:72:a7:28'],
                              ['inet '])
         self.assert_iface_up(self.dev_e2_client,
                              ['master mybond', '00:0a:f7:72:a7:28'],
                              ['inet '])
-        self.assert_iface_up('mybond',
-                             ['inet 192.168.5.[0-9]+/24'])
+        self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertIn(self.dev_e_client, f.read().strip())
 

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -113,7 +113,7 @@ class _CommonTests():
           - to: 10.10.10.0/24
             via: 192.168.5.254
             metric: 99''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.dev_e_client])
+        self.generate_and_settle([self.state_dhcp4(self.dev_e_client)])
         self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.[0-9]+/24'])  # from DHCP
         self.assertIn(b'default via 192.168.5.1',  # from DHCP
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -47,7 +47,7 @@ class _CommonTests():
           via: 9876:BBBB::5
           on-link: true''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client])
-        self.assert_iface_up(self.dev_e_client, ['inet 10.20.10.1'])
+        self.assert_iface_up(self.dev_e_client, ['inet6 9876:bbbb::11/70'])
         out = subprocess.check_output(['ip', '-6', 'route', 'show', 'dev', self.dev_e_client],
                                       universal_newlines=True)
         # NM routes have a (default) 'metric' in between 'proto static' and 'onlink'

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -5,8 +5,9 @@
 # These need to be run in a VM and do change the system
 # configuration.
 #
-# Copyright (C) 2018 Canonical, Ltd.
+# Copyright (C) 2018-2021 Canonical, Ltd.
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+# Author: Lukas Märdian <slyon@ubuntu.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -29,11 +30,10 @@ from base import IntegrationTestsBase, test_backends
 
 class _CommonTests():
 
+    # Supposed to fail if tested against NetworkManager < 1.12/1.18
+    # The on-link option was introduced as of NM 1.12+ (for IPv4)
+    # The on-link option was introduced as of NM 1.18+ (for IPv6)
     def test_route_on_link(self):
-        '''Supposed to fail if tested against NetworkManager < 1.12/1.18
-
-        The on-link option was introduced as of NM 1.12+ (for IPv4)
-        The on-link option was introduced as of NM 1.18+ (for IPv6)'''
         self.setup_eth(None)
         with open(self.config, 'w') as f:
             f.write('''network:
@@ -46,17 +46,16 @@ class _CommonTests():
         - to: 2001:f00f:f00f::1/64
           via: 9876:BBBB::5
           on-link: true''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client])
         self.assert_iface_up(self.dev_e_client, ['inet 10.20.10.1'])
         out = subprocess.check_output(['ip', '-6', 'route', 'show', 'dev', self.dev_e_client],
                                       universal_newlines=True)
         # NM routes have a (default) 'metric' in between 'proto static' and 'onlink'
         self.assertRegex(out, r'2001:f00f:f00f::/64 via 9876:bbbb::5 proto static[^\n]* onlink')
 
+    # Supposed to fail if tested against NetworkManager < 1.8
+    # The from option was introduced as of NM 1.8+
     def test_route_from(self):
-        '''Supposed to fail if tested against NetworkManager < 1.8
-
-        The from option was introduced as of NM 1.8+'''
         self.setup_eth(None)
         with open(self.config, 'w') as f:
             f.write('''network:
@@ -69,16 +68,15 @@ class _CommonTests():
         - to: 10.10.10.0/24
           via: 192.168.14.20
           from: 192.168.14.2''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client])
         self.assert_iface_up(self.dev_e_client, ['inet 192.168.14.2'])
         out = subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client],
                                       universal_newlines=True)
         self.assertIn('10.10.10.0/24 via 192.168.14.20 proto static src 192.168.14.2', out)
 
+    # Supposed to fail if tested against NetworkManager < 1.10
+    # The table option was introduced as of NM 1.10+
     def test_route_table(self):
-        '''Supposed to fail if tested against NetworkManager < 1.10
-
-        The table option was introduced as of NM 1.10+'''
         self.setup_eth(None)
         table_id = '255' # This is the 'local' FIB of /etc/iproute2/rt_tables
         with open(self.config, 'w') as f:
@@ -95,7 +93,7 @@ class _CommonTests():
           via: 11.0.0.1
           table: %(tid)s
           on-link: true''' % {'r': self.backend, 'ec': self.dev_e_client, 'tid': table_id})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client])
         self.assert_iface_up(self.dev_e_client, ['inet '])
         out = subprocess.check_output(['ip', 'route', 'show', 'table', table_id, 'dev',
                                       self.dev_e_client], universal_newlines=True)
@@ -115,9 +113,8 @@ class _CommonTests():
           - to: 10.10.10.0/24
             via: 192.168.5.254
             metric: 99''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'])  # from DHCP
+        self.generate_and_settle([self.dev_e_client])
+        self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.[0-9]+/24'])  # from DHCP
         self.assertIn(b'default via 192.168.5.1',  # from DHCP
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
         self.assertIn(b'10.10.10.0/24 via 192.168.5.254',  # from static route
@@ -139,9 +136,8 @@ class _CommonTests():
           - to: 10.10.10.0/24
             via: 192.168.5.254
             metric: 99''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'])  # from DHCP
+        self.generate_and_settle([self.dev_e_client])
+        self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.[0-9]+/24'])  # from DHCP
         self.assertIn(b'default via 192.168.5.1',  # from DHCP
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
         self.assertIn(b'10.10.10.0/24 via 192.168.5.254',  # from DHCP
@@ -162,9 +158,8 @@ class _CommonTests():
           - to: 2001:f00f:f00f::1/64
             via: 9876:BBBB::5
             metric: 799''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet6 9876:bbbb::11/70'])
+        self.generate_and_settle([self.dev_e_client])
+        self.assert_iface_up(self.dev_e_client, ['inet6 9876:bbbb::11/70'])
         self.assertNotIn(b'default',
                          subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
         self.assertIn(b'via 9876:bbbb::1',
@@ -188,7 +183,7 @@ class _CommonTests():
           - to: 10.10.10.0/24
             via: 192.168.5.254
             mtu: 777''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client])
         self.assertIn(b'mtu 777',  # check mtu from static route
                       subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
 
@@ -206,9 +201,9 @@ class _CommonTests():
         - to: 10.10.10.0/24
           via: 192.168.5.254
           congestion-window: 16''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client])
         self.assertIn(b'initcwnd 16',  # check initcwnd from static route
-                    subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
+                      subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
 
     def test_per_route_advertised_receive_window(self):
         self.setup_eth(None)
@@ -224,9 +219,9 @@ class _CommonTests():
         - to: 10.10.10.0/24
           via: 192.168.5.254
           advertised-receive-window: 16''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client])
         self.assertIn(b'initrwnd 16',  # check initrwnd from static route
-                    subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
+                      subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
 
 @unittest.skipIf("networkd" not in test_backends,
                      "skipping as networkd backend tests are disabled")
@@ -247,9 +242,8 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
           - to: 10.10.10.0/24
             scope: link
             metric: 99''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet 192.168.5.[0-9]+/24'])  # from DHCP
+        self.generate_and_settle([self.dev_e_client])
+        self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.[0-9]+/24'])  # from DHCP
         self.assertIn(b'default via 192.168.5.1',  # from DHCP
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
         self.assertIn(b'10.10.10.0/24 proto static scope link',
@@ -271,9 +265,8 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         - to: 10.10.10.0/24
           via: 10.20.10.100
           type: blackhole''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet '])
+        self.generate_and_settle([self.dev_e_client])
+        self.assert_iface_up(self.dev_e_client, ['inet '])
         self.assertIn(b'blackhole 10.10.10.0/24',
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
 
@@ -298,9 +291,8 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         - from: 10.20.10.0/24
           to: 40.0.0.0/24
           table: 99''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e_client,
-                             ['inet '])
+        self.generate_and_settle([self.dev_e_client])
+        self.assert_iface_up(self.dev_e_client, ['inet '])
         self.assertIn(b'to 40.0.0.0/24 lookup 99',
                       subprocess.check_output(['ip', 'rule', 'show']))
         self.assertIn(b'40.0.0.0/24 via 10.20.10.88',

--- a/tests/integration/scenarios.py
+++ b/tests/integration/scenarios.py
@@ -62,7 +62,7 @@ class _CommonTests():
             self.assertIn(self.dev_e2_client, result)
 
     def test_mix_vlan_on_bridge_on_bond(self):
-        self.setup_eth(None)
+        self.setup_eth(None, False)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'bond0'], stderr=subprocess.DEVNULL)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'br0'], stderr=subprocess.DEVNULL)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'br1'], stderr=subprocess.DEVNULL)

--- a/tests/integration/scenarios.py
+++ b/tests/integration/scenarios.py
@@ -56,7 +56,7 @@ class _CommonTests():
         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'br0', 'bond0'])
         self.assert_iface_up(self.dev_e2_client, ['master bond0'], ['inet '])
         self.assert_iface_up('bond0', ['master br0'])
-        self.assert_iface_up('br0', ['inet 192.168.0.2/24'])
+        self.assert_iface('br0', ['inet 192.168.0.2/24'])
         with open('/sys/class/net/bond0/bonding/slaves') as f:
             result = f.read().strip()
             self.assertIn(self.dev_e2_client, result)

--- a/tests/integration/scenarios.py
+++ b/tests/integration/scenarios.py
@@ -6,8 +6,9 @@
 # These need to be run in a VM and do change the system
 # configuration.
 #
-# Copyright (C) 2018 Canonical, Ltd.
+# Copyright (C) 2018-2021 Canonical, Ltd.
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+# Author: Lukas Märdian <slyon@ubuntu.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -34,7 +35,6 @@ class _CommonTests():
         self.setup_eth(None)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'bond0'], stderr=subprocess.DEVNULL)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'br0'], stderr=subprocess.DEVNULL)
-        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'br1'], stderr=subprocess.DEVNULL)
         with open(self.config, 'w') as f:
             f.write('''network:
   renderer: %(r)s
@@ -53,15 +53,10 @@ class _CommonTests():
     ethb2:
       match: {name: %(e2c)s}
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master bond0'],
-                             ['inet '])
-        self.assert_iface_up('bond0',
-                             ['master br0'])
-        ipaddr = subprocess.check_output(['ip', 'a', 'show', 'dev', 'br0'],
-                                         universal_newlines=True)
-        self.assertIn('inet 192.168', ipaddr)
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'br0', 'bond0'])
+        self.assert_iface_up(self.dev_e2_client, ['master bond0'], ['inet '])
+        self.assert_iface_up('bond0', ['master br0'])
+        self.assert_iface_up('br0', ['inet 192.168.0.2/24'])
         with open('/sys/class/net/bond0/bonding/slaves') as f:
             result = f.read().strip()
             self.assertIn(self.dev_e2_client, result)
@@ -106,15 +101,11 @@ class _CommonTests():
     ethb2:
       match: {name: %(e2c)s}
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'br0', 'br1', 'bond0', 'vlan1', 'vlan2'])
         self.assert_iface_up('vlan1', ['vlan1@br0'])
-        self.assert_iface_up('vlan2',
-                             ['vlan2@' + self.dev_e_client, 'master br0'])
-        self.assert_iface_up(self.dev_e2_client,
-                             ['master br1'],
-                             ['inet '])
-        self.assert_iface_up('bond0',
-                             ['master br0'])
+        self.assert_iface_up('vlan2', ['vlan2@' + self.dev_e_client, 'master br0'])
+        self.assert_iface_up(self.dev_e2_client, ['master br1'], ['inet '])
+        self.assert_iface_up('bond0', ['master br0'])
 
 
 @unittest.skipIf("networkd" not in test_backends,

--- a/tests/integration/vlans.py
+++ b/tests/integration/vlans.py
@@ -5,8 +5,9 @@
 # These need to be run in a VM and do change the system
 # configuration.
 #
-# Copyright (C) 2018 Canonical, Ltd.
+# Copyright (C) 2018-2021 Canonical, Ltd.
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+# Author: Lukas Märdian <slyon@ubuntu.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -43,7 +44,6 @@ class _CommonTests():
   version: 2
   renderer: %(r)s
   ethernets:
-    %(ec)s: {}
     myether:
       match: {name: %(e2c)s}
       dhcp4: yes
@@ -56,9 +56,8 @@ class _CommonTests():
       id: 2002
       link: myether
       dhcp4: true
-      ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
-
+      ''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client, 'nptestone', 'nptesttwo'])
         self.assert_iface_up('nptestone', ['nptestone@' + self.dev_e2_client, 'inet 10.9.8.7/24'])
         self.assert_iface_up('nptesttwo', ['nptesttwo@' + self.dev_e2_client, 'inet 192.168.5'])
         self.assertNotIn(b'default',
@@ -75,14 +74,13 @@ class _CommonTests():
   ethernets:
     ethbn:
       match: {name: %(ec)s}
-    %(e2c)s: {}
   vlans:
     myvlan:
       id: 101
       link: ethbn
       macaddress: aa:bb:cc:dd:ee:22
-        ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
-        self.generate_and_settle()
+        ''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client, 'myvlan'])
         self.assert_iface_up('myvlan', ['myvlan@' + self.dev_e_client])
         with open('/sys/class/net/myvlan/address') as f:
             self.assertEqual(f.read().strip(), 'aa:bb:cc:dd:ee:22')

--- a/tests/integration/vlans.py
+++ b/tests/integration/vlans.py
@@ -57,7 +57,9 @@ class _CommonTests():
       link: myether
       dhcp4: true
       ''' % {'r': self.backend, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client, 'nptestone', 'nptesttwo'])
+        self.generate_and_settle([self.state_dhcp4(self.dev_e2_client),
+                                  'nptestone',
+                                  self.state_dhcp4('nptesttwo')])
         self.assert_iface_up('nptestone', ['nptestone@' + self.dev_e2_client, 'inet 10.9.8.7/24'])
         self.assert_iface_up('nptesttwo', ['nptesttwo@' + self.dev_e2_client, 'inet 192.168.5'])
         self.assertNotIn(b'default',

--- a/tests/integration/wifi.py
+++ b/tests/integration/wifi.py
@@ -44,7 +44,7 @@ class _CommonTests():
       access-points:
         "fake net": {}
         decoy: {}''' % {'r': self.backend})
-        self.generate_and_settle([self.dev_w_client])
+        self.generate_and_settle([self.state_dhcp4(self.dev_w_client)])
         p = subprocess.Popen(['netplan', 'generate', '--mapping', 'mac80211_hwsim'],
                              stdout=subprocess.PIPE)
         out = p.communicate()[0]
@@ -63,7 +63,7 @@ class _CommonTests():
       access-points:
         "fake net": {}
         decoy: {}''' % {'r': self.backend, 'wc': self.dev_w_client})
-        self.generate_and_settle([self.dev_w_client])
+        self.generate_and_settle([self.state_dhcp4(self.dev_w_client)])
         self.assert_iface_up(self.dev_w_client, ['inet 192.168.5.[0-9]+/24'])
         self.assertIn(b'default via 192.168.5.1',  # from DHCP
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_w_client]))
@@ -97,7 +97,7 @@ wpa_passphrase=12345678
         "fake net":
           password: 12345678
         decoy: {}''' % {'r': self.backend, 'wc': self.dev_w_client})
-        self.generate_and_settle([self.dev_w_client])
+        self.generate_and_settle([self.state_dhcp4(self.dev_w_client)])
         self.assert_iface_up(self.dev_w_client, ['inet 192.168.5.[0-9]+/24'])
         self.assertIn(b'default via 192.168.5.1',  # from DHCP
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_w_client]))
@@ -136,7 +136,7 @@ class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
       access-points:
         "fake net":
           mode: ap''' % {'wc': self.dev_w_client})
-        self.generate_and_settle([self.dev_w_client])
+        self.generate_and_settle([self.state_dhcp4(self.dev_w_client)])
         out = subprocess.check_output(['iw', 'dev', self.dev_w_client, 'info'],
                                       universal_newlines=True)
         self.assertIn('type AP', out)

--- a/tests/integration/wifi.py
+++ b/tests/integration/wifi.py
@@ -136,7 +136,7 @@ class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
       access-points:
         "fake net":
           mode: ap''' % {'wc': self.dev_w_client})
-        self.generate_and_settle([self.state_dhcp4(self.dev_w_client)])
+        self.generate_and_settle([self.state(self.dev_w_client, 'inet 10.')])
         out = subprocess.check_output(['iw', 'dev', self.dev_w_client, 'info'],
                                       universal_newlines=True)
         self.assertIn('type AP', out)
@@ -152,10 +152,7 @@ class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
                                       universal_newlines=True)
         self.assertIn('type managed', out)
         self.assertIn('ssid fake net', out)
-        out = subprocess.check_output(['ip', 'a', 'show', self.dev_w_ap],
-                                      universal_newlines=True)
-        self.assertIn('state UP', out)
-        self.assertIn('inet 10.', out)
+        self.assert_iface_up(self.dev_w_ap, ['inet 10.'])
 
 
 unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
## Description
This is a big refactoring of the integration test suite, which should make it much faster and more stable in different testing environments (e.g. armhf LXD containers).

The main change is in `tests/integration/base.py` and changes the waiting logic to decide when an given interface is readily configured. Previously, we were relying on `/lib/systemd/systemd-networkd-wait-online` to tell us magically when the networking is fully configured. This does not properly work for interfaces controlled by NetworkManager and is only watching the "general" networking state (i.e. whenever the first interface is up and running).

Waiting only on an arbitrary "first" network interface to be ready leads to races as we use asserts on many individual interfaces, which might not be ready at that time. So with this change the `generate_and_settle(self, wait_interfaces=None):` method got a new `wait_interfaces` argument, where the developer needs to specify each interface to be tested in a given test case. Furthermore, the developer can wait for a specified state (i.e. DHCP4/6 address assigned), to account for waiting on asynchronous background tasks, e.g.:

```
self.generate_and_settle([self.dev_e_client, 'eth43', self.state_dhcp4('mybond')])
```

All existing integration tests have been adopted to specify their interfaces-under-test in `generate_and_settle()`. Additionally, some logging was added to always print the name of the currently waited on interface and one dot per second (up to 60s), to see how long it takes to become ready (or times out), especially on slower architectures.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1922126

