### PR TITLE
keyfile: do not try to write out unvalidated YAML (LP: #1952967)

### DIFF
--- a/src/abi_compat.c
+++ b/src/abi_compat.c
@@ -272,7 +272,10 @@ _write_netplan_conf(const char* netdef_id, const char* rootdir)
     const NetplanNetDefinition* def = NULL;
     ht = netplan_finish_parse(NULL);
     def = g_hash_table_lookup(ht, netdef_id);
-    write_netplan_conf(def, rootdir);
+    if (def)
+        write_netplan_conf(def, rootdir);
+    else
+        g_warning("_write_netplan_conf: netdef_id (%s) not found.", netdef_id); // LCOV_EXCL_LINE
 }
 
 /**

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -46,8 +46,10 @@ type_from_str(const char* type_str)
         return NETPLAN_DEF_TYPE_BRIDGE;
     else if (!g_strcmp0(type_str, "bond"))
         return NETPLAN_DEF_TYPE_BOND;
+    /* TODO: Vlans are not yet fully supported by the keyfile parser
     else if (!g_strcmp0(type_str, "vlan"))
         return NETPLAN_DEF_TYPE_VLAN;
+    */
     /* TODO: Tunnels are not yet supported by the keyfile parser
     else if (!g_strcmp0(type_str, "ip-tunnel") || !g_strcmp0(type_str, "wireguard"))
         return NETPLAN_DEF_TYPE_TUNNEL;
@@ -499,8 +501,7 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
         || nd_type == NETPLAN_DEF_TYPE_WIFI
         || nd_type == NETPLAN_DEF_TYPE_MODEM
         || nd_type == NETPLAN_DEF_TYPE_BRIDGE
-        || nd_type == NETPLAN_DEF_TYPE_BOND
-        || nd_type == NETPLAN_DEF_TYPE_VLAN)
+        || nd_type == NETPLAN_DEF_TYPE_BOND)
         _kf_clear_key(kf, "connection", "type");
 
     /* Handle match: Netplan usually defines a connection per interface, while

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -25,6 +25,7 @@
 #include "util.h"
 #include "types.h"
 #include "util-internal.h"
+#include "validation.h"
 
 /**
  * NetworkManager writes the alias for '802-3-ethernet' (ethernet),
@@ -751,5 +752,11 @@ only_passthrough:
     }
 
     g_key_file_free(kf);
+
+    /* validate definition-level conditions */
+    if (!npp->missing_id)
+        npp->missing_id = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, g_free);
+    if (!validate_netdef_grammar(npp, nd, NULL, error))
+        return FALSE;
     return TRUE;
 }

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -48,8 +48,10 @@ type_from_str(const char* type_str)
         return NETPLAN_DEF_TYPE_BOND;
     else if (!g_strcmp0(type_str, "vlan"))
         return NETPLAN_DEF_TYPE_VLAN;
+    /* TODO: Tunnels are not yet supported by the keyfile parser
     else if (!g_strcmp0(type_str, "ip-tunnel") || !g_strcmp0(type_str, "wireguard"))
         return NETPLAN_DEF_TYPE_TUNNEL;
+    */
     /* Unsupported type, needs to be specified via passthrough */
     return NETPLAN_DEF_TYPE_NM;
 }

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -150,7 +150,9 @@ class TestKeyfileBase(unittest.TestCase):
         argv = [exe_generate, '--root-dir', self.workdir.name]
         p = subprocess.Popen(argv, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, universal_newlines=True)
+        returncode = p.wait(5)
         (out, err) = p.communicate()
+        self.assertEqual(returncode, 0, err)
         self.assertEqual(out, '')
         con_dir = os.path.join(self.workdir.name, 'run', 'NetworkManager', 'system-connections')
         if file_contents_map:

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -106,7 +106,7 @@ class TestKeyfileBase(unittest.TestCase):
                     return err.contents.message.decode('utf-8')
             else:
                 self.assertTrue(lib.netplan_parse_keyfile(f.encode(), ctypes.byref(err)))
-                if err:  # pragma: nocover (this case should never happen)
+                if err:  # pragma: nocover (only happens if a test fails so irrelevant for coverage)
                     return err.contents.message.decode('utf-8')
                 # If the original file does not have a standard netplan-*.nmconnection
                 # filename it is being deleted in favor of the newly generated file.

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -358,7 +358,7 @@ route1_options=unknown=invalid,
         self._template_keyfile_type('bonds', 'bond')
 
     def test_keyfile_type_vlan(self):
-        self._template_keyfile_type('vlans', 'vlan')
+        self._template_keyfile_type('nm-devices', 'vlan', False)
 
     def test_keyfile_type_tunnel(self):
         self._template_keyfile_type('nm-devices', 'ip-tunnel', False)
@@ -782,21 +782,24 @@ address1=1.2.3.4/24
 
 [ipv6]
 method=ignore
-'''.format(UUID), netdef_id='enblue', expect_fail=False, filename="some.keyfile")
+'''.format(UUID))
         self.assert_netplan({UUID: '''network:
   version: 2
-  vlans:
-    enblue:
+  nm-devices:
+    NM-{}:
       renderer: NetworkManager
-      addresses:
-      - "1.2.3.4/24"
-      id: 1
       networkmanager:
         uuid: "{}"
         name: "netplan-enblue"
         passthrough:
+          connection.type: "vlan"
+          connection.interface-name: "enblue"
+          vlan.id: "1"
           vlan.parent: "en1"
-'''.format(UUID)})
+          ipv4.method: "manual"
+          ipv4.address1: "1.2.3.4/24"
+          ipv6.method: "ignore"
+'''.format(UUID, UUID)})
 
     def test_keyfile_bridge(self):
         self.generate_from_keyfile('''[connection]

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -202,7 +202,6 @@ route-metric=4242
 
 [ipv6]
 addr-gen-mode=eui64
-token=1234::3
 dns-search=
 method=auto
 ignore-auto-routes=true
@@ -227,7 +226,6 @@ route-metric=4242
         route-metric: 4242
       macaddress: "00:11:22:33:44:55"
       ipv6-address-generation: "eui64"
-      ipv6-address-token: "1234::3"
       mtu: 1500
       networkmanager:
         uuid: "{}"

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -903,7 +903,7 @@ method=auto
 
 [ipv6]
 method=ignore
-'''.format(UUID), netdef_id='bn0')
+'''.format(UUID), netdef_id='bn0', expect_fail=False, filename='some.keyfile')
         self.assert_netplan({UUID: '''network:
   version: 2
   bonds:

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -236,6 +236,25 @@ route-metric=4242
           proxy._: ""
 '''.format(UUID, UUID)})
 
+    def test_keyfile_fail_validation(self):
+        err = self.generate_from_keyfile('''[connection]
+id=Test
+uuid={}
+type=ethernet
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+addr-gen-mode=eui64
+token=::42
+method=auto
+'''.format(UUID), expect_fail=True)
+        self.assertIn('Error in network definition:', err)
+
     def test_keyfile_method_manual(self):
         self.generate_from_keyfile('''[connection]
 id=Test

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1133,3 +1133,52 @@ route4=5:6:7:8:9:0:1:2/62
           ipv6.dns-search: "wallaceandgromit.com;"
           proxy._: ""
 '''.format(UUID, UUID)})
+
+    def test_keyfile_tunnel_regression_lp1952967(self):
+        self.generate_from_keyfile('''[connection]
+id=IP tunnel connection 1
+uuid={}
+type=ip-tunnel
+autoconnect=false
+interface-name=gre10
+permissions=
+
+[ip-tunnel]
+local=10.20.20.1
+mode=2
+remote=10.20.20.2
+
+[ipv4]
+dns-search=
+method=auto
+
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=auto
+
+[proxy]
+'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      dhcp6: true
+      ipv6-address-generation: "stable-privacy"
+      networkmanager:
+        uuid: "{}"
+        name: "IP tunnel connection 1"
+        passthrough:
+          connection.type: "ip-tunnel"
+          connection.autoconnect: "false"
+          connection.interface-name: "gre10"
+          connection.permissions: ""
+          ip-tunnel.local: "10.20.20.1"
+          ip-tunnel.mode: "2"
+          ip-tunnel.remote: "10.20.20.2"
+          ipv4.dns-search: ""
+          ipv6.dns-search: ""
+          proxy._: ""
+'''.format(UUID, UUID)})

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -363,10 +363,10 @@ route1_options=unknown=invalid,
         self._template_keyfile_type('vlans', 'vlan')
 
     def test_keyfile_type_tunnel(self):
-        self._template_keyfile_type('tunnels', 'ip-tunnel', False)
+        self._template_keyfile_type('nm-devices', 'ip-tunnel', False)
 
     def test_keyfile_type_wireguard(self):
-        self._template_keyfile_type('tunnels', 'wireguard', False)
+        self._template_keyfile_type('nm-devices', 'wireguard', False)
 
     def test_keyfile_type_other(self):
         self._template_keyfile_type('nm-devices', 'dummy', False)
@@ -1161,12 +1161,9 @@ method=auto
 '''.format(UUID))
         self.assert_netplan({UUID: '''network:
   version: 2
-  tunnels:
+  nm-devices:
     NM-{}:
       renderer: NetworkManager
-      dhcp4: true
-      dhcp6: true
-      ipv6-address-generation: "stable-privacy"
       networkmanager:
         uuid: "{}"
         name: "IP tunnel connection 1"
@@ -1179,6 +1176,9 @@ method=auto
           ip-tunnel.mode: "2"
           ip-tunnel.remote: "10.20.20.2"
           ipv4.dns-search: ""
+          ipv4.method: "auto"
+          ipv6.addr-gen-mode: "stable-privacy"
           ipv6.dns-search: ""
+          ipv6.method: "auto"
           proxy._: ""
 '''.format(UUID, UUID)})


### PR DESCRIPTION
## Description
netplan's keyfile parser can handle certain device types and settings from NM's keyfile format. But we should try to avoid writing out partial YAML where some (essential) fields are missing, as they cannot (yet) be properly parsed.

We need to check that during testing and ideally also at runtime, in order to fall back to the full passthrough mode, using the generic `nm-devices` type.

FR-1898

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1952967

