### PR TITLE
netplan: set: make it possible to unset a whole devtype subtree (LP: #1942930) (FR-1685)

### DIFF
--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -59,7 +59,14 @@ class NetplanSet(utils.NetplanCommand):
         for devtype in network:
             if devtype in GLOBAL_KEYS:
                 continue  # special handling of global keys down below
-            for netdef in network.get(devtype, []):
+            devtype_content = network.get(devtype, [])
+            # Special case: removal of a whole devtype.
+            # We replace the devtype null node with a dict of all defined netdefs
+            # set to None.
+            if devtype_content is None:
+                devtype_content = {dev: None for dev in utils.netplan_get_ids_for_devtype(devtype, self.root_dir)}
+                network[devtype] = devtype_content
+            for netdef in devtype_content:
                 hint = FALLBACK_HINT
                 filename = utils.netplan_get_filename_by_id(netdef, self.root_dir)
                 if filename:

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -32,6 +32,10 @@ NM_SERVICE_NAME = 'NetworkManager.service'
 NM_SNAP_SERVICE_NAME = 'snap.network-manager.networkmanager.service'
 
 
+class LibNetplanException(Exception):
+    pass
+
+
 class _GError(ctypes.Structure):
     _fields_ = [("domain", ctypes.c_uint32), ("code", ctypes.c_int), ("message", ctypes.c_char_p)]
 
@@ -39,6 +43,8 @@ class _GError(ctypes.Structure):
 lib = ctypes.CDLL(ctypes.util.find_library('netplan'))
 lib.netplan_parse_yaml.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.POINTER(_GError))]
 lib.netplan_get_filename_by_id.restype = ctypes.c_char_p
+lib.process_yaml_hierarchy.argtypes = [ctypes.c_char_p]
+lib.process_yaml_hierarchy.restype = ctypes.c_int
 
 
 def netplan_parse(path):
@@ -57,6 +63,46 @@ def netplan_parse(path):
 def netplan_get_filename_by_id(netdef_id, rootdir):
     res = lib.netplan_get_filename_by_id(netdef_id.encode(), rootdir.encode())
     return res.decode('utf-8') if res else None
+
+
+class _NetdefIdIterator:
+    def __init__(self, devtype):
+        self.iterator = lib._netplan_iter_defs_per_devtype_init(devtype.encode('utf-8'))
+
+    def __del__(self):
+        lib._netplan_iter_defs_per_devtype_free(self.iterator)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        next_value = lib._netplan_iter_defs_per_devtype_next(self.iterator)
+        if next_value is None:
+            raise StopIteration
+        return next_value
+
+
+def netplan_get_ids_for_devtype(devtype, rootdir):
+    if not hasattr(lib, '_netplan_iter_defs_per_devtype_init'):  # pragma: nocover (hard to unit-test against the WRONG lib)
+        raise LibNetplanException('''
+            The current version of libnetplan does not allow iterating by devtype.
+            Please ensure that both the netplan CLI package and its library are up to date.
+        ''')
+    lib._netplan_iter_defs_per_devtype_init.argtypes = [ctypes.c_char_p]
+    lib._netplan_iter_defs_per_devtype_init.restype = ctypes.c_void_p
+
+    lib._netplan_iter_defs_per_devtype_next.argtypes = [ctypes.c_void_p]
+    lib._netplan_iter_defs_per_devtype_next.restype = ctypes.c_void_p
+
+    lib._netplan_iter_defs_per_devtype_free.argtypes = [ctypes.c_void_p]
+    lib._netplan_iter_defs_per_devtype_free.restype = None
+
+    lib._netplan_netdef_id.argtypes = [ctypes.c_void_p]
+    lib._netplan_netdef_id.restype = ctypes.c_char_p
+
+    lib.process_yaml_hierarchy(rootdir.encode('utf-8'))
+    nds = list(_NetdefIdIterator(devtype))
+    return [lib._netplan_netdef_id(nd).decode('utf-8') for nd in nds]
 
 
 def get_generator_path():

--- a/src/names.c
+++ b/src/names.c
@@ -105,6 +105,17 @@ NAME_FUNCTION(tunnel_mode, NetplanTunnelMode);
 NAME_FUNCTION(addr_gen_mode, NetplanAddrGenMode);
 NAME_FUNCTION(wifi_mode, NetplanWifiMode);
 
+#define ENUM_FUNCTION(_radical, _type) _type netplan_ ## _radical ## _from_name(const char* val) \
+{ \
+    for (int i = 0; i < sizeof(netplan_ ## _radical ## _to_str); ++i) { \
+        if (g_strcmp0(val, netplan_ ## _radical ## _to_str[i]) == 0) \
+            return i; \
+    } \
+    return -1; \
+}
+
+ENUM_FUNCTION(def_type, NetplanDefType);
+
 /* ABI compatibility definitions */
 
 NETPLAN_ABI const char*

--- a/src/names.h
+++ b/src/names.h
@@ -40,3 +40,6 @@ netplan_addr_gen_mode_name(NetplanAddrGenMode val);
 
 const char*
 netplan_wifi_mode_name(NetplanWifiMode val);
+
+NetplanDefType
+netplan_def_type_from_name(const char* val);

--- a/src/util.c
+++ b/src/util.c
@@ -334,3 +334,47 @@ get_global_network(int ip_family)
     else
         return "::/0";
 }
+
+struct netdef_pertype_iterator {
+    NetplanDefType type;
+    GHashTableIter iter;
+};
+
+NETPLAN_INTERNAL struct netdef_pertype_iterator*
+_netplan_iter_defs_per_devtype_init(const char *devtype)
+{
+    NetplanDefType type = netplan_def_type_from_name(devtype);
+    struct netdef_pertype_iterator *iter = g_malloc0(sizeof(*iter));
+    iter->type = type;
+    if (netdefs)
+        g_hash_table_iter_init(&iter->iter, netdefs);
+    return iter;
+}
+
+NETPLAN_INTERNAL NetplanNetDefinition*
+_netplan_iter_defs_per_devtype_next(struct netdef_pertype_iterator* it)
+{
+    gpointer key, value;
+
+    if (!netdefs)
+        return NULL;
+
+    while (g_hash_table_iter_next(&it->iter, &key, &value)) {
+        NetplanNetDefinition* netdef = value;
+        if (netdef->type == it->type)
+            return netdef;
+    }
+    return NULL;
+}
+
+NETPLAN_INTERNAL void
+_netplan_iter_defs_per_devtype_free(struct netdef_pertype_iterator* it)
+{
+    g_free(it);
+}
+
+NETPLAN_INTERNAL const char*
+_netplan_netdef_id(NetplanNetDefinition* nd)
+{
+    return nd->id;
+}

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -193,6 +193,20 @@ class TestSet(unittest.TestCase):
             self.assertNotIn('addresses:', out)
             self.assertNotIn('eth0:', out)
 
+    def test_set_delete_subtree(self):
+        with open(self.path, 'w') as f:
+            f.write('''network:\n  version: 2\n  renderer: NetworkManager
+  ethernets:
+    eth0: {addresses: [1.2.3.4/24]}''')
+        self._set(['network.ethernets=null'])
+        self.assertTrue(os.path.isfile(self.path))
+        with open(self.path, 'r') as f:
+            out = f.read()
+        self.assertIn('network:\n', out)
+        self.assertIn(' version: 2\n', out)
+        self.assertIn(' renderer: NetworkManager\n', out)
+        self.assertNotIn('ethernets:', out)
+
     def test_set_delete_file(self):
         with open(self.path, 'w') as f:
             f.write('''network:

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -31,13 +31,11 @@ from netplan.cli.core import Netplan
 def _call_cli(args):
     old_sys_argv = sys.argv
     sys.argv = [old_sys_argv[0]] + args
+    f = io.StringIO()
     try:
-        f = io.StringIO()
         with redirect_stdout(f):
             Netplan().main()
             return f.getvalue()
-    except Exception as e:
-        return e
     finally:
         sys.argv = old_sys_argv
 
@@ -110,20 +108,20 @@ class TestSet(unittest.TestCase):
             self.assertEquals('network:\n  ethernets:\n    eth0:\n      dhcp4: true\n', f.read())
 
     def test_set_empty_origin_hint(self):
-        err = self._set(['ethernets.eth0.dhcp4=true', '--origin-hint='])
-        self.assertIsInstance(err, Exception)
-        self.assertIn('Invalid/empty origin-hint', str(err))
+        with self.assertRaises(Exception) as context:
+            self._set(['ethernets.eth0.dhcp4=true', '--origin-hint='])
+        self.assertTrue('Invalid/empty origin-hint' in str(context.exception))
 
     def test_set_invalid(self):
-        err = self._set(['xxx.yyy=abc'])
-        self.assertIsInstance(err, Exception)
-        self.assertIn('unknown key \'xxx\'\n  xxx:\n', str(err))
+        with self.assertRaises(Exception) as context:
+            self._set(['xxx.yyy=abc'])
+        self.assertIn('unknown key \'xxx\'\n  xxx:\n', str(context.exception))
         self.assertFalse(os.path.isfile(self.path))
 
     def test_set_invalid_validation(self):
-        err = self._set(['ethernets.eth0.set-name=myif0'])
-        self.assertIsInstance(err, Exception)
-        self.assertIn('eth0: \'set-name:\' requires \'match:\' properties', str(err))
+        with self.assertRaises(Exception) as context:
+            self._set(['ethernets.eth0.set-name=myif0'])
+        self.assertIn('eth0: \'set-name:\' requires \'match:\' properties', str(context.exception))
         self.assertFalse(os.path.isfile(self.path))
 
     def test_set_invalid_validation2(self):
@@ -134,9 +132,9 @@ class TestSet(unittest.TestCase):
       mode: sit
       local: 1.2.3.4
       remote: 5.6.7.8''')
-        err = self._set(['tunnels.tun0.keys.input=12345'])
-        self.assertIsInstance(err, Exception)
-        self.assertIn('tun0: \'input-key\' is not required for this tunnel type', str(err))
+        with self.assertRaises(Exception) as context:
+            self._set(['tunnels.tun0.keys.input=12345'])
+        self.assertIn('tun0: \'input-key\' is not required for this tunnel type', str(context.exception))
 
     def test_set_append(self):
         with open(self.path, 'w') as f:
@@ -220,9 +218,9 @@ class TestSet(unittest.TestCase):
             f.write('''network:\n  version: 2\n  renderer: NetworkManager
   ethernets:
     eth0: {addresses: [1.2.3.4]}''')
-        err = self._set(['ethernets.eth0.addresses'])
-        self.assertIsInstance(err, Exception)
-        self.assertEquals('Invalid value specified', str(err))
+        with self.assertRaises(Exception) as context:
+            self._set(['ethernets.eth0.addresses'])
+        self.assertEquals('Invalid value specified', str(context.exception))
 
     def test_set_escaped_dot(self):
         self._set([r'ethernets.eth0\.123.dhcp4=false'])
@@ -231,9 +229,11 @@ class TestSet(unittest.TestCase):
             self.assertIn('network:\n  ethernets:\n    eth0.123:\n      dhcp4: false', f.read())
 
     def test_set_invalid_input(self):
-        err = self._set([r'ethernets.eth0={dhcp4:false}'])
-        self.assertIsInstance(err, Exception)
-        self.assertEquals('Invalid input: {\'network\': {\'ethernets\': {\'eth0\': {\'dhcp4:false\': None}}}}', str(err))
+        with self.assertRaises(Exception) as context:
+            self._set([r'ethernets.eth0={dhcp4:false}'])
+        self.assertEquals(
+                'Invalid input: {\'network\': {\'ethernets\': {\'eth0\': {\'dhcp4:false\': None}}}}',
+                str(context.exception))
 
     def test_set_override_existing_file(self):
         override = os.path.join(self.workdir.name, 'etc', 'netplan', 'some-file.yaml')


### PR DESCRIPTION
## Description

Previously, trying to unset a whole devtype subtree, such as `netplan set network.ethernets=null` would fail. This PR fixes it by detecting this special case and manually deleting each netdef assigned to the subtype.

This approach is far from being performant, but it has the merit of working without needing too much new code.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Closes an open bug in Launchpad: LP#1942930

