### PR TITLE
get/set: ignore empty YAML hints and delete files on "set network=null" (LP: #1946957)

### DIFF
--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -191,8 +191,11 @@ class NetplanSet(utils.NetplanCommand):
             # Valid, move it to final destination
             shutil.copy2(tmpp, absp)
             os.remove(tmpp)
-        elif os.path.isfile(absp):
-            # Clear file if the last/only key got removed
-            os.remove(absp)
-        else:
+        elif stripped == {}:
+            # Clear file (if it exists) if the last/only key got removed
+            # do nothing otherwise
+            logging.debug('Removed last key from YAML, deleting file {}'.format(absp))
+            if os.path.isfile(absp):
+                os.remove(absp)
+        else:  # pragma nocover
             raise Exception('Invalid input: {}'.format(set_tree))

--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -149,7 +149,8 @@ class NetplanSet(utils.NetplanCommand):
 
         config = {'network': {}}
         absp = os.path.join(rootdir, path, name)
-        if os.path.isfile(absp):
+        # check stat(absp), as we don't care about empty hint files
+        if os.path.isfile(absp) and os.stat(absp).st_size > 0:
             with open(absp, 'r') as f:
                 config = yaml.safe_load(f)
 

--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -171,7 +171,9 @@ class NetplanSet(utils.NetplanCommand):
         # check stat(absp), as we don't care about empty hint files
         if os.path.isfile(absp) and os.stat(absp).st_size > 0:
             with open(absp, 'r') as f:
-                config = yaml.safe_load(f)
+                c = yaml.safe_load(f)
+                if c is not None:  # ignore empty file, even if it contains whitespace
+                    config = c
 
         new_tree = self.merge(config, set_tree)
         stripped = ConfigManager.strip_tree(new_tree)

--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -178,7 +178,9 @@ class NetplanSet(utils.NetplanCommand):
         logging.debug('Writing file {}: {}'.format(name, stripped))
         if 'network' in stripped and list(stripped['network'].keys()) == ['version']:
             # Clear file if only 'network: {version: 2}' is left
-            os.remove(absp)
+            logging.debug('Empty YAML, deleting file {}'.format(absp))
+            if os.path.isfile(absp):
+                os.remove(absp)
         elif 'network' in stripped:
             tmpp = os.path.join(tmproot.name, path, name)
             with open(tmpp, 'w+') as f:

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -127,6 +127,11 @@ class TestSet(unittest.TestCase):
         self._set(['network=null', '--origin-hint=00-no-exist'])
         self.assertFalse(os.path.isfile(not_a_file))
 
+    def test_unset_non_existing_hint(self):
+        not_a_file = os.path.join(self.workdir.name, 'etc', 'netplan', '00-no-exist.yaml')
+        self._set(['network.ethernets=null', '--origin-hint=00-no-exist'])
+        self.assertFalse(os.path.isfile(not_a_file))
+
     def test_set_network_null_hint_rm(self):
         some_hint = os.path.join(self.workdir.name, 'etc', 'netplan', '00-some-hint.yaml')
         with open(some_hint, 'w') as f:
@@ -277,13 +282,6 @@ class TestSet(unittest.TestCase):
         self.assertTrue(os.path.isfile(self.path))
         with open(self.path, 'r') as f:
             self.assertIn('network:\n  ethernets:\n    eth0.123:\n      dhcp4: false', f.read())
-
-    def test_set_invalid_input(self):
-        with self.assertRaises(Exception) as context:
-            self._set([r'ethernets.eth0={dhcp4:false}'])
-        self.assertEquals(
-                'Invalid input: {\'network\': {\'ethernets\': {\'eth0\': {\'dhcp4:false\': None}}}}',
-                str(context.exception))
 
     def test_set_override_existing_file(self):
         override = os.path.join(self.workdir.name, 'etc', 'netplan', 'some-file.yaml')

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -53,7 +53,8 @@ class TestSet(unittest.TestCase):
 
     def _set(self, args):
         args.insert(0, 'set')
-        return _call_cli(args + ['--root-dir', self.workdir.name])
+        out = _call_cli(args + ['--root-dir', self.workdir.name])
+        self.assertEqual(out, '', msg='netplan set returned unexpected output')
 
     def test_set_scalar(self):
         self._set(['ethernets.eth0.dhcp4=true'])
@@ -222,8 +223,7 @@ class TestSet(unittest.TestCase):
   version: 2
   ethernets:
     ens3: {dhcp4: yes}''')
-        out = self._set(['network.ethernets.ens3=NULL'])
-        print(out, flush=True)
+        self._set(['network.ethernets.ens3=NULL'])
         # The file should be deleted if only "network: {version: 2}" is left
         self.assertFalse(os.path.isfile(self.path))
 

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -116,11 +116,18 @@ class TestSet(unittest.TestCase):
 
     def test_set_empty_hint_file(self):
         empty_file = os.path.join(self.workdir.name, 'etc', 'netplan', '00-empty.yaml')
-        open(empty_file, 'w').close()  # touch empty file
+        open(empty_file, 'w').close()  # touch 00-empty.yaml
         self._set(['ethernets.eth0.dhcp4=true', '--origin-hint=00-empty'])
         self.assertTrue(os.path.isfile(empty_file))
         with open(empty_file, 'r') as f:
             self.assertIn('network:\n  ethernets:\n    eth0:\n      dhcp4: true', f.read())
+
+    def test_set_empty_hint_file_whitespace(self):
+        empty_file = os.path.join(self.workdir.name, 'etc', 'netplan', '00-empty.yaml')
+        with open(empty_file, 'w') as f:
+            f.write('\n')  # echo "" > 00-empty.yaml
+        self._set(['ethernets.eth0=null', '--origin-hint=00-empty'])
+        self.assertFalse(os.path.isfile(empty_file))
 
     def test_set_network_null_hint(self):
         not_a_file = os.path.join(self.workdir.name, 'etc', 'netplan', '00-no-exist.yaml')

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -113,6 +113,14 @@ class TestSet(unittest.TestCase):
             self._set(['ethernets.eth0.dhcp4=true', '--origin-hint='])
         self.assertTrue('Invalid/empty origin-hint' in str(context.exception))
 
+    def test_set_empty_hint_file(self):
+        empty_file = os.path.join(self.workdir.name, 'etc', 'netplan', '00-empty.yaml')
+        open(empty_file, 'w').close()  # touch empty file
+        self._set(['ethernets.eth0.dhcp4=true', '--origin-hint=00-empty'])
+        self.assertTrue(os.path.isfile(empty_file))
+        with open(empty_file, 'r') as f:
+            self.assertIn('network:\n  ethernets:\n    eth0:\n      dhcp4: true', f.read())
+
     def test_set_invalid(self):
         with self.assertRaises(Exception) as context:
             self._set(['xxx.yyy=abc'])


### PR DESCRIPTION
## Description
This PR contains several improvements wrt. the handling of YAML hint files, as used by the `netplan set` CLI.
* If a `--origin-hint` is specified, that already exists as an empty file, that file is ignored.
* If `netplan set network=null [--origin-hint FILE]` is executed, a special handler makes sure that either the specified origin hint file is remove, or all files in `etc/netplan/*.yaml` are cleared otherwise.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1946957

