### PR TITLE
cli:apply: initialize self.state (LP: #1949104)

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -44,6 +44,7 @@ class NetplanApply(utils.NetplanCommand):
                          leaf=True)
         self.sriov_only = False
         self.only_ovs_cleanup = False
+        self.state = None  # to be filled by the '--state' argument
 
     def run(self):  # pragma: nocover (covered in autopkgtest)
         self.parser.add_argument('--sriov-only', action='store_true',


### PR DESCRIPTION
## Description
The `self.state` attribute needs to be available even if NetplanApply() is not executed via the command line (and thus the `run()` method is not executed).

Fixes a regression in #231

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad: LP#1949104

