### PR TITLE
Disable temporary address generation when renderer is NetworkManager (LP: #1948027) – change in behavior

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -819,6 +819,8 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
             g_key_file_set_string(kf, "ipv6", "addr-gen-mode", addr_gen_mode_str(def->ip6_addr_gen_mode));
         if (def->ip6_privacy)
             g_key_file_set_integer(kf, "ipv6", "ip6-privacy", 2);
+        else
+            g_key_file_set_integer(kf, "ipv6", "ip6-privacy", 0);
         if (def->gateway6)
             g_key_file_set_string(kf, "ipv6", "gateway", def->gateway6);
         if (def->ip6_nameservers) {

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -76,7 +76,7 @@ ND_WITHIPGW = '[Match]\nName=%s\n\n[Network]\nLinkLocalAddressing=ipv6\nAddress=
 ConfigureWithoutCarrier=yes\n'
 NM_WG = '[connection]\nid=netplan-wg0\ntype=wireguard\ninterface-name=wg0\n\n[wireguard]\nprivate-key=%s\nlisten-port=%s\n%s\
 \n\n[ipv4]\nmethod=manual\naddress1=15.15.15.15/24\ngateway=20.20.20.21\n\n[ipv6]\nmethod=manual\naddress1=\
-2001:de:ad:be:ef:ca:fe:1/128\n'
+2001:de:ad:be:ef:ca:fe:1/128\nip6-privacy=0\n'
 ND_WG = '[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey%s\nListenPort=%s\n%s\n'
 ND_VLAN = '[NetDev]\nName=%s\nKind=vlan\n\n[VLAN]\nId=%d\n'
 SD_WPA = '''[Unit]

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -1048,6 +1048,7 @@ method=link-local
 
 [ipv6]
 method=auto
+ip6-privacy=0
 '''})
 
     def test_eth_dhcp4_and_6(self):
@@ -1069,6 +1070,7 @@ method=auto
 
 [ipv6]
 method=auto
+ip6-privacy=0
 '''})
 
     def test_ip6_addr_gen_mode(self):
@@ -1096,6 +1098,7 @@ method=link-local
 [ipv6]
 method=auto
 addr-gen-mode=1
+ip6-privacy=0
 ''',
                         'enblue': '''[connection]
 id=netplan-enblue
@@ -1111,6 +1114,7 @@ method=link-local
 [ipv6]
 method=auto
 addr-gen-mode=0
+ip6-privacy=0
 '''})
 
     def test_ip6_addr_gen_token(self):
@@ -1139,6 +1143,7 @@ method=link-local
 method=auto
 addr-gen-mode=0
 token=::2
+ip6-privacy=0
 ''',
                         'enblue': '''[connection]
 id=netplan-enblue
@@ -1155,6 +1160,7 @@ method=link-local
 method=auto
 addr-gen-mode=0
 token=::2
+ip6-privacy=0
 '''})
 
     def test_eth_manual_addresses(self):
@@ -1184,6 +1190,7 @@ address2=172.16.0.4/16
 [ipv6]
 method=manual
 address1=2001:FFfe::1/64
+ip6-privacy=0
 '''})
         self.assert_networkd({})
         self.assert_nm_udev(None)
@@ -1214,6 +1221,7 @@ address1=192.168.14.2/24
 [ipv6]
 method=manual
 address1=2001:FFfe::1/64
+ip6-privacy=0
 '''})
 
     def test_eth_ipv6_privacy(self):
@@ -1264,6 +1272,7 @@ gateway=192.168.14.1
 [ipv6]
 method=manual
 address1=2001:FFfe::1/64
+ip6-privacy=0
 gateway=2001:FFfe::2
 '''})
 
@@ -1298,6 +1307,7 @@ dns-search=lab;kitchen;
 
 [ipv6]
 method=manual
+ip6-privacy=0
 dns=1234::FFFF;
 dns-search=lab;kitchen;
 ''',

--- a/tests/generator/test_dhcp_overrides.py
+++ b/tests/generator/test_dhcp_overrides.py
@@ -422,5 +422,6 @@ method=auto
 
 [ipv6]
 method=auto
+ip6-privacy=0
 route-metric=6666
 '''})

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -844,6 +844,7 @@ method=link-local
 [ipv6]
 method=manual
 address1=2001:f00f:f00f::2/64
+ip6-privacy=0
 route1=2001:dead:beef::2/64,2001:beef:beef::1
 '''})
 
@@ -875,6 +876,7 @@ method=link-local
 [ipv6]
 method=manual
 address1=2001:f00f:f00f::2/64
+ip6-privacy=0
 route1=2001:dead:beef::2/64,2001:beef:beef::1
 route2=2001:dead:feed::2/64,2001:beef:beef::2,1000
 '''})
@@ -904,6 +906,7 @@ method=link-local
 [ipv6]
 method=manual
 address1=2001:dead:beef::2/64
+ip6-privacy=0
 route1=::/0,2001:beef:beef::1
 '''})
 
@@ -948,6 +951,7 @@ route3=11.11.11.0/24,192.168.1.3,9999
 [ipv6]
 method=manual
 address1=2001:f00f::2/128
+ip6-privacy=0
 route1=2001:dead:beef::2/64,2001:beef:beef::1,997
 route2=2001:f00f:f00f::fe/64,2001:beef:feed::1
 '''})
@@ -1272,6 +1276,7 @@ method=auto
 
 [ipv6]
 method=auto
+ip6-privacy=0
 ignore-auto-routes=true
 never-default=true
 '''})
@@ -1302,6 +1307,7 @@ route-metric=4000
 
 [ipv6]
 method=auto
+ip6-privacy=0
 '''})
 
     def test_default_metric_v6(self):
@@ -1329,5 +1335,6 @@ method=auto
 
 [ipv6]
 method=auto
+ip6-privacy=0
 route-metric=5050
 '''})

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -408,6 +408,7 @@ gateway=20.20.20.21
 [ipv6]
 method=manual
 address1=2001:de:ad:be:ef:ca:fe:1/128
+ip6-privacy=0
 ''',
                             'br0.nmconnection': '''[connection]
 id=netplan-br0
@@ -977,6 +978,7 @@ gateway=1.1.1.254
 [ipv6]
 method=manual
 address1=2001:cafe:face::1/64
+ip6-privacy=0
 ''',
                         'he-ipv6': '''[connection]
 id=netplan-he-ipv6
@@ -994,6 +996,7 @@ method=disabled
 [ipv6]
 method=manual
 address1=2001:dead:beef::2/64
+ip6-privacy=0
 gateway=2001:dead:beef::1
 '''})
 

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -203,6 +203,7 @@ method=link-local
 
 [ipv6]
 method=auto
+ip6-privacy=0
 '''})
         self.assert_nm_udev(None)
 

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -302,5 +302,6 @@ method=link-local
 
 [ipv6]
 method=auto
+ip6-privacy=0
 '''})
         self.assert_nm_udev(None)

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -132,6 +132,8 @@ class TestKeyfileBase(unittest.TestCase):
                 # Normalize lines
                 if k == 'addr-gen-mode':
                     v = v.replace('1', 'stable-privacy').replace('0', 'eui64')
+                elif k == 'ip6-privacy' and v == '0':
+                    continue
                 elif k == 'wake-on-lan' and v == '1':
                     continue
                 elif k == 'stp' and v == 'true':

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -68,7 +68,6 @@ method=auto
 
 [ipv6]
 dns-search=
-ip6-privacy=0
 method=auto
 '''.format(UUID))
         self.assert_netplan({UUID: '''network:
@@ -95,7 +94,6 @@ method=auto
           gsm.home-only: "true"
           ipv4.dns-search: ""
           ipv6.dns-search: ""
-          ipv6.ip6-privacy: "0"
 '''.format(UUID, UUID)})
 
     def test_keyfile_cdma(self):
@@ -267,7 +265,6 @@ dns=dead:beef::2;
 method=manual
 address1=1:2:3::9/128
 gateway=6:6::6
-ip6-privacy=0
 route1=dead:beef::1/128,2001:1234::2
 route1_options=unknown=invalid,
 
@@ -319,7 +316,6 @@ route1_options=unknown=invalid,
           ipv4.method: "manual"
           ipv4.address1: "1.2.3.4/24,8.8.8.8"
           ipv6.dns-search: "bar.local"
-          ipv6.ip6-privacy: "0"
           ipv6.route1: "dead:beef::1/128,2001:1234::2"
           ipv6.route1_options: "unknown=invalid,"
           proxy._: ""
@@ -1001,7 +997,6 @@ dns=8.8.8.8;8.8.4.4;8.8.8.8;8.8.4.4;8.8.8.8;8.8.4.4;
 
 [ipv6]
 method=auto
-ip6-privacy=0
 addr-gen-mode=1
 '''.format(UUID))
         self.assert_netplan({UUID: '''network:
@@ -1029,7 +1024,6 @@ addr-gen-mode=1
           ipv4.address1: "10.10.28.159/24"
           ipv4.address2: "10.10.164.254/24"
           ipv4.address3: "10.10.246.132/24"
-          ipv6.ip6-privacy: "0"
           ipv6.addr-gen-mode: "1"
 '''.format(UUID, UUID)})
 
@@ -1065,7 +1059,6 @@ address1=abcd::beef/64
 address2=dcba::beef/56
 dns=1::cafe;2::cafe;
 dns-search=wallaceandgromit.com;
-ip6-privacy=0
 method=manual
 route1=1:2:3:4:5:6:7:8/64,8:7:6:5:4:3:2:1,3
 route2=2001::1000/56,2001::1111,1
@@ -1138,6 +1131,5 @@ route4=5:6:7:8:9:0:1:2/62
           ipv4.route4: "3.3.3.3/6,0.0.0.0,4"
           ipv4.route4_options: "cwnd=10,mtu=1492,src=1.2.3.4"
           ipv6.dns-search: "wallaceandgromit.com;"
-          ipv6.ip6-privacy: "0"
           proxy._: ""
 '''.format(UUID, UUID)})

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -68,6 +68,7 @@ method=auto
 
 [ipv6]
 dns-search=
+ip6-privacy=0
 method=auto
 '''.format(UUID))
         self.assert_netplan({UUID: '''network:
@@ -265,6 +266,7 @@ dns=dead:beef::2;
 method=manual
 address1=1:2:3::9/128
 gateway=6:6::6
+ip6-privacy=0
 route1=dead:beef::1/128,2001:1234::2
 route1_options=unknown=invalid,
 
@@ -997,6 +999,7 @@ dns=8.8.8.8;8.8.4.4;8.8.8.8;8.8.4.4;8.8.8.8;8.8.4.4;
 
 [ipv6]
 method=auto
+ip6-privacy=0
 addr-gen-mode=1
 '''.format(UUID))
         self.assert_netplan({UUID: '''network:
@@ -1059,6 +1062,7 @@ address1=abcd::beef/64
 address2=dcba::beef/56
 dns=1::cafe;2::cafe;
 dns-search=wallaceandgromit.com;
+ip6-privacy=0
 method=manual
 route1=1:2:3:4:5:6:7:8/64,8:7:6:5:4:3:2:1,3
 route2=2001::1000/56,2001::1111,1

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -95,6 +95,7 @@ method=auto
           gsm.home-only: "true"
           ipv4.dns-search: ""
           ipv6.dns-search: ""
+          ipv6.ip6-privacy: "0"
 '''.format(UUID, UUID)})
 
     def test_keyfile_cdma(self):
@@ -318,6 +319,7 @@ route1_options=unknown=invalid,
           ipv4.method: "manual"
           ipv4.address1: "1.2.3.4/24,8.8.8.8"
           ipv6.dns-search: "bar.local"
+          ipv6.ip6-privacy: "0"
           ipv6.route1: "dead:beef::1/128,2001:1234::2"
           ipv6.route1_options: "unknown=invalid,"
           proxy._: ""
@@ -1027,6 +1029,7 @@ addr-gen-mode=1
           ipv4.address1: "10.10.28.159/24"
           ipv4.address2: "10.10.164.254/24"
           ipv4.address3: "10.10.246.132/24"
+          ipv6.ip6-privacy: "0"
           ipv6.addr-gen-mode: "1"
 '''.format(UUID, UUID)})
 
@@ -1135,5 +1138,6 @@ route4=5:6:7:8:9:0:1:2/62
           ipv4.route4: "3.3.3.3/6,0.0.0.0,4"
           ipv4.route4_options: "cwnd=10,mtu=1492,src=1.2.3.4"
           ipv6.dns-search: "wallaceandgromit.com;"
+          ipv6.ip6-privacy: "0"
           proxy._: ""
 '''.format(UUID, UUID)})


### PR DESCRIPTION
…and ipv6-privacy is false


## Description

Fix for https://bugs.launchpad.net/bugs/1948027

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1948027

