### PR TITLE
feat: mdns configuration

### DIFF
--- a/doc/example-config
+++ b/doc/example-config
@@ -10,6 +10,7 @@ network:
         macaddress: 00:11:22:33:44:55
       wakeonlan: true
       dhcp4: true
+      mdns: true
       addresses:
         - 192.168.14.2/24
         - "2001:1::1/64"

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -428,6 +428,11 @@ similar to ``gateway*``, and ``search:`` is a list of search domains.
               search: [lab, home]
               addresses: [8.8.8.8, "FEDC::1"]
 
+``mdns`` (bool)
+
+:   Enables multicast DNS support. That allows IP address resolution by hostname
+in networks without dedicated DNS server.
+
 ``macaddress`` (scalar)
 
 :   Set the device's MAC address. The MAC address must be in the form
@@ -910,7 +915,7 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
           the ``band`` property is also set.
 
      ``hidden`` (bool) – since **0.100**
-     :    Set to ``true`` to change the SSID scan technique for connecting to 
+     :    Set to ``true`` to change the SSID scan technique for connecting to
           hidden WiFi networks. Note this may have slower performance compared
           to ``false`` (the default) when connecting to publicly broadcast
           SSIDs.

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -687,6 +687,8 @@ write_network_file(const NetplanNetDefinition* def, const char* rootdir, const c
     if (def->ip6_nameservers)
         for (unsigned i = 0; i < def->ip6_nameservers->len; ++i)
             g_string_append_printf(network, "DNS=%s\n", g_array_index(def->ip6_nameservers, char*, i));
+    if (def->mdns)
+        g_string_append_printf(network, "MulticastDNS=yes\n");
     if (def->search_domains) {
         g_string_append_printf(network, "Domains=%s", g_array_index(def->search_domains, char*, 0));
         for (unsigned i = 1; i < def->search_domains->len; ++i)

--- a/src/nm.c
+++ b/src/nm.c
@@ -608,6 +608,8 @@ write_nm_conf_access_point(NetplanNetDefinition* def, const char* rootdir, const
         uuid_unparse(def->uuid, uuidstr);
         g_key_file_set_string(kf, "connection", "uuid", uuidstr);
     }
+    if (def->mdns)
+        g_key_file_set_string(kf, "connection", "mdns", "yes");
 
     if (def->activation_mode) {
         /* XXX: For now NetworkManager only supports the "manual" activation

--- a/src/parse.c
+++ b/src/parse.c
@@ -2252,6 +2252,7 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"macaddress", YAML_SCALAR_NODE, handle_netdef_mac, NULL, netdef_offset(set_mac)},        \
     {"mtu", YAML_SCALAR_NODE, handle_netdef_guint, NULL, netdef_offset(mtubytes)},            \
     {"nameservers", YAML_MAPPING_NODE, NULL, nameservers_handlers},                           \
+    {"mdns", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(mdns)},                \
     {"optional", YAML_SCALAR_NODE, handle_netdef_bool, NULL, netdef_offset(optional)},        \
     {"optional-addresses", YAML_SEQUENCE_NODE, handle_optional_addresses},                    \
     {"renderer", YAML_SCALAR_NODE, handle_netdef_renderer},                                   \

--- a/src/types.h
+++ b/src/types.h
@@ -200,6 +200,7 @@ struct net_definition {
     char* gateway6;
     GArray* ip4_nameservers;
     GArray* ip6_nameservers;
+    gboolean mdns;
     GArray* search_domains;
     GArray* routes;
     GArray* ip_rules;


### PR DESCRIPTION
Fix for [\#1830507](https://bugs.launchpad.net/netplan/+bug/1830507)

## Description
Adds mdns boolean flag for all connection types, which enables multicast DNS support on specific link

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`). (Actually 53%, same as before changes)
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

