### PR TITLE
clarify requirements for a link local route

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -585,7 +585,8 @@ eth1:
 ``routes`` (mapping)
 
 :    The ``routes`` block defines standard static routes for an interface.
-     At least ``to`` and ``via`` must be specified.
+     At least ``to`` and ``via`` must be specified.  Routes with scope
+     ``link`` does not need to specify ``via``.
 
      For ``from``, ``to``, and ``via``, both IPv4 and IPv6 addresses are
      recognized, and must be in the form ``addr/prefixlen`` or ``addr``.

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -585,8 +585,8 @@ eth1:
 ``routes`` (mapping)
 
 :    The ``routes`` block defines standard static routes for an interface.
-     At least ``to`` and ``via`` must be specified.  Routes with scope
-     ``link`` does not need to specify ``via``.
+     At least ``to`` must be specified.  Unless the scope is ``link``, ``via`` is
+     also required.
 
      For ``from``, ``to``, and ``via``, both IPv4 and IPv6 addresses are
      recognized, and must be in the form ``addr/prefixlen`` or ``addr``.

--- a/src/parse.c
+++ b/src/parse.c
@@ -1669,7 +1669,7 @@ handle_routes(yaml_document_t* doc, yaml_node_t* node, const void* _, GError** e
         } else if (  g_ascii_strcasecmp(cur_route->type, "unicast") == 0
                 && g_ascii_strcasecmp(cur_route->scope, "global") == 0
                 && (!cur_route->to || !cur_route->via)) {
-            yaml_error(node, error, "unicast route must include both a 'to' and 'via' IP");
+            yaml_error(node, error, "global unicast route must include both a 'to' and 'via' IP");
             goto err;
         } else if (g_ascii_strcasecmp(cur_route->type, "unicast") != 0 && !cur_route->to) {
             yaml_error(node, error, "non-unicast routes must specify a 'to' IP");


### PR DESCRIPTION
## Description
This gives a better hint on how to add a link local route.  Ie., if the user tries to add a local route (without a gateway (`via`)), they will get an error message that a global route needs `via`, and hopefully understand they should use `scope: local`.  Also, the docs spell this out.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

