### PR TITLE
Improve routing capabilities (LP: #1892272) (LP: #1805038)

### DIFF
--- a/TODO
+++ b/TODO
@@ -39,3 +39,11 @@
 - replace nose for python tests with something else, preserving coverage reports
 
 - add automated integration tests for WPA Enterprise / 802.1x that can run self-contained
+
+# After soname bump (ABI break)
+
+- get rid of abi_compat.c
+
+- change route->scope to ENUM
+
+- move tunnel_ttl into tunnel struct

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -632,8 +632,11 @@ eth1:
 ``routes`` (mapping)
 
 :    The ``routes`` block defines standard static routes for an interface.
-     At least ``to`` must be specified.  Unless the scope is ``link``, ``via`` is
-     also required.
+     At least ``to`` must be specified. If type is ``local`` or ``nat`` a
+     default scope of ``host`` is assumed.
+     If type is ``unicast`` and no gateway (``via``) is given or type is 
+     ``broadcast``, ``multicast`` or ``anycast`` a default scope of ``link``
+     is assumend. Otherwise, a ``global`` scope is the default setting.
 
      For ``from``, ``to``, and ``via``, both IPv4 and IPv6 addresses are
      recognized, and must be in the form ``addr/prefixlen`` or ``addr``.
@@ -657,8 +660,9 @@ eth1:
      :    The relative priority of the route. Must be a positive integer value.
 
      ``type`` (scalar)
-     :    The type of route. Valid options are "unicast" (default),
-          "unreachable", "blackhole" or "prohibit".
+     :    The type of route. Valid options are "unicast" (default), "anycast",
+          "blackhole", "broadcast", "local", "multicast", "nat", "prohibit",
+          "throw", "unreachable" or "xresolve".
 
      ``scope`` (scalar)
      :    The route scope, how wide-ranging it is to the network. Possible

--- a/src/parse.c
+++ b/src/parse.c
@@ -1375,10 +1375,20 @@ handle_routes_type(NetplanParser* npp, yaml_node_t* node, const void* data, GErr
         g_free(route->type);
     route->type = g_strdup(scalar(node));
 
-    if (g_ascii_strcasecmp(route->type, "unicast") == 0 ||
-        g_ascii_strcasecmp(route->type, "unreachable") == 0 ||
-        g_ascii_strcasecmp(route->type, "blackhole") == 0 ||
-        g_ascii_strcasecmp(route->type, "prohibit") == 0)
+    /* local, broadcast, anycast, multicast, nat and xresolve are supported
+     * since systemd-networkd v243 */
+    /* keep "unicast" default at position 1 */
+    if (   g_ascii_strcasecmp(route->type, "unicast") == 0
+        || g_ascii_strcasecmp(route->type, "anycast") == 0
+        || g_ascii_strcasecmp(route->type, "blackhole") == 0
+        || g_ascii_strcasecmp(route->type, "broadcast") == 0
+        || g_ascii_strcasecmp(route->type, "local") == 0
+        || g_ascii_strcasecmp(route->type, "multicast") == 0
+        || g_ascii_strcasecmp(route->type, "nat") == 0
+        || g_ascii_strcasecmp(route->type, "prohibit") == 0
+        || g_ascii_strcasecmp(route->type, "throw") == 0
+        || g_ascii_strcasecmp(route->type, "unreachable") == 0
+        || g_ascii_strcasecmp(route->type, "xresolve") == 0)
         return TRUE;
 
     return yaml_error(npp, node, error, "invalid route type '%s'", route->type);

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -745,6 +745,7 @@ class TestConfigErrors(TestBase):
     engreen:
       routes:
         - to: 2001:dead:beef::2
+          scope: global
           metric: 1
       addresses:
         - 192.168.14.2/24

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -720,6 +720,92 @@ RouteMetric=100
 UseMTU=true
 '''})
 
+    def test_default_scope_link_lp1805038(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: true
+      routes:
+      - to: 10.96.0.0/24
+    enred:
+      dhcp4: true
+      routes:
+      - to: 10.97.0.0/24
+        type: broadcast
+''', skip_generated_yaml_validation=True)  # scope: link is a default value in this case
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=ipv6
+
+[Route]
+Destination=10.96.0.0/24
+Scope=link
+
+[DHCP]
+RouteMetric=100
+UseMTU=true
+''',
+                              'enred.network': '''[Match]
+Name=enred
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=ipv6
+
+[Route]
+Destination=10.97.0.0/24
+Scope=link
+Type=broadcast
+
+[DHCP]
+RouteMetric=100
+UseMTU=true
+'''})
+
+    def test_type_local_lp1892272(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      dhcp4: true
+      routes:
+      - to: 0.0.0.0/0
+        type: local
+        table: 99
+      - to: ::0/0
+        type: local
+        table: 100
+''', skip_generated_yaml_validation=True)  # scope: host is a default value in this case
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+DHCP=ipv4
+LinkLocalAddressing=ipv6
+
+[Route]
+Destination=0.0.0.0/0
+Scope=host
+Type=local
+Table=99
+
+[Route]
+Destination=::0/0
+Scope=host
+Type=local
+Table=100
+
+[DHCP]
+RouteMetric=100
+UseMTU=true
+'''})
+
 
 class TestNetworkManager(TestBase):
 


### PR DESCRIPTION
## Description
* Supporting additional route types: anycast, broadcast, local, multicast, nat, throw, xresolve (supported by systemd-networkd as of v243)
* Not assuming a type: unicast, scope: global, by default, but making the default scope depend on the route type:
  * local -> host
  * nat -> host
  * broadcast -> link
  * multicast -> link
  * anycast -> link
  * unicast without gateway/via -> link
  * unicast with gateway/via -> global
  * global otherwise

This only affects the systemd-networkd backend renderer as for NetworkManager only "unicast" routes are supported.

FR-1798
FR-1078
FR-1077

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1892272 & LP#1805038

