### PR TITLE
tests: normalize multiple keys on a single dict

### DIFF
--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -174,35 +174,35 @@ class NetplanV2Normalizer():
             if 'password' in keys and ':auth' not in full_key:
                 data['auth'] = {'key-management': 'psk', 'password': data['password']}
                 del data['password']
-            elif 'auth' in keys and data['auth'] == {}:
+            if 'auth' in keys and data['auth'] == {}:
                 data['auth'] = {'key-management': 'none'}
             # remove default stanza ("link-local: [ ipv6 ]"")
-            elif 'link-local' in keys and data['link-local'] == ['ipv6']:
+            if 'link-local' in keys and data['link-local'] == ['ipv6']:
                 del data['link-local']
             # remove default stanza ("wakeonwlan: [ default ]")
-            elif 'wakeonwlan' in keys and data['wakeonwlan'] == ['default']:
+            if 'wakeonwlan' in keys and data['wakeonwlan'] == ['default']:
                 del data['wakeonwlan']
             # remove explicit openvswitch stanzas, they might not always be
             # defined in the original YAML (due to being implicit)
-            elif ('openvswitch' in keys and data['openvswitch'] == {} and
-                  any(map(full_key.__contains__, [':bonds:', ':bridges:', ':vlans:']))):
+            if ('openvswitch' in keys and data['openvswitch'] == {} and
+                    any(map(full_key.__contains__, [':bonds:', ':bridges:', ':vlans:']))):
                 del data['openvswitch']
             # remove default empty bond-parameters, those are not rendered by the YAML generator
-            elif 'parameters' in keys and data['parameters'] == {} and ':bonds:' in full_key:
+            if 'parameters' in keys and data['parameters'] == {} and ':bonds:' in full_key:
                 del data['parameters']
             # remove default mode=infrastructore from wifi APs, keeping the SSID
-            elif 'mode' in keys and ':wifis:' in full_key and 'infrastructure' in data['mode']:
+            if 'mode' in keys and ':wifis:' in full_key and 'infrastructure' in data['mode']:
                 del data['mode']
             # ignore renderer: on other than global levels for now, as that
             # information is currently not stored in the netdef data structure
-            elif ('renderer' in keys and len(full_key.split(':')) > 1 and
-                  data['renderer'] in ['networkd', 'NetworkManager']):
+            if ('renderer' in keys and len(full_key.split(':')) > 1 and
+                    data['renderer'] in ['networkd', 'NetworkManager']):
                 del data['renderer']
             # remove default values from the dhcp4/6-overrides mappings
-            elif full_key.endswith(':dhcp4-overrides') or full_key.endswith(':dhcp6-overrides'):
+            if full_key.endswith(':dhcp4-overrides') or full_key.endswith(':dhcp6-overrides'):
                 self._clear_mapping_defaults(keys, self.DEFAULT_DHCP, data)
             # remove default values from netdef/interface mappings
-            elif len(full_key.split(':')) == 3:  # netdef level
+            if len(full_key.split(':')) == 3:  # netdef level
                 self._clear_mapping_defaults(keys, self.DEFAULT_NETDEF, data)
 
             # continue to walk the dict


### PR DESCRIPTION
## Description

The YAML normalizer has some special cases for some given keys. However,
the code block where those are dealt with used `elif` everywhere, which
meant that if a single dict had multiple keys needing to be dealt with,
only the first one would be fixed, and the rest would continue on, still
broken.

This bug is latent in the current codebase, but it showed up in a
patchset I'm working on, where by the game of butterfly effects the
rendered configuration would insist on having proper renderer for each
netdef. This key needs normalizing, but in the test cases where the
netdefs have other problematic properties, for instance the GSM config
in `test_cdma_config`, those pesky renderer lines would still show up
and screw up the test.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

