### PR TITLE
dbus: wait for 'netplan try' to be ready (LP: #1949893)

### DIFF
--- a/doc/netplan-dbus.md
+++ b/doc/netplan-dbus.md
@@ -24,8 +24,8 @@ netplan-dbus - daemon to access netplan's functionality via a DBus API
 
 The ``/io/netplan/Netplan/config/<ID>`` objects provide a ``io.netplan.Netplan.Config`` interface, offering the following methods:
 
- * ``Get() -> s``: calls **netplan get --root-dir=/tmp/netplan-config-ID all** and returns the merged YAML config of the the given config object's state
- * ``Set(s:CONFIG_DELTA, s:ORIGIN_HINT) -> b``: calls **netplan set --root-dir=/tmp/netplan-config-ID --origin-hint=ORIGIN_HINT CONFIG_DELTA**
+ * ``Get() -> s``: calls **netplan get --root-dir=/run/netplan/config-ID all** and returns the merged YAML config of the the given config object's state
+ * ``Set(s:CONFIG_DELTA, s:ORIGIN_HINT) -> b``: calls **netplan set --root-dir=/run/netplan/config-ID --origin-hint=ORIGIN_HINT CONFIG_DELTA**
 
     CONFIG_DELTA can be something like: ``network.ethernets.eth0.dhcp4=true`` and ORIGIN_HINT can be something like: ``70-snapd`` (it will then write the config to ``70-snapd.yaml``). Once ``Set()`` is called on a config object, all other current and future config objects are being invalidated and cannot ``Set()`` or ``Try()/Apply()`` anymore, due to this pending dirty state. After the dirty config object is rejected via ``Cancel()``, the other config objects are valid again. If the dirty config object is accepted via ``Apply()``, newly created config objects will be valid, while the older states will stay invalid.
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -174,7 +174,7 @@ _clear_tmp_state(const char *config_id, NetplanData *d)
 {
     g_autofree gchar *rootdir = NULL;
     /* Remove tmp YAML files */
-    rootdir = g_strdup_printf("%s/netplan-config-%s", g_get_tmp_dir(), config_id);
+    rootdir = g_strdup_printf("%s/run/netplan/config-%s", NETPLAN_ROOT, config_id);
     unlink_glob(rootdir, "/{etc,run,lib}/netplan/*.yaml");
 
     /* Remove tmp state directories */
@@ -208,7 +208,7 @@ _backup_global_state(sd_bus_error *ret_error)
 {
     int r = 0;
     g_autofree gchar *path = NULL;
-    path = g_strdup_printf("%s/netplan-config-%s", g_get_tmp_dir(), NETPLAN_GLOBAL_CONFIG);
+    path = g_strdup_printf("%s/run/netplan/config-%s", NETPLAN_ROOT, NETPLAN_GLOBAL_CONFIG);
     /* Create {etc,run,lib} subdirs with owner r/w permissions */
     char *subdir = NULL;
     for (int i = 0; i < 3; i++) {
@@ -246,7 +246,7 @@ method_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     if (d->try_pid > 0)
         return _try_accept(TRUE, m, userdata, ret_error);
     if (d->config_id)
-        state = g_strdup_printf("--state=%s/netplan-config-%s", g_get_tmp_dir(), NETPLAN_GLOBAL_CONFIG);
+        state = g_strdup_printf("--state=%s/run/netplan/config-%s", NETPLAN_ROOT, NETPLAN_GLOBAL_CONFIG);
     gchar *argv[] = {SBINDIR "/" "netplan", "apply", state, NULL};
 
     // for tests only: allow changing what netplan to run
@@ -361,7 +361,7 @@ method_get(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     gint exit_status = 0;
 
     if (d->config_id)
-        root_dir = g_strdup_printf("--root-dir=%s/netplan-config-%s", g_get_tmp_dir(), d->config_id);
+        root_dir = g_strdup_printf("--root-dir=%s/run/netplan/config-%s", NETPLAN_ROOT, d->config_id);
     gchar *argv[] = {SBINDIR "/" "netplan", "get", "all", root_dir, NULL};
 
     // for tests only: allow changing what netplan to run
@@ -408,7 +408,7 @@ method_set(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     }
 
     if (d->config_id) {
-        root_dir = g_strdup_printf("--root-dir=%s/netplan-config-%s", g_get_tmp_dir(), d->config_id);
+        root_dir = g_strdup_printf("--root-dir=%s/run/netplan/config-%s", NETPLAN_ROOT, d->config_id);
         args[cur_arg] = root_dir;
         cur_arg++;
     }
@@ -443,7 +443,7 @@ netplan_try_cancelled_cb(sd_event_source *es, const siginfo_t *si, void* userdat
         /* Delete GLOBAL state */
         unlink_glob(NETPLAN_ROOT, "/{etc,run,lib}/netplan/*.yaml");
         /* Restore GLOBAL backup config state to main rootdir */
-        state_dir = g_strdup_printf("%s/netplan-config-%s", g_get_tmp_dir(), NETPLAN_GLOBAL_CONFIG);
+        state_dir = g_strdup_printf("%s/run/netplan/config-%s", NETPLAN_ROOT, NETPLAN_GLOBAL_CONFIG);
         _copy_yaml_state(state_dir, NETPLAN_ROOT, NULL);
 
         /* Un-invalidate all other current config objects */
@@ -480,7 +480,7 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     if (seconds > 0)
         timeout = g_strdup_printf("--timeout=%u", seconds);
     if (d->config_id)
-        state = g_strdup_printf("--state=%s/netplan-config-%s", g_get_tmp_dir(), NETPLAN_GLOBAL_CONFIG);
+        state = g_strdup_printf("--state=%s/run/netplan/config-%s", NETPLAN_ROOT, NETPLAN_GLOBAL_CONFIG);
     gchar *argv[] = {SBINDIR "/" "netplan", "try", timeout, state, NULL};
 
     // for tests only: allow changing what netplan to run
@@ -488,7 +488,7 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
        argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
 
     /* Delete any left-over netplan-try.ready stamp file, if it exists */
-    netplan_try_stamp = g_build_path("/", NETPLAN_ROOT, "run", "netplan-try.ready", NULL);
+    netplan_try_stamp = g_build_path("/", NETPLAN_ROOT, "run", "netplan", "netplan-try.ready", NULL);
     unlink(netplan_try_stamp);
     /* Launch 'netplan try' child process, lock 'try_pid' to real PID */
     g_spawn_async_with_pipes("/", argv, NULL,
@@ -558,7 +558,7 @@ method_config_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
         /* Delete GLOBAL state */
         unlink_glob(NETPLAN_ROOT, "/{etc,run,lib}/netplan/*.yaml");
         /* Copy current config state to GLOBAL */
-        state_dir = g_strdup_printf("%s/netplan-config-%s", g_get_tmp_dir(), d->config_id);
+        state_dir = g_strdup_printf("%s/run/netplan/config-%s", NETPLAN_ROOT, d->config_id);
         _copy_yaml_state(state_dir, NETPLAN_ROOT, ret_error);
         d->handler_id = g_strdup(d->config_id);
     }
@@ -633,7 +633,7 @@ method_config_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     unlink_glob(NETPLAN_ROOT, "/{etc,run,lib}/netplan/*.yaml");
 
     /* Copy current config *.yaml state to main rootdir (i.e. /etc/netplan/) */
-    state_dir = g_strdup_printf("%s/netplan-config-%s", g_get_tmp_dir(), d->config_id);
+    state_dir = g_strdup_printf("%s/run/netplan/config-%s", NETPLAN_ROOT, d->config_id);
     _copy_yaml_state(state_dir, NETPLAN_ROOT, ret_error);
 
     /* Exec try */
@@ -664,7 +664,7 @@ method_config_cancel(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
         /* Delete GLOBAL state */
         unlink_glob(NETPLAN_ROOT, "/{etc,run,lib}/netplan/*.yaml");
         /* Restore GLOBAL backup config state to main rootdir */
-        state_dir = g_strdup_printf("%s/netplan-config-%s", g_get_tmp_dir(), NETPLAN_GLOBAL_CONFIG);
+        state_dir = g_strdup_printf("%s/run/netplan/config-%s", NETPLAN_ROOT, NETPLAN_GLOBAL_CONFIG);
         _copy_yaml_state(state_dir, NETPLAN_ROOT, ret_error);
 
         /* Clear GLOBAL backup and config state */
@@ -701,15 +701,20 @@ method_config(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     NetplanData *d = userdata;
     sd_bus_slot *slot = NULL;
     g_autoptr(GError) err = NULL;
-    g_autofree gchar *path = NULL;
+    g_autofree gchar *tmpl = NULL;
+    g_autofree gchar *dir = NULL;
+    gchar *path = NULL;
     int r = 0;
 
-    /* Create temp. directory, according to "netplan-config-XXXXXX" template */
-    path = g_dir_make_tmp("netplan-config-XXXXXX", &err);
-    if (err != NULL)
+    /* Create state directory, according to "run/netplan/config-XXXXXX" template */
+    tmpl = g_build_path("/", NETPLAN_ROOT, "run", "netplan", "config-XXXXXX", NULL);
+    dir = g_path_get_dirname(tmpl);
+    r = g_mkdir_with_parents(dir, 0700);
+    path = g_mkdtemp(tmpl); // returns pointer to tmpl (with modified string)
+    if (r < 0 || !path)
         // LCOV_EXCL_START
         return sd_bus_error_setf(ret_error, SD_BUS_ERROR_FAILED,
-                                 "Failed to create temp dir: %s\n", err->message);
+                                 "Failed to create temp dir: %s\n", strerror(errno));
         // LCOV_EXCL_STOP
 
     /* Extract the last 6 randomly generated chars (i.e. "XXXXXX" from template) */

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -488,7 +488,7 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
        argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
 
     /* Delete any left-over netplan-try.ready stamp file, if it exists */
-    netplan_try_stamp = g_build_path("/", g_get_tmp_dir(), "netplan-try.ready", NULL);
+    netplan_try_stamp = g_build_path("/", NETPLAN_ROOT, "run", "netplan-try.ready", NULL);
     unlink(netplan_try_stamp);
     /* Launch 'netplan try' child process, lock 'try_pid' to real PID */
     g_spawn_async_with_pipes("/", argv, NULL,
@@ -511,7 +511,7 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
                                  "cannot watch 'netplan try' child: %s", strerror(-r));
         // LCOV_EXCL_STOP
 
-    /* wait for the /tmp/netplan-try.ready stamp file to appear */
+    /* wait for the /run/netplan/netplan-try.ready stamp file to appear */
     guint poll_timeout = 500;
     if (seconds > 0 && seconds < 5)
         poll_timeout = seconds * 100;

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -332,7 +332,6 @@ class TestNetplanDBus(unittest.TestCase):
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
-        print(self.mock_netplan_cmd.calls(), flush=True)
         self.assertEquals(self.mock_netplan_cmd.calls(), [[
             "netplan", "set", "ethernets.eth42.dhcp6=true",
             "--root-dir={}".format(tmpdir)

--- a/tests/test_cli_units.py
+++ b/tests/test_cli_units.py
@@ -17,11 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import unittest
 import subprocess
 
 from unittest.mock import patch
 from netplan.cli.commands.apply import NetplanApply
+from netplan.cli.commands.try_command import NetplanTry
 
 
 class TestCLI(unittest.TestCase):
@@ -79,3 +81,10 @@ class TestCLI(unittest.TestCase):
             self.assertEquals(res, [])
             self.assertEqual(ctx.output, ['WARNING:root:Cannot clear virtual links: no network interfaces provided.'])
         mock.assert_not_called()
+
+    def test_netplan_try_ready_stamp(self):
+        self.assertFalse(os.path.isfile('/tmp/netplan-try.ready'))
+        NetplanTry.touch_ready_stamp()
+        self.assertTrue(os.path.isfile('/tmp/netplan-try.ready'))
+        NetplanTry.clear_ready_stamp()
+        self.assertFalse(os.path.isfile('/tmp/netplan-try.ready'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,6 +68,10 @@ printf '\\0' >> %(log)s
         with open(self.path, "a") as fp:
             fp.write("cat << EOF\n%s\nEOF" % output)
 
+    def touch(self, stamp_path):
+        with open(self.path, "a") as fp:
+            fp.write("touch %s\n" % stamp_path)
+
     def set_timeout(self, timeout_dsec=10):
         with open(self.path, "a") as fp:
             fp.write("""


### PR DESCRIPTION
## Description
netplan-dbus now waits for the spawned 'netplan try' child to touch the `/run/netplan/netplan-try.ready` stamp file before it returns the DBus call. If no stamp file is detected within up to 5 sec it hits a timeout and returns an error.

Additionally, this PR places ephemeral netplan configs in `/run/netplan/config-XXXXXX`, to avoid potential exploits of tmpfiles, like https://lwn.net/Articles/250468/

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1949893

