### PR TITLE
Implement YAML state tracking and use it in the DBus API and netplan-try (LP: #1943120) (FR-1745)

### DIFF
--- a/doc/netplan-apply.md
+++ b/doc/netplan-apply.md
@@ -47,13 +47,17 @@ see **netplan**(5).
 
 # KNOWN ISSUES
 
-**netplan apply** will not remove virtual devices such as bridges
-and bonds that have been created, even if they are no longer described
-in the netplan configuration.
+**netplan apply** will not remove virtual devices such as bridges and bonds
+that have been created, even if they are no longer described in the netplan
+configuration. That is due to the fact that netplan operates statelessly and
+is not aware of the previously defined virtal devices.
 
-This can be resolved by manually removing the virtual device (for
-example ``ip link delete dev bond0``) and then running **netplan
-apply**, or by rebooting.
+This can be resolved by manually removing the virtual device (for example
+``ip link delete dev bond0``) and then running **netplan apply**, by rebooting,
+or by creating a temporary backup of the YAML state in ``/etc/netplan``
+before modifying the configuration and passing this state to netplan (e.g.
+``mkdir -p /tmp/netplan_state_backup/etc && cp -r /etc/netplan /tmp/netplan_state_backup/etc/``
+then running **netplan apply --state /tmp/netplan_state_backup**)
 
 
 # SEE ALSO

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -280,7 +280,7 @@ class NetplanApply(utils.NetplanCommand):
         return False
 
     @staticmethod
-    def clear_virtual_links(prev_links, curr_links, devices):
+    def clear_virtual_links(prev_links, curr_links, devices=[]):
         """
         Calculate the delta of virtual links. And remove the links that were
         dropped from the YAML config, if they were not dropped by the backend
@@ -288,6 +288,9 @@ class NetplanApply(utils.NetplanCommand):
         We can make use of the netplan netdef ids, as those equal the interface
         name for virtual links.
         """
+        if not devices:
+            logging.warning('Cannot clear virtual links: no network interfaces provided.')
+            return []
 
         dropped_interfaces = list(set(prev_links) - set(curr_links))
         # some interfaces might have been cleaned up already, e.g. by the

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -50,6 +50,8 @@ class NetplanApply(utils.NetplanCommand):
                                  help='Only apply SR-IOV related configuration and exit')
         self.parser.add_argument('--only-ovs-cleanup', action='store_true',
                                  help='Only clean up old OpenVSwitch interfaces and exit')
+        self.parser.add_argument('--state',
+                                 help='Directory containing previous YAML configuration')
 
         self.func = self.command_apply
 
@@ -192,6 +194,14 @@ class NetplanApply(utils.NetplanCommand):
         # for now, only applies to non-virtual (real) devices.
         config_manager.parse()
         changes = NetplanApply.process_link_changes(devices, config_manager)
+        # delete virtual interfaces that have been defined in a previous state
+        # but are not configured anymore in the current YAML
+        if self.state:
+            cm = ConfigManager(self.state)
+            cm.parse()  # get previous configuration state
+            prev_links = cm.virtual_interfaces.keys()
+            curr_links = config_manager.virtual_interfaces.keys()
+            NetplanApply.clear_virtual_links(prev_links, curr_links, devices)
 
         # if the interface is up, we can still apply some .link file changes
         # but we cannot apply the interface rename via udev, as it won't touch
@@ -266,6 +276,26 @@ class NetplanApply(utils.NetplanCommand):
                         return True
 
         return False
+
+    @staticmethod
+    def clear_virtual_links(prev_links, curr_links, devices):
+        """
+        Calculate the delta of virtual links. And remove the links that were
+        dropped from the YAML config, if they were not dropped by the backend
+        already.
+        We can make use of the netplan netdef ids, as those equal the interface
+        name for virtual links.
+        """
+
+        dropped_interfaces = list(set(prev_links) - set(curr_links))
+        # some interfaces might have been cleaned up already, e.g. by the
+        # NetworkManager backend
+        interfaces_to_clear = list(set(dropped_interfaces).intersection(devices))
+        for link in interfaces_to_clear:
+            subprocess.check_call(['ip', 'link', 'delete', 'dev', link],
+                                  stdout=subprocess.DEVNULL,
+                                  stderr=subprocess.DEVNULL)
+        return dropped_interfaces
 
     @staticmethod
     def process_link_changes(interfaces, config_manager):  # pragma: nocover (covered in autopkgtest)

--- a/netplan/configmanager.py
+++ b/netplan/configmanager.py
@@ -63,6 +63,16 @@ class ConfigManager(object):
         return interfaces
 
     @property
+    def virtual_interfaces(self):
+        interfaces = {}
+        # what about ovs_ports?
+        interfaces.update(self.bridges)
+        interfaces.update(self.bonds)
+        interfaces.update(self.tunnels)
+        interfaces.update(self.vlans)
+        return interfaces
+
+    @property
     def ovs_ports(self):
         return self.network['ovs_ports']
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -199,6 +199,30 @@ _clear_tmp_state(const char *config_id, NetplanData *d)
     return TRUE;
 }
 
+static int
+_backup_global_state(sd_bus_error *ret_error)
+{
+    int r = 0;
+    g_autofree gchar *path = NULL;
+    path = g_strdup_printf("%s/netplan-config-%s", g_get_tmp_dir(), NETPLAN_GLOBAL_CONFIG);
+    /* Create {etc,run,lib} subdirs with owner r/w permissions */
+    char *subdir = NULL;
+    for (int i = 0; i < 3; i++) {
+        subdir = g_strdup_printf("%s/%s/netplan", path, NETPLAN_SUBDIRS[i]);
+        r = g_mkdir_with_parents(subdir, 0700);
+        if (r < 0)
+            // LCOV_EXCL_START
+            return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
+                                    "Failed to create '%s': %s\n", subdir, strerror(errno));
+            // LCOV_EXCL_STOP
+        g_free(subdir);
+    }
+
+    /* Copy main *.yaml files from /{etc,run,lib}/netplan/ to GLOBAL backup dir */
+    _copy_yaml_state(NETPLAN_ROOT, path, ret_error);
+    return 0;
+}
+
 /**
  * io.netplan.Netplan methods
  */
@@ -487,6 +511,10 @@ method_config_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     d->config_dirty = g_strdup(d->config_id);
 
     if (d->try_pid < 0) {
+        r = _backup_global_state(ret_error);
+        if (r < 0)
+            return r; // LCOV_EXCL_LINE
+
         /* Delete GLOBAL state */
         unlink_glob(NETPLAN_ROOT, "/{etc,run,lib}/netplan/*.yaml");
         /* Copy current config state to GLOBAL */
@@ -496,6 +524,8 @@ method_config_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     }
 
     r = method_apply(m, d, ret_error);
+    /* Clear GLOBAL backup and config state */
+    _clear_tmp_state(NETPLAN_GLOBAL_CONFIG, d);
     _clear_tmp_state(d->config_id, d);
 
     /* unlock current config ID and handler ID */
@@ -540,7 +570,6 @@ static int
 method_config_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 {
     NetplanData *d = userdata;
-    g_autofree gchar *path = NULL;
     g_autofree gchar *state_dir = NULL;
     const char *config_id = sd_bus_message_get_path(m) + 27;
     if (d->try_pid > 0)
@@ -556,23 +585,9 @@ method_config_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     d->try_pid = G_MAXINT;
     d->config_id = config_id;
 
-    /* Backup GLOBAL state */
-    path = g_strdup_printf("%s/netplan-config-%s", g_get_tmp_dir(), NETPLAN_GLOBAL_CONFIG);
-    /* Create {etc,run,lib} subdirs with owner r/w permissions */
-    char *subdir = NULL;
-    for (int i = 0; i < 3; i++) {
-        subdir = g_strdup_printf("%s/%s/netplan", path, NETPLAN_SUBDIRS[i]);
-        r = g_mkdir_with_parents(subdir, 0700);
-        if (r < 0)
-            // LCOV_EXCL_START
-            return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
-                                    "Failed to create '%s': %s\n", subdir, strerror(errno));
-            // LCOV_EXCL_STOP
-        g_free(subdir);
-    }
-
-    /* Copy main *.yaml files from /{etc,run,lib}/netplan/ to GLOBAL backup dir */
-    _copy_yaml_state(NETPLAN_ROOT, path, ret_error);
+    r = _backup_global_state(ret_error);
+    if (r < 0)
+        return r; // LCOV_EXCL_LINE
 
     /* Clear main *.yaml files */
     unlink_glob(NETPLAN_ROOT, "/{etc,run,lib}/netplan/*.yaml");

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -400,7 +400,7 @@ class TestNetplanDBus(unittest.TestCase):
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
-        self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "apply"]])
+        self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "apply", "--state=/tmp/netplan-config-BACKUP"]])
         time.sleep(1)  # Give some time for 'Apply' to clean up
         self.assertFalse(os.path.isdir(tmpdir))
 
@@ -478,7 +478,8 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertIn('Unknown object \'/io/netplan/Netplan/config/{}\''.format(cid), err)
 
         # Verify 'netplan try' has been called
-        self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "try", "--timeout=3"]])
+        self.assertEquals(self.mock_netplan_cmd.calls(),
+                          [["netplan", "try", "--timeout=3", "--state=/tmp/netplan-config-BACKUP"]])
 
     def test_netplan_dbus_config_try_cb(self):
         self.mock_netplan_cmd.set_timeout(1)  # actually self-terminate after 0.1 sec
@@ -518,7 +519,8 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertIn('Unknown object \'/io/netplan/Netplan/config/{}\''.format(cid), err)
 
         # Verify 'netplan try' has been called
-        self.assertEquals(self.mock_netplan_cmd.calls(), [["netplan", "try", "--timeout=1"]])
+        self.assertEquals(self.mock_netplan_cmd.calls(),
+                          [["netplan", "try", "--timeout=1", "--state=/tmp/netplan-config-BACKUP"]])
 
     def test_netplan_dbus_config_try_apply(self):
         self.mock_netplan_cmd.set_timeout(30)  # 30 dsec = 3 sec
@@ -639,7 +641,7 @@ class TestNetplanDBus(unittest.TestCase):
              "--root-dir=/tmp/netplan-config-{}".format(cid)],
             ["netplan", "set", "ethernets.eth0.dhcp4=yes", "--origin-hint=70-snapd",
              "--root-dir=/tmp/netplan-config-{}".format(cid)],
-            ["netplan", "apply"]
+            ["netplan", "apply", "--state=/tmp/netplan-config-BACKUP"]
         ])
 
         # Now it works again
@@ -756,7 +758,7 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEquals(self.mock_netplan_cmd.calls(), [
             ["netplan", "set", "ethernets.eth0.dhcp4=true", "--origin-hint=70-snapd",
              "--root-dir=/tmp/netplan-config-{}".format(cid)],
-            ["netplan", "try", "--timeout=1"],
+            ["netplan", "try", "--timeout=1", "--state=/tmp/netplan-config-BACKUP"],
             ["netplan", "set", "ethernets.eth0.dhcp4=false", "--origin-hint=70-snapd",
              "--root-dir=/tmp/netplan-config-{}".format(cid2)]
         ])

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -361,6 +361,7 @@ class TestNetplanDBus(unittest.TestCase):
     def test_netplan_dbus_config_cancel(self):
         cid = self._new_config_object()
         tmpdir = '/tmp/netplan-config-{}'.format(cid)
+        backup = '/tmp/netplan-config-BACKUP'
 
         # Verify .Config.Cancel() teardown of the config object and state dirs
         BUSCTL_NETPLAN_CMD = [
@@ -380,9 +381,14 @@ class TestNetplanDBus(unittest.TestCase):
         err = self._check_dbus_error(BUSCTL_NETPLAN_CMD)
         self.assertIn('Unknown object \'/io/netplan/Netplan/config/{}\''.format(cid), err)
 
+        # Verify the backup and config state dir are gone
+        self.assertFalse(os.path.isdir(backup))
+        self.assertFalse(os.path.isdir(tmpdir))
+
     def test_netplan_dbus_config_apply(self):
         cid = self._new_config_object()
         tmpdir = '/tmp/netplan-config-{}'.format(cid)
+        backup = '/tmp/netplan-config-BACKUP'
         with open(os.path.join(tmpdir, 'etc', 'netplan', 'apply_test.yaml'), 'w') as f:
             f.write('TESTING-apply')
         with open(os.path.join(tmpdir, 'lib', 'netplan', 'apply_test.yaml'), 'w') as f:
@@ -412,6 +418,10 @@ class TestNetplanDBus(unittest.TestCase):
         # Verify the object is gone from the bus
         err = self._check_dbus_error(BUSCTL_NETPLAN_CMD)
         self.assertIn('Unknown object \'/io/netplan/Netplan/config/{}\''.format(cid), err)
+
+        # Verify the backup and config state dir are gone
+        self.assertFalse(os.path.isdir(backup))
+        self.assertFalse(os.path.isdir(tmpdir))
 
     def test_netplan_dbus_config_try_cancel(self):
         # self-terminate after 30 dsec = 3 sec, if not cancelled before
@@ -504,7 +514,7 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEqual(b'b true\n', out)
         time.sleep(1.5)  # Give some time for the timeout to happen
 
-        # Verify the backup andconfig state dir are gone
+        # Verify the backup and config state dir are gone
         self.assertFalse(os.path.isdir(backup))
         self.assertFalse(os.path.isdir(tmpdir))
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -293,11 +293,14 @@ class IntegrationTestsBase(unittest.TestCase):
         if 'bond' not in iface:
             self.assertIn('state UP', out)
 
-    def generate_and_settle(self, wait_interfaces=None):
+    def generate_and_settle(self, wait_interfaces=None, state_dir=None):
         '''Generate config, launch and settle NM and networkd'''
 
         # regenerate netplan config
-        out = subprocess.check_output(['netplan', 'apply'], stderr=subprocess.STDOUT, universal_newlines=True)
+        cmd = ['netplan', 'apply']
+        if state_dir:
+            cmd = cmd + ['--state', state_dir]
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, universal_newlines=True)
         if 'Run \'systemctl daemon-reload\' to reload units.' in out:
             self.fail('systemd units changed without reload')
         # start NM so that we can verify that it does not manage anything

--- a/tests/test_configmanager.py
+++ b/tests/test_configmanager.py
@@ -151,6 +151,12 @@ class TestConfigManager(unittest.TestCase):
         self.assertEquals(2, self.configmanager.version)
         self.assertEquals('networkd', self.configmanager.renderer)
         self.assertIn('fallback', self.configmanager.nm_devices)
+        self.assertIn('vlan2', self.configmanager.virtual_interfaces)
+        self.assertIn('br3', self.configmanager.virtual_interfaces)
+        self.assertIn('br4', self.configmanager.virtual_interfaces)
+        self.assertIn('bond5', self.configmanager.virtual_interfaces)
+        self.assertIn('bond6', self.configmanager.virtual_interfaces)
+        self.assertIn('he-ipv6', self.configmanager.virtual_interfaces)
 
     def test_parse_merging(self):
         self.configmanager.parse(extra_config=[os.path.join(self.workdir.name, "newfile_merging.yaml")])


### PR DESCRIPTION
## Description
Allow to pass an optional `--state` parameter to `netplan try/apply` describing a directory that contains a netplan configuration tree/state (i.e. `/{etc,run,lib}/netplan/*.yaml`).
Netplan will make use of this "old state" to calculate the delta of dropped interface definitions, like bridges/bonds/vlans/tunnels that have been configured before but are not part of the current YAML configuration anymore. It will then try to delete those virtual interfaces (via `ip link del dev IFACE`) if they still exist.

The same functionality is used to roll back a `netplan try` command that failed or was rejected.

Generally, the state needs to be provided manually. The DBus API (using io.netplan.Netplan.Config.Try/Apply) is an exception, as the previous state can be backed up automatically in this case.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad: LP#1943120

