### PR TITLE
generate:dbus:util: glib 2.70 compat

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -110,7 +110,7 @@ _try_accept(bool accept, sd_bus_message *m, NetplanData *d, sd_bus_error *ret_er
      * Check return code/errors. */
     kill(d->try_pid, signal);
     waitpid(d->try_pid, &status, 0);
-    g_spawn_check_exit_status(status, &error);
+    g_spawn_check_wait_status(status, &error);
     if (error != NULL)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan try failed: %s", error->message); // LCOV_EXCL_LINE
 
@@ -254,7 +254,7 @@ method_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     if (err != NULL)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                  "cannot run netplan apply: %s", err->message);
-    g_spawn_check_exit_status(exit_status, &err);
+    g_spawn_check_wait_status(exit_status, &err);
     if (err != NULL)
        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                 "netplan apply failed: %s\nstdout: '%s'\nstderr: '%s'",
@@ -283,7 +283,7 @@ method_generate(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     if (err != NULL)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                  "cannot run netplan generate: %s", err->message);
-    g_spawn_check_exit_status(exit_status, &err);
+    g_spawn_check_wait_status(exit_status, &err);
     if (err != NULL)
        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
                                 "netplan generate failed: %s\nstdout: '%s'\nstderr: '%s'",
@@ -360,7 +360,7 @@ method_get(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     if (err != NULL)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan get: %s", err->message); // LCOV_EXCL_LINE
 
-    g_spawn_check_exit_status(exit_status, &err);
+    g_spawn_check_wait_status(exit_status, &err);
     if (err != NULL)
        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan get failed: %s\nstdout: '%s'\nstderr: '%s'", err->message, stdout, stderr); // LCOV_EXCL_LINE
 
@@ -406,7 +406,7 @@ method_set(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     if (err != NULL)
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "cannot run netplan set %s: %s", config_delta, err->message); // LCOV_EXCL_LINE
 
-    g_spawn_check_exit_status(exit_status, &err);
+    g_spawn_check_wait_status(exit_status, &err);
     if (err != NULL)
        return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED, "netplan set failed: %s\nstdout: '%s'\nstderr: '%s'", err->message, stdout, stderr); // LCOV_EXCL_LINE
 

--- a/src/generate.c
+++ b/src/generate.c
@@ -70,7 +70,7 @@ check_called_just_in_time()
         gint exit_code = 0;
         g_spawn_sync(NULL, (gchar**)argv2, NULL, G_SPAWN_STDERR_TO_DEV_NULL, NULL, NULL, NULL, NULL, &exit_code, NULL);
         /* return TRUE, if network.target is not yet active */
-        return !g_spawn_check_exit_status(exit_code, NULL);
+        return !g_spawn_check_wait_status(exit_code, NULL);
     }
     g_free(output);
     return FALSE;

--- a/src/util.c
+++ b/src/util.c
@@ -195,7 +195,7 @@ systemd_escape(char* string)
 
     gchar *argv[] = {"bin" "/" "systemd-escape", string, NULL};
     g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &escaped, &stderrh, &exit_status, &err);
-    g_spawn_check_exit_status(exit_status, &err);
+    g_spawn_check_wait_status(exit_status, &err);
     if (err != NULL) {
         // LCOV_EXCL_START
         g_fprintf(stderr, "failed to ask systemd to escape %s; exit %d\nstdout: '%s'\nstderr: '%s'", string, exit_status, escaped, stderrh);


### PR DESCRIPTION
## Description
`g_spawn_check_exit_status()` is deprecated since libglib 2.70 and replaced by `g_spawn_check_wait_status()`

https://docs.gtk.org/glib/func.spawn_check_wait_status.html

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

