### PR TITLE
parse: routes: avoid creating dangling pointers on error

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -1446,7 +1446,6 @@ handle_routes_ip(yaml_document_t* doc, yaml_node_t* node, const void* data, GErr
     guint offset = GPOINTER_TO_UINT(data);
     int family = get_ip_family(scalar(node));
     char** dest = (char**) ((void*) cur_route + offset);
-    g_free(*dest);
 
     if (family < 0)
         return yaml_error(node, error, "invalid IP family '%d'", family);
@@ -1454,6 +1453,7 @@ handle_routes_ip(yaml_document_t* doc, yaml_node_t* node, const void* data, GErr
     if (!check_and_set_family(family, &cur_route->family))
         return yaml_error(node, error, "IP family mismatch in route to %s", scalar(node));
 
+    g_free(*dest);
     *dest = g_strdup(scalar(node));
 
     return TRUE;
@@ -1465,7 +1465,6 @@ handle_ip_rule_ip(yaml_document_t* doc, yaml_node_t* node, const void* data, GEr
     guint offset = GPOINTER_TO_UINT(data);
     int family = get_ip_family(scalar(node));
     char** dest = (char**) ((void*) cur_ip_rule + offset);
-    g_free(*dest);
 
     if (family < 0)
         return yaml_error(node, error, "invalid IP family '%d'", family);
@@ -1473,6 +1472,7 @@ handle_ip_rule_ip(yaml_document_t* doc, yaml_node_t* node, const void* data, GEr
     if (!check_and_set_family(family, &cur_ip_rule->family))
         return yaml_error(node, error, "IP family mismatch in route to %s", scalar(node));
 
+    g_free(*dest);
     *dest = g_strdup(scalar(node));
 
     return TRUE;


### PR DESCRIPTION
## Description

Parsing a yaml route looking like this:

```yaml
routes:
- to: 162.168.0.0/16
- to: invalid value
```

would result in having a dangling pointer in cur_route->to, as its
content would have been freed when starting to parse the invalid value,
without the pointer itself having been cleared. By deferring the free() to
right before the pointer update, we ensure that (barring interrupts or
multithreading, neither of which are supported AFAIK) the pointer remain
valid.

Note that to be thread-safe, we'd need to do an atomic swap and only
then free the variable, but that's out of scope ATM.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

