### PR TITLE
YAML consolidation prelude: new YAML dump APIs (FR-702)

### DIFF
--- a/include/netplan.h
+++ b/include/netplan.h
@@ -54,11 +54,13 @@ netplan_state_get_netdefs_size(const NetplanState* np_state);
 NETPLAN_PUBLIC NetplanNetDefinition*
 netplan_state_get_netdef(const NetplanState* np_state, const char* id);
 
+/* Dump the whole yaml configuration into the given file, regardless of the origin
+ * of each definition.
+ */
 NETPLAN_PUBLIC gboolean
-netplan_state_write_yaml(
+netplan_state_dump_yaml(
         const NetplanState* np_state,
-        const char* file_hint,
-        const char* rootdir,
+        int output_fd,
         GError** error);
 
 NETPLAN_PUBLIC gboolean

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -249,3 +249,14 @@ def netplan_get_ids_for_devtype(devtype, rootdir):
         raise Exception(err.contents.message.decode('utf-8'))
     nds = list(_NetdefIterator(__GlobalState(), devtype))
     return [nd.id for nd in nds]
+
+
+lib.netplan_util_dump_yaml_subtree.argtypes = [c_char_p, c_int, c_int, _GErrorPP]
+lib.netplan_util_dump_yaml_subtree.restype = c_int
+
+
+def dump_yaml_subtree(prefix, input_file, output_file):
+    _checked_lib_call(lib.netplan_util_dump_yaml_subtree,
+                      prefix.encode('utf-8'),
+                      input_file.fileno(),
+                      output_file.fileno())

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -127,6 +127,9 @@ class State:
         lib.netplan_state_get_netdef.argtypes = [_NetplanStateP, c_char_p]
         lib.netplan_state_get_netdef.restype = _NetplanNetDefinitionP
 
+        lib.netplan_state_dump_yaml.argtypes = [_NetplanStateP, c_int, _GErrorPP]
+        lib.netplan_state_dump_yaml.restype = c_int
+
         cls._abi_loaded = True
 
     def __init__(self):
@@ -138,6 +141,10 @@ class State:
 
     def import_parser_results(self, parser):
         _checked_lib_call(lib.netplan_state_import_parser_results, self._ptr, parser._ptr)
+
+    def dump_yaml(self, output_file):
+        fd = output_file.fileno()
+        _checked_lib_call(lib.netplan_state_dump_yaml, self._ptr, fd)
 
     def __len__(self):
         return lib.netplan_state_get_netdefs_size(self._ptr)

--- a/src/types.c
+++ b/src/types.c
@@ -22,6 +22,7 @@
 
 #include <glib.h>
 #include "types.h"
+#include "util-internal.h"
 
 #define FREE_AND_NULLIFY(ptr) { g_free(ptr); ptr = NULL; }
 
@@ -436,3 +437,10 @@ netplan_netdef_get_id(const NetplanNetDefinition* netdef)
 
 NETPLAN_INTERNAL const char*
 _netplan_netdef_id(NetplanNetDefinition* netdef) __attribute__((alias("netplan_netdef_get_id")));
+
+gboolean
+netplan_state_has_nondefault_globals(const NetplanState* np_state)
+{
+        return (np_state->backend != NETPLAN_BACKEND_NONE)
+                || has_openvswitch(&np_state->ovs_settings, NETPLAN_BACKEND_NONE, NULL);
+}

--- a/src/types.h
+++ b/src/types.h
@@ -511,3 +511,6 @@ ip_rule_clear(NetplanIPRule** rule);
 
 void
 route_clear(NetplanIPRoute** route);
+
+gboolean
+netplan_state_has_nondefault_globals(const NetplanState* np_state);

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -79,3 +79,6 @@ process_input_file(const char* f);
 
 NETPLAN_INTERNAL gboolean
 process_yaml_hierarchy(const char* rootdir);
+
+gboolean
+has_openvswitch(const NetplanOVSSettings* ovs, NetplanBackend backend, GHashTable *ovs_ports);

--- a/src/util.c
+++ b/src/util.c
@@ -411,3 +411,19 @@ _netplan_iter_defs_per_devtype_next(struct netdef_pertype_iter* it);
 
 __attribute((alias("_netplan_netdef_pertype_iter_free"))) NETPLAN_ABI void
 _netplan_iter_defs_per_devtype_free(struct netdef_pertype_iter* it);
+
+gboolean
+has_openvswitch(const NetplanOVSSettings* ovs, NetplanBackend backend, GHashTable *ovs_ports)
+{
+    return (ovs_ports && g_hash_table_size(ovs_ports) > 0)
+            || (ovs->external_ids && g_hash_table_size(ovs->external_ids) > 0)
+            || (ovs->other_config && g_hash_table_size(ovs->other_config) > 0)
+            || ovs->lacp
+            || ovs->fail_mode
+            || ovs->mcast_snooping
+            || ovs->rstp
+            || ovs->protocols
+            || (ovs->ssl.ca_certificate || ovs->ssl.client_certificate || ovs->ssl.client_key)
+            || (ovs->controller.connection_mode || ovs->controller.addresses)
+            || backend == NETPLAN_BACKEND_OVS;
+}

--- a/src/yaml-helpers.h
+++ b/src/yaml-helpers.h
@@ -44,6 +44,11 @@
     yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t *)YAML_STR_TAG, (yaml_char_t *)scalar, strlen(scalar), 1, 0, YAML_PLAIN_SCALAR_STYLE); \
     if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto err_path; \
 }
+
+#define YAML_NULL_PLAIN(event_ptr, emitter_ptr) \
+    yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t*)YAML_NULL_TAG, (yaml_char_t*)"null", strlen("null"), 1, 0, YAML_PLAIN_SCALAR_STYLE); \
+    if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto err_path; \
+
 /* Implicit plain and quoted tags, double quoted style */
 #define YAML_SCALAR_QUOTED(event_ptr, emitter_ptr, scalar) \
 { \
@@ -70,6 +75,10 @@
     YAML_STRING_PLAIN(event_ptr, emitter_ptr, key, tmp); \
     g_free(tmp); \
 }
+
+#define YAML_NULL(event_ptr, emitter_ptr, key) \
+    YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, key); \
+    YAML_NULL_PLAIN(event_ptr, emitter_ptr); \
 
 /* open YAML emitter, document, stream and initial mapping */
 #define YAML_OUT_START(event_ptr, emitter_ptr, file) \

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import tempfile
 import io
+import yaml
 
 from generator.base import TestBase
 from parser.base import capture_stderr
@@ -342,3 +343,77 @@ class TestFreeFunctions(TestBase):
     def test_NetdefIterator_with_clear_netplan(self):
         state = libnetplan.State()
         self.assertSequenceEqual(list(libnetplan._NetdefIterator(state, "ethernets")), [])
+
+    def test_dump_yaml_subtree_bad_file_perms(self):
+        input_file = os.path.join(self.workdir.name, 'input.yaml')
+        with open(input_file, "w") as f, tempfile.TemporaryFile() as output:
+            with self.assertRaises(libnetplan.LibNetplanException) as context:
+                libnetplan.dump_yaml_subtree('network', f, output)
+        self.assertIn('Invalid argument', str(context.exception))
+
+    def test_dump_yaml_subtree_bad_yaml_outside(self):
+        input_file = os.path.join(self.workdir.name, 'input.yaml')
+        with open(input_file, "w+") as f, tempfile.TemporaryFile() as output:
+            f.write('{garbage)')
+            f.flush()
+            with self.assertRaises(libnetplan.LibNetplanException) as context:
+                libnetplan.dump_yaml_subtree('network', f, output)
+        self.assertIn('Error parsing YAML', str(context.exception))
+
+    def test_dump_yaml_subtree_bad_yaml_inside(self):
+        input_file = os.path.join(self.workdir.name, 'input.yaml')
+        with open(input_file, "w+") as f, tempfile.TemporaryFile() as output:
+            f.write('''network:
+  ethernets:
+    {garbage)''')
+            f.flush()
+
+            with self.assertRaises(libnetplan.LibNetplanException) as context:
+                libnetplan.dump_yaml_subtree('network', f, output)
+        self.assertIn('Error parsing YAML', str(context.exception))
+
+    def test_dump_yaml_subtree_bad_type(self):
+        input_file = os.path.join(self.workdir.name, 'input.yaml')
+        with open(input_file, "w+") as f, tempfile.TemporaryFile() as output:
+            f.write('''[]''')
+            f.flush()
+
+            with self.assertRaises(libnetplan.LibNetplanException) as context:
+                libnetplan.dump_yaml_subtree('network', f, output)
+        self.assertIn('Unexpected YAML structure found', str(context.exception))
+
+    def test_dump_yaml_subtree_bad_yaml_ignored(self):
+        input_file = os.path.join(self.workdir.name, 'input.yaml')
+        with open(input_file, "w+") as f, tempfile.TemporaryFile() as output:
+            f.write('''network:
+  ethernets: null
+ignored:
+  - [}''')
+            f.flush()
+            with self.assertRaises(libnetplan.LibNetplanException) as context:
+                libnetplan.dump_yaml_subtree('network', f, output)
+        self.assertIn('Error parsing YAML', str(context.exception))
+
+    def test_dump_yaml_subtree_discard_tail(self):
+        input_file = os.path.join(self.workdir.name, 'input.yaml')
+        with open(input_file, "w+") as f, tempfile.TemporaryFile() as output:
+            f.write('''network:
+  ethernets: {}
+tail:
+  - []''')
+            f.flush()
+            libnetplan.dump_yaml_subtree('network\tethernets', f, output)
+            output.seek(0)
+            self.assertEqual(yaml.safe_load(output), {})
+
+    def test_dump_yaml_absent_key(self):
+        input_file = os.path.join(self.workdir.name, 'input.yaml')
+        with open(input_file, "w+") as f, tempfile.TemporaryFile() as output:
+            f.write('''network:
+  ethernets: {}
+tail:
+  - []''')
+            f.flush()
+            libnetplan.dump_yaml_subtree('network\tethernets\teth0', f, output)
+            output.seek(0)
+            self.assertEqual(yaml.safe_load(output), None)


### PR DESCRIPTION
## Description

Introduce a couple of APIs that are needed for the various YAML consolidation efforts. Note that this is technically an API break, but the function that is removed has never been part of a release, so this *should* be OK.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

