### PR TITLE
fix no attribute CSafeLoader

### DIFF
--- a/netplan/configmanager.py
+++ b/netplan/configmanager.py
@@ -270,7 +270,7 @@ class ConfigManager(object):
 
         try:
             with open(yaml_file) as f:
-                yaml_data = yaml.load(f, Loader=yaml.CSafeLoader)
+                yaml_data = yaml.load(f, Loader=yaml.SafeLoader)
                 network = None
                 if yaml_data is not None:
                     network = yaml_data.get('network')


### PR DESCRIPTION
## Description

Fixes this bug. Raspberry Pi 4, Ubuntu 18.04

![Screenshot from 2021-08-12 21-43-35](https://user-images.githubusercontent.com/1786477/129274056-2b309aff-632d-4bfe-83f6-aa53aa592f50.png)


## Checklist

- [X] Runs `make check` successfully.
- [X] Retains 100% code coverage (`make check-coverage`).
- [X] New/changed keys in YAML format are documented.
