### PR TITLE
Add `.editorconfig` for convenience

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.{c,h,py}]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
The `Convenientions` section in `CONTRIBUTING` emphasizes an
indentation of 4 spaces which is not always the default in the
developer's environment. The EditorConfig project aims to maintain
consistent styles across various IDEs and editors. Some editors
natively support EditorConfig [1] and for some editors a plugin to
support EditorConfig can be downloaded [2].

[1] https://editorconfig.org/#pre-installed
[2] https://editorconfig.org/#download

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
