### PR TITLE
parser: fix some error handling code

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2686,8 +2686,7 @@ netplan_finish_parse(GError** error)
         }
         g_hash_table_iter_init (&iter, netdefs);
 
-        while (g_hash_table_iter_next (&iter, &key, &value))
-        {
+        while (g_hash_table_iter_next (&iter, &key, &value)) {
             if (!finish_iterator((NetplanNetDefinition *) value, error))
                 return NULL;
             g_debug("Configuration is valid");

--- a/src/parse.c
+++ b/src/parse.c
@@ -1999,11 +1999,13 @@ handle_wireguard_peers(yaml_document_t* doc, yaml_node_t* node, const void* _, G
         cur_wireguard_peer->allowed_ips = g_array_new(FALSE, FALSE, sizeof(char*));
         g_debug("%s: adding new wireguard peer", cur_netdef->id);
 
-        g_array_append_val(cur_netdef->wireguard_peers, cur_wireguard_peer);
         if (!process_mapping(doc, entry, wireguard_peer_handlers, NULL, error)) {
+            g_array_free(cur_wireguard_peer->allowed_ips, TRUE);
+            g_free(cur_wireguard_peer); /* TODO: in-depth cleaning ! */
             cur_wireguard_peer = NULL;
             return FALSE;
         }
+        g_array_append_val(cur_netdef->wireguard_peers, cur_wireguard_peer);
         cur_wireguard_peer = NULL;
     }
     return TRUE;


### PR DESCRIPTION
## Description

This PR rework some error handling paths, to achieve two results:

* Avoid as much as possible putting data in a netdef before it has been validated. This makes recoverable error handling much easier, and also facilitates debugging: reducing side effects means enhanced local reasoning, resulting in less headaches ;)
* Be consistent regarding `GError**` acceptable values. Most of the code assumes that actual error signalling is done via the value returned on the stack, either via `FALSE` or `NULL`, but a couple of places would use the GError mechanisms instead. This meant that providing `GError** error = NULL` would mostly work, but for those places where the code would glance over some failures as it wouldn't be able to detect them.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.

