### PR TITLE
Implicitly consider devices with activation-mode set as optional

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -445,7 +445,8 @@ similar to ``gateway*``, and ``search:`` is a list of search domains.
      ``activation-mode`` setting users can override that behavior by either
      specifying ``manual``, to hand over control over the interface state to the
      administrator or (for networkd backend *only*) ``off`` to force the link
-     in a down state at all times.
+     in a down state at all times. Any interface with ``activation-mode``
+     defined is implicitly considered ``optional``.
      Supported officially as of ``networkd`` v248+.
 
     Example:

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -85,6 +85,7 @@ Name=eth0
 
 [Link]
 ActivationPolicy=always-down
+RequiredForOnline=no
 
 [Network]
 DHCP=ipv6
@@ -108,6 +109,7 @@ Name=eth0
 
 [Link]
 ActivationPolicy=manual
+RequiredForOnline=no
 
 [Network]
 DHCP=ipv6


### PR DESCRIPTION
## Description

When the networkd backend is used, whenever an interface defines `activation-mode` it also needs to be implicitly marked as `optional`. Both of the available `activation-mode` states end up with the interface not being brought up by networkd on boot, and this can cause systemd to wait indefinitely for the interface to go online during wait-online. Currently systemd doesn't make this `NeededForOnline=no` assumption for us, so we need to do it ourselves.

I tried re-using the existing code for marking as optional not to duplicate too much code, so it's basically just moving stuff around.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

