### PR TITLE
YAML consolidation prelude: High-level libnetplan bindings (FR-702)

### DIFF
--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -25,14 +25,15 @@ import logging
 import shutil
 import glob
 
-import netplan.cli.utils as utils
+from netplan.cli.utils import NetplanCommand
+import netplan.libnetplan as libnetplan
 from netplan.configmanager import ConfigManager
 
 FALLBACK_HINT = '70-netplan-set'
 GLOBAL_KEYS = ['renderer', 'version']
 
 
-class NetplanSet(utils.NetplanCommand):
+class NetplanSet(NetplanCommand):
 
     def __init__(self):
         super().__init__(command_id='set',
@@ -70,11 +71,11 @@ class NetplanSet(utils.NetplanCommand):
             # We replace the devtype null node with a dict of all defined netdefs
             # set to None.
             if devtype_content is None:
-                devtype_content = {dev: None for dev in utils.netplan_get_ids_for_devtype(devtype, self.root_dir)}
+                devtype_content = {dev: None for dev in libnetplan.netplan_get_ids_for_devtype(devtype, self.root_dir)}
                 network[devtype] = devtype_content
             for netdef in devtype_content:
                 hint = FALLBACK_HINT
-                filename = utils.netplan_get_filename_by_id(netdef, self.root_dir)
+                filename = libnetplan.netplan_get_filename_by_id(netdef, self.root_dir)
                 if filename:
                     hint = os.path.basename(filename)[:-5]  # strip prefix and .yaml
                 netdef_tree = {'network': {devtype: {netdef: network.get(devtype).get(netdef)}}}
@@ -189,7 +190,7 @@ class NetplanSet(utils.NetplanCommand):
                 new_yaml = yaml.dump(stripped, indent=2, default_flow_style=False)
                 f.write(new_yaml)
             # Validate the newly created file, by parsing it via libnetplan
-            utils.netplan_parse(tmpp)
+            libnetplan.netplan_parse(tmpp)
             # Valid, move it to final destination
             shutil.copy2(tmpp, absp)
             os.remove(tmpp)

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-#
 # Copyright (C) 2018-2020 Canonical, Ltd.
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 # Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@canonical.com>
@@ -20,104 +18,14 @@
 import sys
 import os
 import logging
-import fnmatch
 import argparse
 import subprocess
 import netifaces
+import fnmatch
 import re
-import ctypes
-import ctypes.util
 
 NM_SERVICE_NAME = 'NetworkManager.service'
 NM_SNAP_SERVICE_NAME = 'snap.network-manager.networkmanager.service'
-
-
-class LibNetplanException(Exception):
-    pass
-
-
-class _GError(ctypes.Structure):
-    _fields_ = [("domain", ctypes.c_uint32), ("code", ctypes.c_int), ("message", ctypes.c_char_p)]
-
-
-lib = ctypes.CDLL(ctypes.util.find_library('netplan'))
-lib.netplan_parse_yaml.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.POINTER(_GError))]
-lib.netplan_get_filename_by_id.restype = ctypes.c_char_p
-lib.process_yaml_hierarchy.argtypes = [ctypes.c_char_p]
-lib.process_yaml_hierarchy.restype = ctypes.c_int
-
-
-def netplan_parse(path):
-    # Clear old NetplanNetDefinitions from libnetplan memory
-    lib.netplan_clear_netdefs()
-    err = ctypes.POINTER(_GError)()
-    ret = bool(lib.netplan_parse_yaml(path.encode(), ctypes.byref(err)))
-    if not ret:
-        raise Exception(err.contents.message.decode('utf-8'))
-    lib.netplan_finish_parse(ctypes.byref(err))
-    if err:
-        raise Exception(err.contents.message.decode('utf-8'))
-    return True
-
-
-def netplan_get_filename_by_id(netdef_id, rootdir):
-    res = lib.netplan_get_filename_by_id(netdef_id.encode(), rootdir.encode())
-    return res.decode('utf-8') if res else None
-
-
-class _NetdefIdIterator:
-    _abi_checked = False
-
-    @classmethod
-    def c_abi_sanity_check(cls):
-        if cls._abi_checked:
-            return
-
-        if not hasattr(lib, '_netplan_iter_defs_per_devtype_init'):  # pragma: nocover (hard to unit-test against the WRONG lib)
-            raise LibNetplanException('''
-                The current version of libnetplan does not allow iterating by devtype.
-                Please ensure that both the netplan CLI package and its library are up to date.
-            ''')
-        lib._netplan_iter_defs_per_devtype_init.argtypes = [ctypes.c_char_p]
-        lib._netplan_iter_defs_per_devtype_init.restype = ctypes.c_void_p
-
-        lib._netplan_iter_defs_per_devtype_next.argtypes = [ctypes.c_void_p]
-        lib._netplan_iter_defs_per_devtype_next.restype = ctypes.c_void_p
-
-        lib._netplan_iter_defs_per_devtype_free.argtypes = [ctypes.c_void_p]
-        lib._netplan_iter_defs_per_devtype_free.restype = None
-
-        lib._netplan_netdef_id.argtypes = [ctypes.c_void_p]
-        lib._netplan_netdef_id.restype = ctypes.c_char_p
-
-        cls._abi_checked = True
-
-    def __init__(self, devtype):
-        self.c_abi_sanity_check()
-        self.iterator = lib._netplan_iter_defs_per_devtype_init(devtype.encode('utf-8'))
-
-    def __del__(self):
-        lib._netplan_iter_defs_per_devtype_free(self.iterator)
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        next_value = lib._netplan_iter_defs_per_devtype_next(self.iterator)
-        if next_value is None:
-            raise StopIteration
-        return next_value
-
-
-def netplan_get_ids_for_devtype(devtype, rootdir):
-    err = ctypes.POINTER(_GError)()
-    lib.netplan_clear_netdefs()
-    lib.process_yaml_hierarchy(rootdir.encode('utf-8'))
-    lib.netplan_finish_parse(ctypes.byref(err))
-    if err:  # pragma: nocover (this is a "break in case of emergency" thing)
-        raise Exception(err.contents.message.decode('utf-8'))
-    nds = list(_NetdefIdIterator(devtype))
-    return [lib._netplan_netdef_id(nd).decode('utf-8') for nd in nds]
 
 
 def get_generator_path():

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -2,6 +2,7 @@
 # Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
 # Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@canonical.com>
 # Author: Lukas 'slyon' Märdian <lukas.maerdian@canonical.com>
+# Author: Simon Chopin <simon.chopin@canonical.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +18,7 @@
 
 import ctypes
 import ctypes.util
+from ctypes import c_char_p, c_void_p, c_int
 
 
 class LibNetplanException(Exception):
@@ -24,7 +26,19 @@ class LibNetplanException(Exception):
 
 
 class _GError(ctypes.Structure):
-    _fields_ = [("domain", ctypes.c_uint32), ("code", ctypes.c_int), ("message", ctypes.c_char_p)]
+    _fields_ = [("domain", ctypes.c_uint32), ("code", c_int), ("message", c_char_p)]
+
+
+class _netplan_state(ctypes.Structure):
+    pass
+
+
+class _netplan_parser(ctypes.Structure):
+    pass
+
+
+class _netplan_net_definition(ctypes.Structure):
+    pass
 
 
 lib = ctypes.CDLL(ctypes.util.find_library('netplan'))
@@ -32,6 +46,11 @@ lib.netplan_parse_yaml.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.POINTE
 lib.netplan_get_filename_by_id.restype = ctypes.c_char_p
 lib.process_yaml_hierarchy.argtypes = [ctypes.c_char_p]
 lib.process_yaml_hierarchy.restype = ctypes.c_int
+
+_GErrorPP = ctypes.POINTER(ctypes.POINTER(_GError))
+_NetplanParserP = ctypes.POINTER(_netplan_parser)
+_NetplanStateP = ctypes.POINTER(_netplan_state)
+_NetplanNetDefinitionP = ctypes.POINTER(_netplan_net_definition)
 
 lib.netplan_get_id_from_nm_filename.restype = ctypes.c_char_p
 
@@ -49,17 +68,123 @@ def netplan_parse(path):
     return True
 
 
+def _checked_lib_call(fn, *args):
+    err = ctypes.POINTER(_GError)()
+    ret = bool(fn(*args, ctypes.byref(err)))
+    if not ret:
+        raise LibNetplanException(err.contents.message.decode('utf-8'))
+
+
 def netplan_get_filename_by_id(netdef_id, rootdir):
     res = lib.netplan_get_filename_by_id(netdef_id.encode(), rootdir.encode())
     return res.decode('utf-8') if res else None
 
 
-class _NetdefIdIterator:
-    _abi_checked = False
+class Parser:
+    _abi_loaded = False
 
     @classmethod
-    def c_abi_sanity_check(cls):
-        if cls._abi_checked:
+    def _load_abi(cls):
+        if cls._abi_loaded:
+            return
+
+        lib.netplan_parser_new.restype = _NetplanParserP
+        lib.netplan_parser_clear.argtypes = [ctypes.POINTER(_NetplanParserP)]
+
+        lib.netplan_parser_load_yaml.argtypes = [_NetplanParserP, c_char_p, _GErrorPP]
+        lib.netplan_parser_load_yaml.restype = c_int
+
+        cls._abi_loaded = True
+
+    def __init__(self):
+        self._load_abi()
+        self._ptr = lib.netplan_parser_new()
+
+    def __del__(self):
+        lib.netplan_parser_clear(ctypes.byref(self._ptr))
+
+    def load_yaml(self, filename):
+        _checked_lib_call(lib.netplan_parser_load_yaml, self._ptr, filename.encode('utf-8'))
+
+
+class State:
+    _abi_loaded = False
+
+    @classmethod
+    def _load_abi(cls):
+        if cls._abi_loaded:
+            return
+
+        lib.netplan_state_new.restype = _NetplanStateP
+        lib.netplan_state_clear.argtypes = [ctypes.POINTER(_NetplanStateP)]
+
+        lib.netplan_state_import_parser_results.argtypes = [_NetplanStateP, _NetplanParserP, _GErrorPP]
+        lib.netplan_state_import_parser_results.restype = c_int
+
+        lib.netplan_state_get_netdefs_size.argtypes = [_NetplanStateP]
+        lib.netplan_state_get_netdefs_size.restype = c_int
+
+        lib.netplan_state_get_netdef.argtypes = [_NetplanStateP, c_char_p]
+        lib.netplan_state_get_netdef.restype = _NetplanNetDefinitionP
+
+        cls._abi_loaded = True
+
+    def __init__(self):
+        self._load_abi()
+        self._ptr = lib.netplan_state_new()
+
+    def __del__(self):
+        lib.netplan_state_clear(ctypes.byref(self._ptr))
+
+    def import_parser_results(self, parser):
+        _checked_lib_call(lib.netplan_state_import_parser_results, self._ptr, parser._ptr)
+
+    def __len__(self):
+        return lib.netplan_state_get_netdefs_size(self._ptr)
+
+    def __getitem__(self, def_id):
+        ptr = lib.netplan_state_get_netdef(self._ptr, def_id.encode('utf-8'))
+        if not ptr:
+            raise IndexError()
+        return NetDefinition(self, ptr)
+
+
+class NetDefinition:
+    _abi_loaded = False
+
+    @classmethod
+    def _load_abi(cls):
+        if cls._abi_loaded:
+            return
+
+        lib.netplan_netdef_get_id.argtypes = [_NetplanNetDefinitionP]
+        lib.netplan_netdef_get_id.restype = c_char_p
+
+        cls._abi_loaded = True
+
+    def __eq__(self, other):
+        if not hasattr(other, '_ptr'):
+            return False
+        return ctypes.addressof(self._ptr.contents) == ctypes.addressof(other._ptr.contents)
+
+    def __init__(self, np_state, ptr):
+        self._load_abi()
+        self._ptr = ptr
+        # We hold on to this to avoid the underlying pointer being invalidated by
+        # the GC invoking netplan_state_free
+        self._parent = np_state
+
+    @property
+    def id(self):
+        return lib.netplan_netdef_get_id(self._ptr).decode('utf-8')
+
+
+class _NetdefIterator:
+    _abi_loaded = False
+
+    @classmethod
+    def _load_abi(cls):
+        if cls._abi_loaded:
             return
 
         if not hasattr(lib, '_netplan_iter_defs_per_devtype_init'):  # pragma: nocover (hard to unit-test against the WRONG lib)
@@ -67,23 +192,25 @@ class _NetdefIdIterator:
                 The current version of libnetplan does not allow iterating by devtype.
                 Please ensure that both the netplan CLI package and its library are up to date.
             ''')
-        lib._netplan_iter_defs_per_devtype_init.argtypes = [ctypes.c_char_p]
-        lib._netplan_iter_defs_per_devtype_init.restype = ctypes.c_void_p
+        lib._netplan_state_new_netdef_pertype_iter.argtypes = [_NetplanStateP, c_char_p]
+        lib._netplan_state_new_netdef_pertype_iter.restype = c_void_p
 
-        lib._netplan_iter_defs_per_devtype_next.argtypes = [ctypes.c_void_p]
-        lib._netplan_iter_defs_per_devtype_next.restype = ctypes.c_void_p
+        lib._netplan_iter_defs_per_devtype_next.argtypes = [c_void_p]
+        lib._netplan_iter_defs_per_devtype_next.restype = _NetplanNetDefinitionP
 
-        lib._netplan_iter_defs_per_devtype_free.argtypes = [ctypes.c_void_p]
+        lib._netplan_iter_defs_per_devtype_free.argtypes = [c_void_p]
         lib._netplan_iter_defs_per_devtype_free.restype = None
 
-        lib._netplan_netdef_id.argtypes = [ctypes.c_void_p]
-        lib._netplan_netdef_id.restype = ctypes.c_char_p
+        lib._netplan_netdef_id.argtypes = [c_void_p]
+        lib._netplan_netdef_id.restype = c_char_p
 
-        cls._abi_checked = True
+        cls._abi_loaded = True
 
-    def __init__(self, devtype):
-        self.c_abi_sanity_check()
-        self.iterator = lib._netplan_iter_defs_per_devtype_init(devtype.encode('utf-8'))
+    def __init__(self, np_state, devtype):
+        self._load_abi()
+        # To keep things valid, keep a reference to the parent state
+        self.np_state = np_state
+        self.iterator = lib._netplan_state_new_netdef_pertype_iter(np_state._ptr, devtype and devtype.encode('utf-8'))
 
     def __del__(self):
         lib._netplan_iter_defs_per_devtype_free(self.iterator)
@@ -93,9 +220,17 @@ class _NetdefIdIterator:
 
     def __next__(self):
         next_value = lib._netplan_iter_defs_per_devtype_next(self.iterator)
-        if next_value is None:
+        if not next_value:
             raise StopIteration
-        return next_value
+        return NetDefinition(self.np_state, next_value)
+
+
+class __GlobalState(State):
+    def __init__(self):
+        self._ptr = ctypes.cast(lib.global_state, _NetplanStateP)
+
+    def __del__(self):
+        pass
 
 
 def netplan_get_ids_for_devtype(devtype, rootdir):
@@ -105,5 +240,5 @@ def netplan_get_ids_for_devtype(devtype, rootdir):
     lib.netplan_finish_parse(ctypes.byref(err))
     if err:  # pragma: nocover (this is a "break in case of emergency" thing)
         raise Exception(err.contents.message.decode('utf-8'))
-    nds = list(_NetdefIdIterator(devtype))
-    return [lib._netplan_netdef_id(nd).decode('utf-8') for nd in nds]
+    nds = list(_NetdefIterator(__GlobalState(), devtype))
+    return [nd.id for nd in nds]

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2018-2020 Canonical, Ltd.
+# Author: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>
+# Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@canonical.com>
+# Author: Lukas 'slyon' Märdian <lukas.maerdian@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import ctypes
+import ctypes.util
+
+
+class LibNetplanException(Exception):
+    pass
+
+
+class _GError(ctypes.Structure):
+    _fields_ = [("domain", ctypes.c_uint32), ("code", ctypes.c_int), ("message", ctypes.c_char_p)]
+
+
+lib = ctypes.CDLL(ctypes.util.find_library('netplan'))
+lib.netplan_parse_yaml.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.POINTER(_GError))]
+lib.netplan_get_filename_by_id.restype = ctypes.c_char_p
+lib.process_yaml_hierarchy.argtypes = [ctypes.c_char_p]
+lib.process_yaml_hierarchy.restype = ctypes.c_int
+
+lib.netplan_get_id_from_nm_filename.restype = ctypes.c_char_p
+
+
+def netplan_parse(path):
+    # Clear old NetplanNetDefinitions from libnetplan memory
+    lib.netplan_clear_netdefs()
+    err = ctypes.POINTER(_GError)()
+    ret = bool(lib.netplan_parse_yaml(path.encode(), ctypes.byref(err)))
+    if not ret:
+        raise Exception(err.contents.message.decode('utf-8'))
+    lib.netplan_finish_parse(ctypes.byref(err))
+    if err:
+        raise Exception(err.contents.message.decode('utf-8'))
+    return True
+
+
+def netplan_get_filename_by_id(netdef_id, rootdir):
+    res = lib.netplan_get_filename_by_id(netdef_id.encode(), rootdir.encode())
+    return res.decode('utf-8') if res else None
+
+
+class _NetdefIdIterator:
+    _abi_checked = False
+
+    @classmethod
+    def c_abi_sanity_check(cls):
+        if cls._abi_checked:
+            return
+
+        if not hasattr(lib, '_netplan_iter_defs_per_devtype_init'):  # pragma: nocover (hard to unit-test against the WRONG lib)
+            raise LibNetplanException('''
+                The current version of libnetplan does not allow iterating by devtype.
+                Please ensure that both the netplan CLI package and its library are up to date.
+            ''')
+        lib._netplan_iter_defs_per_devtype_init.argtypes = [ctypes.c_char_p]
+        lib._netplan_iter_defs_per_devtype_init.restype = ctypes.c_void_p
+
+        lib._netplan_iter_defs_per_devtype_next.argtypes = [ctypes.c_void_p]
+        lib._netplan_iter_defs_per_devtype_next.restype = ctypes.c_void_p
+
+        lib._netplan_iter_defs_per_devtype_free.argtypes = [ctypes.c_void_p]
+        lib._netplan_iter_defs_per_devtype_free.restype = None
+
+        lib._netplan_netdef_id.argtypes = [ctypes.c_void_p]
+        lib._netplan_netdef_id.restype = ctypes.c_char_p
+
+        cls._abi_checked = True
+
+    def __init__(self, devtype):
+        self.c_abi_sanity_check()
+        self.iterator = lib._netplan_iter_defs_per_devtype_init(devtype.encode('utf-8'))
+
+    def __del__(self):
+        lib._netplan_iter_defs_per_devtype_free(self.iterator)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        next_value = lib._netplan_iter_defs_per_devtype_next(self.iterator)
+        if next_value is None:
+            raise StopIteration
+        return next_value
+
+
+def netplan_get_ids_for_devtype(devtype, rootdir):
+    err = ctypes.POINTER(_GError)()
+    lib.netplan_clear_netdefs()
+    lib.process_yaml_hierarchy(rootdir.encode('utf-8'))
+    lib.netplan_finish_parse(ctypes.byref(err))
+    if err:  # pragma: nocover (this is a "break in case of emergency" thing)
+        raise Exception(err.contents.message.decode('utf-8'))
+    nds = list(_NetdefIdIterator(devtype))
+    return [lib._netplan_netdef_id(nd).decode('utf-8') for nd in nds]

--- a/src/abi_compat.c
+++ b/src/abi_compat.c
@@ -298,8 +298,20 @@ netplan_get_filename_by_id(const char* netdef_id, const char* rootdir)
     }
     netplan_parser_clear(&npp);
 
-    netplan_state_get_netdef(np_state, netdef_id);
-    filename = g_strdup(netplan_netdef_get_filename(netplan_state_get_netdef(np_state, netdef_id)));
+    NetplanNetDefinition* netdef = netplan_state_get_netdef(np_state, netdef_id);
+    if (netdef)
+        filename = g_strdup(netplan_netdef_get_filename(netdef));
     netplan_state_clear(&np_state);
     return filename;
 }
+
+// LCOV_EXCL_START
+NETPLAN_INTERNAL struct netdef_pertype_iter*
+_netplan_state_new_netdef_pertype_iter(NetplanState* np_state, const char* devtype);
+
+NETPLAN_INTERNAL struct netdef_pertype_iter*
+_netplan_iter_defs_per_devtype_init(const char *devtype)
+{
+    return _netplan_state_new_netdef_pertype_iter(&global_state, devtype);
+}
+// LCOV_EXCL_STOP

--- a/src/types.c
+++ b/src/types.c
@@ -419,7 +419,14 @@ netplan_state_get_netdef(const NetplanState* np_state, const char* id)
 NETPLAN_PUBLIC const char *
 netplan_netdef_get_filename(const NetplanNetDefinition* netdef)
 {
-    if (!netdef)
-        return NULL;
     return netdef->filename;
 }
+
+NETPLAN_INTERNAL const char*
+netplan_netdef_get_id(const NetplanNetDefinition* netdef)
+{
+    return netdef->id;
+}
+
+NETPLAN_INTERNAL const char*
+_netplan_netdef_id(NetplanNetDefinition* netdef) __attribute__((alias("netplan_netdef_get_id")));

--- a/src/types.c
+++ b/src/types.c
@@ -342,6 +342,7 @@ netplan_state_new()
 void
 netplan_state_clear(NetplanState** np_state_p)
 {
+    g_assert(np_state_p);
     NetplanState* np_state = *np_state_p;
     *np_state_p = NULL;
     netplan_state_reset(np_state);
@@ -375,12 +376,14 @@ netplan_state_reset(NetplanState* np_state)
 NetplanBackend
 netplan_state_get_backend(const NetplanState* np_state)
 {
+    g_assert(np_state);
     return np_state->backend;
 }
 
 guint
 netplan_state_get_netdefs_size(const NetplanState* np_state)
 {
+    g_assert(np_state);
     return np_state->netdefs ? g_hash_table_size(np_state->netdefs) : 0;
 }
 
@@ -411,6 +414,7 @@ CLEAR_FROM_FREE(free_address_options, address_options_clear, NetplanAddressOptio
 NetplanNetDefinition*
 netplan_state_get_netdef(const NetplanState* np_state, const char* id)
 {
+    g_assert(np_state);
     if (!np_state->netdefs)
         return NULL;
     return g_hash_table_lookup(np_state->netdefs, id);
@@ -419,12 +423,14 @@ netplan_state_get_netdef(const NetplanState* np_state, const char* id)
 NETPLAN_PUBLIC const char *
 netplan_netdef_get_filename(const NetplanNetDefinition* netdef)
 {
+    g_assert(netdef);
     return netdef->filename;
 }
 
 NETPLAN_INTERNAL const char*
 netplan_netdef_get_id(const NetplanNetDefinition* netdef)
 {
+    g_assert(netdef);
     return netdef->id;
 }
 

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -19,7 +19,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from configparser import ConfigParser
-from netplan.cli.utils import _GError
+from netplan.libnetplan import _GError
 import os
 import sys
 import shutil

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -19,23 +19,21 @@
 
 import os
 import shutil
-import ctypes
-import ctypes.util
 
 from generator.base import TestBase
 from parser.base import capture_stderr
 from tests.test_utils import MockCmd
 
+import netplan.libnetplan as libnetplan
+
+lib = libnetplan.lib
 rootdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 exe_cli = os.path.join(rootdir, 'src', 'netplan.script')
 # Make sure we can import our development netplan.
 os.environ.update({'PYTHONPATH': '.'})
 
-lib = ctypes.CDLL(ctypes.util.find_library('netplan'))
-lib.netplan_get_id_from_nm_filename.restype = ctypes.c_char_p
 
-
-class TestLibnetplan(TestBase):
+class TestRawLibnetplan(TestBase):
     '''Test libnetplan functionality as used by the NetworkManager backend'''
 
     def setUp(self):
@@ -83,7 +81,7 @@ class TestLibnetplan(TestBase):
         self.mock_netplan_cmd = MockCmd("netplan")
         os.environ["TEST_NETPLAN_CMD"] = self.mock_netplan_cmd.path
         self.assertTrue(lib.netplan_generate(self.workdir.name.encode()))
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
+        self.assertEqual(self.mock_netplan_cmd.calls(), [
             ["netplan", "generate", "--root-dir", self.workdir.name],
         ])
 
@@ -129,7 +127,7 @@ class TestLibnetplan(TestBase):
         self.assertTrue(os.path.isfile(orig))
         # Verify the file still exists and still contains the other connection
         with open(orig, 'r') as f:
-            self.assertEquals(f.read(), 'network:\n  ethernets:\n    other-id:\n      dhcp6: true\n')
+            self.assertEqual(f.read(), 'network:\n  ethernets:\n    other-id:\n      dhcp6: true\n')
 
     def test_write_netplan_conf(self):
         netdef_id = 'some-netplan-id'
@@ -151,4 +149,76 @@ class TestLibnetplan(TestBase):
         self.assertTrue(os.path.isfile(generated))
         with open(orig, 'r') as f:
             with open(generated, 'r') as new:
-                self.assertEquals(f.read(), new.read())
+                self.assertEqual(f.read(), new.read())
+
+
+class TestFreeFunctions(TestBase):
+    def setUp(self):
+        super().setUp()
+        os.makedirs(self.confdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir.name)
+        super().tearDown()
+
+    def test_netplan_get_filename_by_id(self):
+        file_a = os.path.join(self.workdir.name, 'etc/netplan/a.yaml')
+        file_b = os.path.join(self.workdir.name, 'etc/netplan/b.yaml')
+        with open(file_a, 'w') as f:
+            f.write('network:\n  ethernets:\n    id_a:\n      dhcp4: true')
+        with open(file_b, 'w') as f:
+            f.write('network:\n  ethernets:\n    id_b:\n      dhcp4: true\n    id_a:\n      dhcp4: true')
+        # netdef:b can only be found in b.yaml
+        basename = os.path.basename(libnetplan.netplan_get_filename_by_id('id_b', self.workdir.name))
+        self.assertEqual(basename, 'b.yaml')
+        # netdef:a is defined in a.yaml, overriden by b.yaml
+        basename = os.path.basename(libnetplan.netplan_get_filename_by_id('id_a', self.workdir.name))
+        self.assertEqual(basename, 'b.yaml')
+
+    def test_netplan_get_filename_by_id_no_files(self):
+        self.assertIsNone(libnetplan.netplan_get_filename_by_id('some-id', self.workdir.name))
+
+    def test_netplan_get_filename_by_id_invalid(self):
+        file = os.path.join(self.workdir.name, 'etc/netplan/a.yaml')
+        with open(file, 'w') as f:
+            f.write('''network:
+  tunnels:
+    id_a:
+      mode: sit
+      local: 0.0.0.0
+      remote: 0.0.0.0
+      key: 0.0.0.0''')
+        self.assertIsNone(libnetplan.netplan_get_filename_by_id('some-id', self.workdir.name))
+
+    def test_netplan_get_ids_for_devtype(self):
+        path = os.path.join(self.workdir.name, 'etc/netplan/a.yaml')
+        with open(path, 'w') as f:
+            f.write('''network:
+  ethernets:
+    id_b:
+      dhcp4: true
+    id_a:
+      dhcp4: true
+  vlans:
+    en-intra:
+      id: 3
+      link: id_b
+      dhcp4: true''')
+        self.assertSetEqual(
+                set(libnetplan.netplan_get_ids_for_devtype("ethernets", self.workdir.name)),
+                set(["id_a", "id_b"]))
+
+    def test_netplan_get_ids_for_devtype_no_dev(self):
+        path = os.path.join(self.workdir.name, 'etc/netplan/a.yaml')
+        with open(path, 'w') as f:
+            f.write('''network:
+  ethernets:
+    id_b:
+      dhcp4: true''')
+        self.assertSetEqual(
+                set(libnetplan.netplan_get_ids_for_devtype("tunnels", self.workdir.name)),
+                set([]))
+
+    def test_NetdefIdIterator_with_clear_netplan(self):
+        libnetplan.lib.netplan_clear_netdefs()
+        self.assertSequenceEqual(list(libnetplan._NetdefIdIterator("ethernets")), [])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,14 @@
+import os
+import netplan.libnetplan as libnetplan
+
+
+def state_from_yaml(confdir, yaml, filename="a.yml"):
+    os.makedirs(confdir, exist_ok=True)
+    conf = os.path.join(confdir, filename)
+    with open(conf, "w+") as f:
+        f.write(yaml)
+    parser = libnetplan.Parser()
+    parser.load_yaml(conf)
+    state = libnetplan.State()
+    state.import_parser_results(parser)
+    return state


### PR DESCRIPTION
## Description

This PR introduces some high-level Python bindings. This is mostly a skeleton that will be populated with the needed elements in later PRs, which will remain in draft state until this one is merged.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

