### PR TITLE
Handle enum element override

### DIFF
--- a/src/netplan.h
+++ b/src/netplan.h
@@ -81,7 +81,6 @@ static const char* const netplan_def_type_to_str[NETPLAN_DEF_TYPE_MAX_] = {
     [NETPLAN_DEF_TYPE_ETHERNET] = "ethernets",
     [NETPLAN_DEF_TYPE_WIFI] = "wifis",
     [NETPLAN_DEF_TYPE_MODEM] = "modems",
-    [NETPLAN_DEF_TYPE_VIRTUAL] = NULL,
     [NETPLAN_DEF_TYPE_BRIDGE] = "bridges",
     [NETPLAN_DEF_TYPE_BOND] = "bonds",
     [NETPLAN_DEF_TYPE_VLAN] = "vlans",


### PR DESCRIPTION
NETPLAN_DEF_TYPE_VIRTUAL and NETPLAN_DEF_TYPE_BRIDGE point
to same value in enum, however here they are assigned individually
which results in overriding the initialization of the objects

Fixes
src/netplan.h:85:33: error: initializer overrides prior initialization of this subobject [-Werror,-Winitializer-overrides]
    [NETPLAN_DEF_TYPE_BRIDGE] = "bridges",
                                ^~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

