### PR TITLE
Gateway fields deprecation and default routing support (FR-728) (LP: #1756590)

### DIFF
--- a/doc/example-config
+++ b/doc/example-config
@@ -13,12 +13,14 @@ network:
       addresses:
         - 192.168.14.2/24
         - "2001:1::1/64"
-      gateway4: 192.168.14.1
-      gateway6: "2001:1::2"
       routes:
-       - to: 11.22.0.0/16
-         via: 192.168.14.3
-         metric: 100
+      - to: default
+        via: 192.168.14.1
+      - to: default
+        via: "2001:1::2"
+      - to: 11.22.0.0/16
+        via: 192.168.14.3
+        metric: 100
       nameservers:
         search: [foo.local, bar.local]
         addresses: [8.8.8.8]

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -355,11 +355,13 @@ Virtual devices
 
 ``gateway4``, ``gateway6`` (scalar)
 
-:   Set default gateway for IPv4/6, for manual address configuration. This
+:   Deprecated, see ``Default routes``.
+    Set default gateway for IPv4/6, for manual address configuration. This
     requires setting ``addresses`` too. Gateway IPs must be in a form
     recognized by **``inet_pton``**(3). There should only be a single gateway
-    set in your global config, to make it unambiguous. If you need multiple
-    default routes, please define them via ``routing-policy``.
+    per IP address family set in your global config, to make it unambiguous.
+    If you need multiple default routes, please define them via
+    ``routing-policy``.
 
     Example for IPv4: ``gateway4: 172.16.0.1``
     Example for IPv6: ``gateway6: "2001:4::1"``
@@ -1388,12 +1390,14 @@ This is a complex example which shows most available features:
             - 192.168.14.2/24
             - 192.168.14.3/24
             - "2001:1::1/64"
-          gateway4: 192.168.14.1
-          gateway6: "2001:1::2"
           nameservers:
             search: [foo.local, bar.local]
             addresses: [8.8.8.8]
           routes:
+            - to: default
+              via: 192.168.14.1
+            - to: default
+              via: "2001:1::2"
             - to: 0.0.0.0/0
               via: 11.0.0.1
               table: 70

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -554,6 +554,32 @@ backend.
 
 These options are available for all types of interfaces.
 
+### Default routes
+
+The most common need for routing concerns the definition of default routes to
+reach the wider Internet. Those default routes can only defined once per IP family
+and routing table. A typical example would look like the following:
+
+```yaml
+eth0:
+  [...]
+  routes:
+  - to: default # could be 0/0 or 0.0.0.0/0 optionally
+    via: 10.0.0.1
+    metric: 100
+    on-link: true
+  - to: default # could be ::/0 optionally
+    via: cf02:de:ad:be:ef::2
+eth1:
+  [...]
+  routes:
+  - to: default
+    via: 172.134.67.1
+    metric: 100
+    on-link: true
+    table: 76 # Not on the main routing table, does not conflict with the eth0 default route
+```
+
 ``routes`` (mapping)
 
 :    The ``routes`` block defines standard static routes for an interface.

--- a/examples/bonding_router.yaml
+++ b/examples/bonding_router.yaml
@@ -28,7 +28,6 @@ network:
     bond-wan:
       interfaces: [enp1s0, enp4s0]
       addresses: [192.168.1.252/24]
-      gateway4: 192.168.1.1
       nameservers:
         search: [local]
         addresses: [8.8.8.8, 8.8.4.4]
@@ -36,6 +35,9 @@ network:
         mode: active-backup
         mii-monitor-interval: 1
         gratuitious-arp: 5
+      routes:
+        - to: default
+          via: 192.168.1.1
     bond-conntrack:
       interfaces: [enp5s0, enp6s0]
       addresses: [192.168.254.2/24]

--- a/examples/ipv6_tunnel.yaml
+++ b/examples/ipv6_tunnel.yaml
@@ -5,7 +5,9 @@ network:
       addresses:
         - 1.1.1.1/24
         - "2001:cafe:face::1/64"
-      gateway4: 1.1.1.254
+      routes:
+        - to: default
+          via: 1.1.1.254
   tunnels:
     he-ipv6:
       mode: sit
@@ -13,4 +15,6 @@ network:
       local: 1.1.1.1
       addresses:
         - "2001:dead:beef::2/64"
-      gateway6: "2001:dead:beef::1"
+      routes:
+        - to: default
+          via: "2001:dead:beef::1"

--- a/examples/source_routing.yaml
+++ b/examples/source_routing.yaml
@@ -17,8 +17,9 @@ network:
       addresses:
        - 192.168.5.24/24
       dhcp4: no
-      gateway4: 192.168.5.1
       routes:
+       - to: default
+         via: 192.168.5.1
        - to: 192.168.5.0/24
          via: 192.168.5.1
          table: 102

--- a/examples/static.yaml
+++ b/examples/static.yaml
@@ -5,7 +5,9 @@ network:
     enp3s0:
       addresses:
         - 10.10.10.2/24
-      gateway4: 10.10.10.1
       nameservers:
         search: [mydomain, otherdomain]
         addresses: [10.10.10.1, 1.1.1.1]
+      routes: 
+        - to: default
+          via: 10.10.10.1

--- a/examples/static_multiaddress.yaml
+++ b/examples/static_multiaddress.yaml
@@ -6,4 +6,6 @@ network:
      addresses:
        - 10.100.1.38/24
        - 10.100.1.39/24
-     gateway4: 10.100.1.1
+     routes:
+       - to: default
+         via: 10.100.1.1

--- a/examples/vlan.yaml
+++ b/examples/vlan.yaml
@@ -7,10 +7,12 @@ network:
         macaddress: "de:ad:be:ef:ca:fe"
       set-name: mainif
       addresses: [ "10.3.0.5/23" ]
-      gateway4: 10.3.0.1
       nameservers:
         addresses: [ "8.8.8.8", "8.8.4.4" ]
         search: [ example.com ]
+      routes:
+        - to: default
+          via: 10.3.0.1
   vlans:
     vlan15:
       id: 15

--- a/examples/wireguard.yaml
+++ b/examples/wireguard.yaml
@@ -4,7 +4,6 @@ network:
     wg0: #server
       mode: wireguard
       addresses: [10.10.10.20/24]
-      gateway4: 10.10.10.21
       key: 4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=
       mark: 42
       port: 51820
@@ -13,10 +12,12 @@ network:
             public: M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=
             shared: 7voRZ/ojfXgfPOlswo3Lpma1RJq7qijIEEUEMShQFV8=
           allowed-ips: [20.20.20.10/24]
+      routes: 
+        - to: default
+          via: 10.10.10.21
     wg1: #client
       mode: wireguard
       addresses: [20.20.20.10/24]
-      gateway4: 20.20.20.11
       key: KPt9BzQjejRerEv8RMaFlpsD675gNexELOQRXt/AcH0=
       peers:
         - endpoint: 10.10.10.20:51820
@@ -25,3 +26,6 @@ network:
             public: rlbInAj0qV69CysWPQY7KEBnKxpYCpaWqOs/dLevdWc=
             shared: 7voRZ/ojfXgfPOlswo3Lpma1RJq7qijIEEUEMShQFV8=
           keepalive: 21
+      routes: 
+        - to: default
+          via: 20.20.20.11

--- a/examples/wireless.yaml
+++ b/examples/wireless.yaml
@@ -6,9 +6,11 @@ network:
       dhcp4: no
       dhcp6: no
       addresses: [192.168.0.21/24]
-      gateway4: 192.168.0.1
       nameservers:
         addresses: [192.168.0.1, 8.8.8.8]
       access-points:
         "network_ssid_name":
           password: "**********"
+      routes:
+        - to: default
+          via: 192.168.0.1

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -422,9 +422,14 @@ write_netdev_file(const NetplanNetDefinition* def, const char* rootdir, const ch
 static void
 write_route(NetplanIPRoute* r, GString* s)
 {
+    const char *to;
     g_string_append_printf(s, "\n[Route]\n");
 
-    g_string_append_printf(s, "Destination=%s\n", r->to);
+    if (g_strcmp0(r->to, "default") == 0)
+        to = get_global_network(r->family);
+    else
+        to = r->to;
+    g_string_append_printf(s, "Destination=%s\n", to);
 
     if (r->via)
         g_string_append_printf(s, "Gateway=%s\n", r->via);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1119,7 +1119,7 @@ handle_gateway4(yaml_document_t* doc, yaml_node_t* node, const void* _, GError**
         return yaml_error(node, error, "invalid IPv4 address '%s'", scalar(node));
     set_str_if_null(cur_netdef->gateway4, scalar(node));
     g_warning("`gateway4` has been deprecated, use default routes instead.\n"
-            "See the 'Default routes' section of the documentation for more details.");
+              "See the 'Default routes' section of the documentation for more details.");
     return TRUE;
 }
 
@@ -1130,7 +1130,7 @@ handle_gateway6(yaml_document_t* doc, yaml_node_t* node, const void* _, GError**
         return yaml_error(node, error, "invalid IPv6 address '%s'", scalar(node));
     set_str_if_null(cur_netdef->gateway6, scalar(node));
     g_warning("`gateway6` has been deprecated, use default routes instead.\n"
-            "See the 'Default routes' section of the documentation for more details.");
+              "See the 'Default routes' section of the documentation for more details.");
     return TRUE;
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1118,6 +1118,8 @@ handle_gateway4(yaml_document_t* doc, yaml_node_t* node, const void* _, GError**
     if (!is_ip4_address(scalar(node)))
         return yaml_error(node, error, "invalid IPv4 address '%s'", scalar(node));
     set_str_if_null(cur_netdef->gateway4, scalar(node));
+    g_warning("`gateway4` has been deprecated, use default routes instead.\n"
+            "See the 'Default routes' section of the documentation for more details.");
     return TRUE;
 }
 
@@ -1127,6 +1129,8 @@ handle_gateway6(yaml_document_t* doc, yaml_node_t* node, const void* _, GError**
     if (!is_ip6_address(scalar(node)))
         return yaml_error(node, error, "invalid IPv6 address '%s'", scalar(node));
     set_str_if_null(cur_netdef->gateway6, scalar(node));
+    g_warning("`gateway6` has been deprecated, use default routes instead.\n"
+            "See the 'Default routes' section of the documentation for more details.");
     return TRUE;
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1464,6 +1464,16 @@ handle_routes_ip(yaml_document_t* doc, yaml_node_t* node, const void* data, GErr
 }
 
 static gboolean
+handle_routes_destination(yaml_document_t *doc, yaml_node_t *node, const void *data, GError **error)
+{
+    const char *addr = scalar(node);
+    if (g_strcmp0(addr, "default") != 0)
+        return handle_routes_ip(doc, node, route_offset(to), error);
+    set_str_if_null(cur_route->to, addr);
+    return TRUE;
+}
+
+static gboolean
 handle_ip_rule_ip(yaml_document_t* doc, yaml_node_t* node, const void* data, GError** error)
 {
     guint offset = GPOINTER_TO_UINT(data);
@@ -1611,7 +1621,7 @@ static const mapping_entry_handler routes_handlers[] = {
     {"on-link", YAML_SCALAR_NODE, handle_routes_bool, NULL, route_offset(onlink)},
     {"scope", YAML_SCALAR_NODE, handle_routes_scope},
     {"table", YAML_SCALAR_NODE, handle_routes_guint, NULL, route_offset(table)},
-    {"to", YAML_SCALAR_NODE, handle_routes_ip, NULL, route_offset(to)},
+    {"to", YAML_SCALAR_NODE, handle_routes_destination},
     {"type", YAML_SCALAR_NODE, handle_routes_type},
     {"via", YAML_SCALAR_NODE, handle_routes_ip, NULL, route_offset(via)},
     {"metric", YAML_SCALAR_NODE, handle_routes_guint, NULL, route_offset(metric)},

--- a/src/util.c
+++ b/src/util.c
@@ -17,6 +17,7 @@
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <arpa/inet.h>
 
 #include <glib.h>
 #include <glib/gprintf.h>
@@ -311,4 +312,18 @@ netplan_get_filename_by_id(const char* netdef_id, const char* rootdir)
     filename = g_strdup(nd->filename);
     netplan_clear_netdefs();
     return filename;
+}
+
+/**
+ * Get a static string describing the default global network
+ * for a given address family.
+ */
+const char *
+get_global_network(int ip_family)
+{
+    g_assert(ip_family == AF_INET || ip_family == AF_INET6);
+    if (ip_family == AF_INET)
+        return "0.0.0.0/0";
+    else
+        return "::/0";
 }

--- a/src/util.h
+++ b/src/util.h
@@ -27,6 +27,8 @@ void g_string_free_to_file(GString* s, const char* rootdir, const char* path, co
 void unlink_glob(const char* rootdir, const char* _glob);
 int find_yaml_glob(const char* rootdir, glob_t* out_glob);
 
+const char *get_global_network(int ip_family);
+
 int wifi_get_freq24(int channel);
 int wifi_get_freq5(int channel);
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -388,14 +388,14 @@ defroute_err(struct _defroute_entry *entry, const char *new_netdef_id, GError **
 
     // XXX: handle 254 as an alias for main ?
     if (entry->table == NETPLAN_ROUTE_TABLE_UNSPEC)
-        strncpy(table_name, "main table", sizeof(table_name) - 1);
+        strncpy(table_name, "table: main", sizeof(table_name) - 1);
     else
-        snprintf(table_name, sizeof(table_name) - 1, "table %d", entry->table);
+        snprintf(table_name, sizeof(table_name) - 1, "table: %d", entry->table);
 
     if (entry->metric == NETPLAN_METRIC_UNSPEC)
-        strncpy(metric_name, "default metric", sizeof(metric_name) - 1);
+        strncpy(metric_name, "metric: default", sizeof(metric_name) - 1);
     else
-        snprintf(metric_name, sizeof(metric_name) - 1, "metric %d", entry->metric);
+        snprintf(metric_name, sizeof(metric_name) - 1, "metric: %d", entry->metric);
 
     g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
             "Conflicting default route declarations for %s (%s, %s), first declared in %s but also in %s",
@@ -484,4 +484,3 @@ validate_default_route_consistency(GHashTable *netdefs, GError ** error)
     g_slist_free_full(defroutes, g_free);
     return ret;
 }
-

--- a/src/validation.h
+++ b/src/validation.h
@@ -34,4 +34,4 @@ gboolean
 validate_backend_rules(NetplanNetDefinition* nd, GError** error);
 
 gboolean
-validate_gateway_consistency(GHashTable* netdefs, GError** error);
+validate_default_route_consistency(GHashTable* netdefs, GError** error);

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -555,14 +555,46 @@ RouteMetric=100
 UseMTU=true
 '''})
 
-    def test_gateway(self):
+    def test_gateway4(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: ["192.168.14.2/24"]
+      gateway4: 192.168.14.1''')
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=192.168.14.2/24
+Gateway=192.168.14.1
+'''})
+
+    def test_gateway6(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: ["2001:FFfe::1/64"]
+      gateway6: 2001:FFfe::2''')
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=2001:FFfe::1/64
+Gateway=2001:FFfe::2
+'''})
+
+    def test_gateway_full(self):
         self.generate('''network:
   version: 2
   ethernets:
     engreen:
       addresses: ["192.168.14.2/24", "2001:FFfe::1/64"]
       gateway4: 192.168.14.1
-      gateway6: 2001:FFfe::2''')
+      gateway6: "2001:FFfe::2"''', skip_generated_yaml_validation=True)
 
         self.assert_networkd({'engreen.network': '''[Match]
 Name=engreen

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -609,6 +609,33 @@ Gateway=192.168.14.1
 Gateway=2001:FFfe::2
 '''})
 
+    def test_gateways_multi_pass(self):
+        self.generate('''network:
+  version: 2
+  bridges:
+    br0:
+      interfaces: [engreen]
+  ethernets:
+    engreen:
+      addresses: ["192.168.14.2/24", "2001:FFfe::1/64"]
+      gateway4: 192.168.14.1
+      gateway6: "2001:FFfe::2"''')
+
+        self.assert_networkd({
+            'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=no
+Address=192.168.14.2/24
+Address=2001:FFfe::1/64
+Gateway=192.168.14.1
+Gateway=2001:FFfe::2
+Bridge=br0
+''',
+            'br0.network': ND_EMPTY % ('br0', 'ipv6'),
+            'br0.netdev': '[NetDev]\nName=br0\nKind=bridge\n'})
+
     def test_nameserver(self):
         self.generate('''network:
   version: 2

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -556,12 +556,13 @@ UseMTU=true
 '''})
 
     def test_gateway4(self):
-        self.generate('''network:
+        err = self.generate('''network:
   version: 2
   ethernets:
     engreen:
       addresses: ["192.168.14.2/24"]
       gateway4: 192.168.14.1''')
+        self.assertIn("`gateway4` has been deprecated, use default routes instead.", err)
         self.assert_networkd({'engreen.network': '''[Match]
 Name=engreen
 
@@ -572,12 +573,13 @@ Gateway=192.168.14.1
 '''})
 
     def test_gateway6(self):
-        self.generate('''network:
+        err = self.generate('''network:
   version: 2
   ethernets:
     engreen:
       addresses: ["2001:FFfe::1/64"]
       gateway6: 2001:FFfe::2''')
+        self.assertIn("`gateway6` has been deprecated, use default routes instead.", err)
         self.assert_networkd({'engreen.network': '''[Match]
 Name=engreen
 
@@ -594,7 +596,7 @@ Gateway=2001:FFfe::2
     engreen:
       addresses: ["192.168.14.2/24", "2001:FFfe::1/64"]
       gateway4: 192.168.14.1
-      gateway6: "2001:FFfe::2"''', skip_generated_yaml_validation=True)
+      gateway6: "2001:FFfe::2"''')
 
         self.assert_networkd({'engreen.network': '''[Match]
 Name=engreen

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -446,7 +446,7 @@ class TestConfigErrors(TestBase):
       addresses: [10.49.34.4/16]
       gateway4: 10.49.2.38''', expect_fail=False)
         self.assertIn("Problem encountered while validating default route consistency", err)
-        self.assertIn("Conflicting default route declarations for IPv4 (main table, default metric)", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (table: main, metric: default)", err)
         self.assertIn("engreen", err)
         self.assertIn("enblue", err)
 
@@ -461,7 +461,7 @@ class TestConfigErrors(TestBase):
       addresses: [2001:FFfe::33/62]
       gateway6: 2001:FFfe::34''', expect_fail=False)
         self.assertIn("Problem encountered while validating default route consistency", err)
-        self.assertIn("Conflicting default route declarations for IPv6 (main table, default metric)", err)
+        self.assertIn("Conflicting default route declarations for IPv6 (table: main, metric: default)", err)
         self.assertIn("engreen", err)
         self.assertIn("enblue", err)
 
@@ -476,7 +476,7 @@ class TestConfigErrors(TestBase):
       - to: default
         via: 10.49.65.89''', expect_fail=False)
         self.assertIn("Problem encountered while validating default route consistency", err)
-        self.assertIn("Conflicting default route declarations for IPv4 (main table, default metric)", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (table: main, metric: default)", err)
         self.assertIn("engreen", err)
 
     def test_multiple_default_routes_on_other_table(self):
@@ -502,7 +502,7 @@ class TestConfigErrors(TestBase):
         table: 23
         ''', expect_fail=False)
         self.assertIn("Problem encountered while validating default route consistency", err)
-        self.assertIn("Conflicting default route declarations for IPv4 (table 23, default metric)", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (table: 23, metric: default)", err)
         self.assertIn("enblue", err)
         self.assertIn("enred", err)
         self.assertNotIn("engreen", err)
@@ -531,7 +531,7 @@ class TestConfigErrors(TestBase):
         metric: 600
         ''', expect_fail=False)
         self.assertIn("Problem encountered while validating default route consistency", err)
-        self.assertIn("Conflicting default route declarations for IPv4 (main table, metric 600)", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (table: main, metric: 600)", err)
         self.assertIn("enblue", err)
         self.assertIn("enred", err)
         self.assertNotIn("engreen", err)
@@ -548,7 +548,7 @@ class TestConfigErrors(TestBase):
       - to: 0.0.0.0/0
         via: 10.49.65.67''', expect_fail=False)
         self.assertIn("Problem encountered while validating default route consistency", err)
-        self.assertIn("Conflicting default route declarations for IPv4 (main table, default metric)", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (table: main, metric: default)", err)
         self.assertIn("engreen", err)
 
     def test_invalid_nameserver_ipv4(self):

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -445,7 +445,10 @@ class TestConfigErrors(TestBase):
     enblue:
       addresses: [10.49.34.4/16]
       gateway4: 10.49.2.38''', expect_fail=False)
-        self.assertIn("More than one global gateway specified", err)
+        self.assertIn("Problem encountered while validating default route consistency", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (main table, default metric)", err)
+        self.assertIn("engreen", err)
+        self.assertIn("enblue", err)
 
     def test_multiple_ip6_gateways(self):
         err = self.generate('''network:
@@ -457,7 +460,96 @@ class TestConfigErrors(TestBase):
     enblue:
       addresses: [2001:FFfe::33/62]
       gateway6: 2001:FFfe::34''', expect_fail=False)
-        self.assertIn("More than one global gateway specified", err)
+        self.assertIn("Problem encountered while validating default route consistency", err)
+        self.assertIn("Conflicting default route declarations for IPv6 (main table, default metric)", err)
+        self.assertIn("engreen", err)
+        self.assertIn("enblue", err)
+
+    def test_gateway_and_default_route(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: [10.49.34.4/16]
+      gateway4: 10.49.2.38
+      routes:
+      - to: default
+        via: 10.49.65.89''', expect_fail=False)
+        self.assertIn("Problem encountered while validating default route consistency", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (main table, default metric)", err)
+        self.assertIn("engreen", err)
+
+    def test_multiple_default_routes_on_other_table(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: [10.49.34.4/16]
+      routes:
+      - to: default
+        via: 10.49.65.89
+    enblue:
+      addresses: [10.50.35.3/16]
+      routes:
+      - to: default
+        via: 10.49.65.89
+        table: 23
+    enred:
+      addresses: [172.137.1.4/24]
+      routes:
+      - to: default
+        via: 172.137.1.1
+        table: 23
+        ''', expect_fail=False)
+        self.assertIn("Problem encountered while validating default route consistency", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (table 23, default metric)", err)
+        self.assertIn("enblue", err)
+        self.assertIn("enred", err)
+        self.assertNotIn("engreen", err)
+
+    def test_multiple_default_routes_on_specific_metrics(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: [10.49.34.4/16]
+      routes:
+      - to: default
+        via: 10.49.65.89
+        metric: 100
+    enblue:
+      addresses: [10.50.35.3/16]
+      routes:
+      - to: default
+        via: 10.49.65.89
+        metric: 600
+    enred:
+      addresses: [172.137.1.4/24]
+      routes:
+      - to: default
+        via: 172.137.1.1
+        metric: 600
+        ''', expect_fail=False)
+        self.assertIn("Problem encountered while validating default route consistency", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (main table, metric 600)", err)
+        self.assertIn("enblue", err)
+        self.assertIn("enred", err)
+        self.assertNotIn("engreen", err)
+
+    def test_default_route_and_0(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: [10.49.34.4/16]
+      routes:
+      - to: default
+        via: 10.49.65.89
+      - to: 0.0.0.0/0
+        via: 10.49.65.67''', expect_fail=False)
+        self.assertIn("Problem encountered while validating default route consistency", err)
+        self.assertIn("Conflicting default route declarations for IPv4 (main table, default metric)", err)
+        self.assertIn("engreen", err)
 
     def test_invalid_nameserver_ipv4(self):
         for a in ['300.400.1.1', '1.2.3', '192.168.14.1/24']:

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -790,6 +790,35 @@ route3=11.11.11.0/24,192.168.1.3,9999
 method=ignore
 '''})
 
+    def test_route_v4_default(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      addresses: ["192.168.1.2/24"]
+      routes:
+        - to: default
+          via: 192.168.1.1
+          ''')
+
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=manual
+address1=192.168.1.2/24
+route1=0.0.0.0/0,192.168.1.1
+
+[ipv6]
+method=ignore
+'''})
+
     def test_route_v6_single(self):
         self.generate('''network:
   version: 2
@@ -848,6 +877,34 @@ method=manual
 address1=2001:f00f:f00f::2/64
 route1=2001:dead:beef::2/64,2001:beef:beef::1
 route2=2001:dead:feed::2/64,2001:beef:beef::2,1000
+'''})
+
+    def test_route_v6_default(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    enblue:
+      addresses: ["2001:dead:beef::2/64"]
+      routes:
+        - to: default
+          via: 2001:beef:beef::1''')
+
+        self.assert_nm({'enblue': '''[connection]
+id=netplan-enblue
+type=ethernet
+interface-name=enblue
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=manual
+address1=2001:dead:beef::2/64
+route1=::/0,2001:beef:beef::1
 '''})
 
     def test_routes_mixed(self):

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -130,6 +130,29 @@ Gateway=192.168.1.3
 Metric=9999
 '''})
 
+    def test_route_v4_default(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: ["192.168.1.2/24"]
+      routes:
+        - to: default
+          via: 192.168.1.1
+          ''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=192.168.1.2/24
+
+[Route]
+Destination=0.0.0.0/0
+Gateway=192.168.1.1
+'''})
+
     def test_route_v4_onlink(self):
         self.generate('''network:
   version: 2
@@ -517,6 +540,28 @@ Gateway=2001:beef:beef::1
 Destination=2001:f00f:f00f::fe/64
 Gateway=2001:beef:feed::1
 Metric=1024
+'''})
+
+    def test_route_v6_default(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    enblue:
+      addresses: ["2001:dead:beef::2/64"]
+      routes:
+        - to: default
+          via: 2001:beef:beef::1''')
+
+        self.assert_networkd({'enblue.network': '''[Match]
+Name=enblue
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=2001:dead:beef::2/64
+
+[Route]
+Destination=::/0
+Gateway=2001:beef:beef::1
 '''})
 
     def test_ip_rule_table(self):

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -169,6 +169,37 @@ class _CommonTests():
         self.assertIn(b'metric 799',
                       subprocess.check_output(['ip', '-6', 'route', 'show', '2001:f00f:f00f::/64']))
 
+    def test_routes_default(self):
+        self.setup_eth(None)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    %(ec)s:
+      addresses:
+          - 192.168.5.99/24
+          - "9876:BBBB::11/70"
+      routes:
+          - to: default
+            via: 192.168.5.1
+          - to: default
+            via: "9876:BBBB::1"
+          - to: 10.10.10.0/24
+            via: 192.168.5.254
+            metric: 99''' % {'r': self.backend, 'ec': self.dev_e_client})
+        self.generate_and_settle([self.dev_e_client])
+        self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.99/24', 'inet6 9876:bbbb::11/70'])  # from DHCP
+        # import pdb
+        # pdb.set_trace()
+        self.assertIn(b'default via 192.168.5.1',  # from DHCP
+                      subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
+        self.assertIn(b'via 9876:bbbb::1',
+                      subprocess.check_output(['ip', '-6', 'route', 'show', 'default']))
+        self.assertIn(b'10.10.10.0/24 via 192.168.5.254',  # from DHCP
+                      subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
+        self.assertIn(b'metric 99',  # check metric from static route
+                      subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
+
     def test_per_route_mtu(self):
         self.setup_eth(None)
         with open(self.config, 'w') as f:

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -170,7 +170,7 @@ class _CommonTests():
                       subprocess.check_output(['ip', '-6', 'route', 'show', '2001:f00f:f00f::/64']))
 
     def test_routes_default(self):
-        self.setup_eth(None)
+        self.setup_eth(None, False)
         with open(self.config, 'w') as f:
             f.write('''network:
   renderer: %(r)s
@@ -188,14 +188,14 @@ class _CommonTests():
             via: 192.168.5.254
             metric: 99''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client])
-        self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.99/24', 'inet6 9876:bbbb::11/70'])  # from DHCP
+        self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.99/24', 'inet6 9876:bbbb::11/70'])
         # import pdb
         # pdb.set_trace()
-        self.assertIn(b'default via 192.168.5.1',  # from DHCP
+        self.assertIn(b'default via 192.168.5.1',
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
         self.assertIn(b'via 9876:bbbb::1',
                       subprocess.check_output(['ip', '-6', 'route', 'show', 'default']))
-        self.assertIn(b'10.10.10.0/24 via 192.168.5.254',  # from DHCP
+        self.assertIn(b'10.10.10.0/24 via 192.168.5.254',
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client]))
         self.assertIn(b'metric 99',  # check metric from static route
                       subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))


### PR DESCRIPTION
## Description

This patchset deprecates the `gateway4/6` fields, advising the user to use a proper route instead. The rationale is that it groups all routing matters in the same place, making things more consistent. Along with this deprecation comes the support for the "default" keyword in the route `to` field, and an expansion of the gateway validation step to encompass all default routes.

### Examples

```yaml
network:
  ethernets:
    en1:
      addresses:
      - 1.2.3.4/8
      - fc00:123:4567:89ab:cdef::1234/64
      routes:
      - to: default
        via: 1.1.1.1
      - to: default
        via: "fc00:123:4567:89cb:cdef::1"
```

Addresses LP: #1756590

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. https://pad.lv/1756590

