### PR TITLE
Consolidate the YAML parsing into libnetplan: low-hanging fruits (FR-702)

### DIFF
--- a/netplan/cli/commands/info.py
+++ b/netplan/cli/commands/info.py
@@ -62,7 +62,7 @@ class NetplanInfo(utils.NetplanCommand):
 
         elif self.version_format == 'yaml':
             print('''netplan.io:
-  website: "https://netplan.io"
-  features:''')
+  website: "{}"
+  features:'''.format(netplan_version['netplan.io']['website']))
             for feature in netplan._features.NETPLAN_FEATURE_FLAGS:
                 print('  - ' + feature)

--- a/netplan/cli/commands/info.py
+++ b/netplan/cli/commands/info.py
@@ -61,5 +61,8 @@ class NetplanInfo(utils.NetplanCommand):
             print(json.dumps(netplan_version, indent=2))
 
         elif self.version_format == 'yaml':
-            import yaml
-            print(yaml.dump(netplan_version, indent=2, default_flow_style=False))
+            print('''netplan.io:
+  website: "https://netplan.io"
+  features:''')
+            for feature in netplan._features.NETPLAN_FEATURE_FLAGS:
+                print('  - ' + feature)

--- a/netplan/cli/commands/migrate.py
+++ b/netplan/cli/commands/migrate.py
@@ -22,7 +22,11 @@ import os
 import sys
 import re
 from glob import glob
-import yaml
+try:
+    import yaml
+    NO_YAML = False
+except ImportError:  # pragma: nocover
+    NO_YAML = True
 from collections import OrderedDict
 import ipaddress
 
@@ -30,7 +34,6 @@ import netplan.cli.utils as utils
 
 
 class NetplanMigrate(utils.NetplanCommand):
-
     def __init__(self):
         super().__init__(command_id='migrate',
                          description='Migration of /etc/network/interfaces to netplan',
@@ -108,6 +111,10 @@ class NetplanMigrate(utils.NetplanCommand):
         self.func = self.command_migrate
 
         self.parse_args()
+        if NO_YAML:  # pragma: nocover
+            logging.error("""The `yaml` Python package couldn't be imported, and is needed for the migrate command.
+To install it on Debian or Ubuntu-based system, run `apt install python3-yaml`""")
+            sys.exit(1)
         self.run_command()
 
     def command_migrate(self):


### PR DESCRIPTION
## Description

Until now, we parsed the YAML configuration at different places in the program:

* libnetplan, where we have most of our business logic, and where we implement data verification
* the `netplan set` command, where we parse the YAML tree to do some syntactical merging of the trees without looking too much into the semantics
* `configmanager.py` + `sriov.py` where we have some business logic to be able to configure the SRIOV backend on the fly.
* `netplan migrate`, which isn't supposed to be used in normal circumstances

Additionally, we use PyYAML in `netplan info` to easily generate well-formed YAML data from a Python dict.

This PR removes the `migrate` and `info` use cases, the other cases will have their own PRs in order to keep review complexity somewhat manageable.

### Why?

There are a couple of advantages to this new approach:

* Single point of validation: whenever we want to parse some configuration, we'll be able to validate the new configuration in a consistent manner
* Smaller dependency tree: netplan is intended for all sorts of use-case, including some where disk size is a real constraint. python3-yaml has an unpacked size of 0.5 Mo, which can now be shaved off.
* Better APIs: this is more of a by-product, but doing this forced us to implement proper APIs for libnetplan ;-)

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).

