### PR TITLE
parser: warn user on multiple global gateway (LP: #1901836) (FR-728)

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2684,8 +2684,8 @@ netplan_finish_parse(GError** error)
     if (netdefs) {
         g_debug("We have some netdefs, pass them through a final round of validation");
         if (!validate_gateway_consistency(netdefs, error))
-            g_warning("More than one global gateway specified, the routing is ambiguous!"
-                    "Please set up multiple routing tables and use `routing-policy` instead.");
+            g_warning("More than one global gateway specified, the routing is ambiguous! "
+                      "Please set up multiple routing tables and use `routing-policy` instead.");
         g_hash_table_foreach(netdefs, finish_iterator, error);
     }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -2683,6 +2683,9 @@ netplan_finish_parse(GError** error)
 {
     if (netdefs) {
         g_debug("We have some netdefs, pass them through a final round of validation");
+        if (!validate_gateway_consistency(netdefs, error))
+            g_warning("More than one global gateway specified, the routing is ambiguous!"
+                    "Please set up multiple routing tables and use `routing-policy` instead.");
         g_hash_table_foreach(netdefs, finish_iterator, error);
     }
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -372,3 +372,28 @@ backend_rules_error:
     return valid;
 }
 
+gboolean
+validate_gateway_consistency(GHashTable *netdefs, GError** error)
+{
+    const char *gw4 = NULL, *gw6 = NULL;
+    gpointer key, value;
+    GHashTableIter iter;
+
+    g_hash_table_iter_init (&iter, netdefs);
+    while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+        NetplanNetDefinition *nd = value;
+        if (nd->gateway4) {
+            if (gw4)
+                return FALSE;
+            gw4 = nd->gateway4;
+        }
+        if (nd->gateway6) {
+            if (gw6)
+                return FALSE;
+            gw6 = nd->gateway6;
+        }
+    }
+    return TRUE;
+}
+

--- a/src/validation.h
+++ b/src/validation.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "parse.h"
+#include <glib.h>
 
 
 gboolean is_ip4_address(const char* address);
@@ -31,3 +32,6 @@ validate_netdef_grammar(NetplanNetDefinition* nd, yaml_node_t* node, GError** er
 
 gboolean
 validate_backend_rules(NetplanNetDefinition* nd, GError** error);
+
+gboolean
+validate_gateway_consistency(GHashTable* netdefs, GError** error);

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -435,6 +435,30 @@ class TestConfigErrors(TestBase):
       gateway6: %s''' % a, expect_fail=True)
             self.assertIn("invalid IPv6 address '%s'" % a, err)
 
+    def test_multiple_ip4_gateways(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: [192.168.22.78/24]
+      gateway4: 192.168.22.1
+    enblue:
+      addresses: [10.49.34.4/16]
+      gateway4: 10.49.2.38''', expect_fail=False)
+        self.assertIn("More than one global gateway specified", err)
+
+    def test_multiple_ip6_gateways(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: [2001:FFfe::1/62]
+      gateway6: 2001:FFfe::2
+    enblue:
+      addresses: [2001:FFfe::33/62]
+      gateway6: 2001:FFfe::34''', expect_fail=False)
+        self.assertIn("More than one global gateway specified", err)
+
     def test_invalid_nameserver_ipv4(self):
         for a in ['300.400.1.1', '1.2.3', '192.168.14.1/24']:
             err = self.generate('''network:


### PR DESCRIPTION
## Description

It doesn't make sense for the user to have multiple global gateways. This patch introduces a consistency check at the end of the parsing stage, and only emits a warning in order not to break current configurations.

Addresses LP #1901836

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

