### PR TITLE
Improve subprocess calls to binaries in /sbin + udevadm

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -49,7 +49,7 @@ static GOptionEntry options[] = {
 static void
 reload_udevd(void)
 {
-    const gchar *argv[] = { "/sbin/udevadm", "control", "--reload", NULL };
+    const gchar *argv[] = { "/bin/udevadm", "control", "--reload", NULL };
     g_spawn_sync(NULL, (gchar**)argv, NULL, G_SPAWN_STDERR_TO_DEV_NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 };
 

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -468,7 +468,7 @@ write_ovs_conf_finish(const char* rootdir)
 
     /* Clear all netplan=true tagged ports/bonds and bridges, via 'netplan apply --only-ovs-cleanup' */
     cmds = g_string_new(NULL);
-    append_systemd_cmd(cmds, "/usr/sbin/netplan apply %s", "--only-ovs-cleanup");
+    append_systemd_cmd(cmds, SBINDIR "/netplan apply %s", "--only-ovs-cleanup");
     write_ovs_systemd_unit("cleanup", cmds, rootdir, FALSE, TRUE, NULL);
     g_string_free(cmds, TRUE);
 }

--- a/src/util.c
+++ b/src/util.c
@@ -232,7 +232,7 @@ netplan_delete_connection(const char* id, const char* rootdir)
     netplan_clear_netdefs();
 
     /* TODO: refactor logic to actually be inside the library instead of spawning another process */
-    const gchar *argv[] = { "/sbin/netplan", "set", del, "--origin-hint" , filename, NULL, NULL, NULL };
+    const gchar *argv[] = { SBINDIR "/" "netplan", "set", del, "--origin-hint" , filename, NULL, NULL, NULL };
     if (rootdir) {
         argv[5] = "--root-dir";
         argv[6] = rootdir;
@@ -246,7 +246,7 @@ gboolean
 netplan_generate(const char* rootdir)
 {
     /* TODO: refactor logic to actually be inside the library instead of spawning another process */
-    const gchar *argv[] = { "/sbin/netplan", "generate", NULL , NULL, NULL };
+    const gchar *argv[] = { SBINDIR "/" "netplan", "generate", NULL , NULL, NULL };
     if (rootdir) {
         argv[2] = "--root-dir";
         argv[3] = rootdir;


### PR DESCRIPTION
## Description
In modern systems `/sbin` is a symlink to `/usr/sbin`, we should not be calling `/sbin/netplan` directly (neither `/usr/sbin/netplan`), but make use of the `SBINDIR` build time variable.

Furthermore, the `/sbin/udevadm -> /bin/udevadm` is not shipped by systemd-udev anymore since Focal, so we should be calling the real binary at `/bin/udevadm` instead.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

