### PR TITLE
cli: Fix failure with "set-name" and "bridges"

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -258,6 +258,8 @@ class NetplanApply(utils.NetplanCommand):
         """
         for composite in composites:
             for _, settings in composite.items():
+                if not type(settings) is dict:
+                    continue
                 members = settings.get('interfaces', [])
                 for iface in members:
                     if iface == phy:

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -251,7 +251,7 @@ class NetplanApply(utils.NetplanCommand):
             utils.systemctl_network_manager('start', sync=sync)
 
     @staticmethod
-    def is_composite_member(composites, phy):  # pragma: nocover (covered in autopkgtest)
+    def is_composite_member(composites, phy):
         """
         Is this physical interface a member of a 'composite' virtual
         interface? (bond, bridge)

--- a/tests/test_cli_units.py
+++ b/tests/test_cli_units.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+# Blackbox tests of netplan CLI. These are run during "make check" and don't
+# touch the system configuration at all.
+#
+# Copyright (C) 2021 Canonical, Ltd.
+# Author: Lukas Märdian <slyon@ubuntu.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from netplan.cli.commands.apply import NetplanApply
+
+
+class TestCLI(unittest.TestCase):
+    '''Netplan CLI unittests'''
+
+    def test_is_composite_member(self):
+        res = NetplanApply.is_composite_member([{'br0': {'interfaces': ['eth0']}}], 'eth0')
+        self.assertTrue(res)
+
+    def test_is_composite_member_false(self):
+        res = NetplanApply.is_composite_member([
+                  {'br0': {'interfaces': ['eth42']}},
+                  {'bond0': {'interfaces': ['eth1']}}
+              ], 'eth0')
+        self.assertFalse(res)
+
+    def test_is_composite_member_with_renderer(self):
+        res = NetplanApply.is_composite_member([{'renderer': 'networkd', 'br0': {'interfaces': ['eth0']}}], 'eth0')
+        self.assertTrue(res)


### PR DESCRIPTION
## Description
The code path when a config has `set-name` as well as `bridges` doesn't seem to work at present, failure below. This change seems to fix it. 

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

Config:
```yaml
network:
  version: 2
#  renderer: networkd
#  networkd doesn't handle ethernet well...
  renderer: NetworkManager
  ethernets:
    devnet:
      renderer: networkd
      match:
        name: enx00aa11223344
    enx00bb11223344:
      addresses: [ 10.20.0.1/24 ]
      renderer: networkd
    wlan:
      match:
        macaddress: 00:99:11:22:33:44
      set-name: "wlan0"

  bridges:
    # ... and NetworkManager doesn't handle bridges well
    renderer: networkd
    br0:
      addresses: [ "10.9.0.1/16" ]
      interfaces: [ "devnet" ]
```


```
netplan try
Traceback (most recent call last):
  File "/usr/share/netplan/netplan/cli/commands/try_command.py", line 84, in command_try
    NetplanApply().command_apply(run_generate=True, sync=True, exit_on_error=False)
  File "/usr/share/netplan/netplan/cli/commands/apply.py", line 191, in command_apply
    changes = NetplanApply.process_link_changes(devices, config_manager)
  File "/usr/share/netplan/netplan/cli/commands/apply.py", line 281, in process_link_changes
    if NetplanApply.is_composite_member(composite_interfaces, phy):
  File "/usr/share/netplan/netplan/cli/commands/apply.py", line 252, in is_composite_member
    members = settings.get('interfaces', [])
AttributeError: 'str' object has no attribute 'get'
```