### PR TITLE
YAML consolidation prelude: OVS handling (FR-702)

### DIFF
--- a/src/names.c
+++ b/src/names.c
@@ -48,7 +48,7 @@ netplan_def_type_to_str[NETPLAN_DEF_TYPE_MAX_] = {
     [NETPLAN_DEF_TYPE_BOND] = "bonds",
     [NETPLAN_DEF_TYPE_VLAN] = "vlans",
     [NETPLAN_DEF_TYPE_TUNNEL] = "tunnels",
-    [NETPLAN_DEF_TYPE_PORT] = NULL,
+    [NETPLAN_DEF_TYPE_PORT] = "ovs-ports",
     [NETPLAN_DEF_TYPE_NM] = "nm-devices",
 };
 

--- a/src/names.c
+++ b/src/names.c
@@ -48,7 +48,7 @@ netplan_def_type_to_str[NETPLAN_DEF_TYPE_MAX_] = {
     [NETPLAN_DEF_TYPE_BOND] = "bonds",
     [NETPLAN_DEF_TYPE_VLAN] = "vlans",
     [NETPLAN_DEF_TYPE_TUNNEL] = "tunnels",
-    [NETPLAN_DEF_TYPE_PORT] = "ovs-ports",
+    [NETPLAN_DEF_TYPE_PORT] = "_ovs-ports",
     [NETPLAN_DEF_TYPE_NM] = "nm-devices",
 };
 


### PR DESCRIPTION
## Description

A couple of patches related to OpenVSwitch handling. The consistency patch is needed to be able to ensure idempotency of the user input (within reason). The type name definition will be needed when we'll rewrite `sriov.py` as we'll need to identify those definitions.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

