### PR TITLE
cli:set: Fix netplan-set on Core20

### DIFF
--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -160,7 +160,7 @@ class NetplanSet(utils.NetplanCommand):
             # Validate the newly created file, by parsing it via libnetplan
             utils.netplan_parse(tmpp)
             # Valid, move it to final destination
-            shutil.copy(tmpp, absp)
+            shutil.copy2(tmpp, absp)
             os.remove(tmpp)
         elif os.path.isfile(absp):
             # Clear file if the last/only key got removed

--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -22,6 +22,7 @@ import yaml
 import tempfile
 import re
 import logging
+import shutil
 
 import netplan.cli.utils as utils
 from netplan.configmanager import ConfigManager
@@ -159,7 +160,8 @@ class NetplanSet(utils.NetplanCommand):
             # Validate the newly created file, by parsing it via libnetplan
             utils.netplan_parse(tmpp)
             # Valid, move it to final destination
-            os.replace(tmpp, absp)
+            shutil.copy(tmpp, absp)
+            os.remove(tmpp)
         elif os.path.isfile(absp):
             # Clear file if the last/only key got removed
             os.remove(absp)


### PR DESCRIPTION
## Description
Using os.replace() leads to "Invalid cross-device link" errors on Core20 setups, due to having different mounts.
Use shutil.copy() & os.remove() instead.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

