### PR TITLE
dbus:cli: implement io.netplan.Netplan.Generate()

### DIFF
--- a/doc/netplan-dbus.md
+++ b/doc/netplan-dbus.md
@@ -18,6 +18,7 @@ netplan-dbus - daemon to access netplan's functionality via a DBus API
 **netplan-dbus** is a DBus daemon, providing ``io.netplan.Netplan`` on the system bus. The ``/io/netplan/Netplan`` object provides an ``io.netplan.Netplan`` interface, offering the following methods:
 
  * ``Apply() -> b``: calls **netplan apply** and returns a success or failure status.
+ * ``Generate() -> b``: calls **netplan generate** and returns a success or failure status.
  * ``Info() -> a(sv)``: returns a dict "Features -> as", containing an array of all available feature flags.
  * ``Config() -> o``: prepares a new config object as ``/io/netplan/Netplan/config/<ID>``, by copying the current state from ``/{etc,run,lib}/netplan/*.yaml``
 

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -80,6 +80,7 @@ class NetplanApply(utils.NetplanCommand):
             #      using core20 netplan binary/client/CLI on core18 base systems. Any change
             #      must be agreed upon with the snapd team, so we don't break support for
             #      base systems running older netplan versions.
+            #      https://github.com/snapcore/snapd/pull/5915
             res = subprocess.call([busctl, "call", "--quiet", "--system",
                                    "io.netplan.Netplan",  # the service
                                    "/io/netplan/Netplan",  # the object

--- a/netplan/cli/commands/generate.py
+++ b/netplan/cli/commands/generate.py
@@ -18,8 +18,10 @@
 '''netplan generate command line'''
 
 import logging
+import os
 import sys
 import subprocess
+import shutil
 
 import netplan.cli.utils as utils
 
@@ -44,6 +46,35 @@ class NetplanGenerate(utils.NetplanCommand):
         self.run_command()
 
     def command_generate(self):
+        # if we are inside a snap, then call dbus to run netplan apply instead
+        if "SNAP" in os.environ:
+            # TODO: maybe check if we are inside a classic snap and don't do
+            # this if we are in a classic snap?
+            busctl = shutil.which("busctl")
+            if busctl is None:
+                raise RuntimeError("missing busctl utility")  # pragma: nocover
+            # XXX: DO NOT TOUCH or change this API call, it is used by snapd to communicate
+            #      using core20 netplan binary/client/CLI on core18 base systems. Any change
+            #      must be agreed upon with the snapd team, so we don't break support for
+            #      base systems running older netplan versions.
+            #      https://github.com/snapcore/snapd/pull/10212
+            res = subprocess.call([busctl, "call", "--quiet", "--system",
+                                   "io.netplan.Netplan",  # the service
+                                   "/io/netplan/Netplan",  # the object
+                                   "io.netplan.Netplan",  # the interface
+                                   "Generate",  # the method
+                                   ])
+
+            if res != 0:
+                if res == 130:
+                    raise PermissionError(
+                        "failed to communicate with dbus service")
+                elif res == 1:
+                    raise RuntimeError(
+                        "failed to communicate with dbus service")
+            else:
+                return
+
         argv = [utils.get_generator_path()]
         if self.root_dir:
             argv += ['--root-dir', self.root_dir]

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -143,6 +143,47 @@ class TestNetplanDBus(unittest.TestCase):
              ],
         ])
 
+    def test_netplan_generate_in_snap_calls_busctl(self):
+        newenv = os.environ.copy()
+        busctlDir = os.path.dirname(self.mock_busctl_cmd.path)
+        newenv["PATH"] = busctlDir+":"+os.environ["PATH"]
+        p = subprocess.Popen(
+            exe_cli + ["generate"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            env=newenv)
+        self.assertEqual(p.stdout.read(), b"")
+        self.assertEqual(p.stderr.read(), b"")
+        self.assertEquals(self.mock_busctl_cmd.calls(), [
+            ["busctl", "call", "--quiet", "--system",
+             "io.netplan.Netplan",  # the service
+             "/io/netplan/Netplan",  # the object
+             "io.netplan.Netplan",  # the interface
+             "Generate",  # the method
+             ],
+        ])
+
+    def test_netplan_generate_in_snap_calls_busctl_ret130(self):
+        newenv = os.environ.copy()
+        busctlDir = os.path.dirname(self.mock_busctl_cmd.path)
+        newenv["PATH"] = busctlDir+":"+os.environ["PATH"]
+        self.mock_busctl_cmd.set_returncode(130)
+        p = subprocess.Popen(
+            exe_cli + ["generate"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            env=newenv)
+        self.assertIn(b"PermissionError: failed to communicate with dbus service", p.stderr.read())
+
+    def test_netplan_generate_in_snap_calls_busctl_ret1(self):
+        newenv = os.environ.copy()
+        busctlDir = os.path.dirname(self.mock_busctl_cmd.path)
+        newenv["PATH"] = busctlDir+":"+os.environ["PATH"]
+        self.mock_busctl_cmd.set_returncode(1)
+        p = subprocess.Popen(
+            exe_cli + ["generate"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            env=newenv)
+        self.assertIn(b"RuntimeError: failed to communicate with dbus service", p.stderr.read())
+
     def test_netplan_dbus_noroot(self):
         # Process should fail instantly, if not: kill it after 5 sec
         r = subprocess.run(NETPLAN_DBUS_CMD, timeout=5, capture_output=True)
@@ -171,6 +212,21 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEquals(self.mock_netplan_cmd.calls(), [
                 ["netplan", "apply"],
                 ["netplan", "apply"],
+        ])
+
+    def test_netplan_dbus_generate(self):
+        BUSCTL_NETPLAN_CMD = [
+            "busctl", "call", "--system",
+            "io.netplan.Netplan",
+            "/io/netplan/Netplan",
+            "io.netplan.Netplan",
+            "Generate",
+        ]
+        output = subprocess.check_output(BUSCTL_NETPLAN_CMD)
+        self.assertEqual(output.decode("utf-8"), "b true\n")
+        # one call to netplan apply in total
+        self.assertEquals(self.mock_netplan_cmd.calls(), [
+                ["netplan", "generate"],
         ])
 
     def test_netplan_dbus_info(self):


### PR DESCRIPTION
## Description
Proxy the 'netplan generate' CLI via DBus, if called from within a snap,
to work around the strict AppArmor confinement.

see: https://github.com/snapcore/snapd/pull/10212

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

