### PR TITLE
YAML consolidation: `netplan get` (FR-702)

### DIFF
--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -106,6 +106,9 @@ class Parser:
     def load_yaml(self, filename):
         _checked_lib_call(lib.netplan_parser_load_yaml, self._ptr, filename.encode('utf-8'))
 
+    def load_yaml_hierarchy(self, rootdir):
+        _checked_lib_call(lib.netplan_parser_load_yaml_hierarchy, self._ptr, rootdir.encode('utf-8'))
+
 
 class State:
     _abi_loaded = False

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -31,14 +31,84 @@
 
 gchar *tmp = NULL;
 
+#define DIRTY(_def, _data) \
+    ((_def)->_private && \
+     (_def)->_private->dirty_fields && \
+     g_hash_table_contains((_def)->_private->dirty_fields, &(_data)))
+
+#define DIRTY_REF(_def, _data_ref) \
+    ((_def)->_private && \
+     (_def)->_private->dirty_fields && \
+     g_hash_table_contains((_def)->_private->dirty_fields, _data_ref))
+
+#define YAML_STRING(_def, event_ptr, emitter_ptr, key, value_ptr) {\
+    if (value_ptr) { \
+        YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, key); \
+        YAML_SCALAR_QUOTED(event_ptr, emitter_ptr, value_ptr); \
+    } else if DIRTY(_def, value_ptr) { \
+        YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, key); \
+        YAML_NULL_PLAIN(event_ptr, emitter_ptr); \
+    } \
+}\
+
+#define YAML_STRING_PLAIN(_def, event_ptr, emitter_ptr, key, value_ptr) {\
+    if (value_ptr) { \
+        YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, key); \
+        YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, value_ptr); \
+    } else if DIRTY(_def, value_ptr) { \
+        YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, key); \
+        YAML_NULL_PLAIN(event_ptr, emitter_ptr); \
+    } \
+}\
+
+#define YAML_UINT_DEFAULT(_def, event_ptr, emitter_ptr, key, value, default_value) {\
+    if (value != default_value) { \
+        _YAML_UINT(event_ptr, emitter_ptr, key, value); \
+    } else if DIRTY(_def, value) { \
+        YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, key); \
+        YAML_NULL_PLAIN(event_ptr, emitter_ptr); \
+    } \
+}\
+
+#define YAML_UINT_0(_def, event_ptr, emitter_ptr, key, value) \
+    YAML_UINT_DEFAULT(_def, event_ptr, emitter_ptr, key, value, 0);
+
+#define YAML_BOOL_TRUE(_def, event_ptr, emitter_ptr, key, value) {\
+    if (value) { \
+        YAML_NONNULL_STRING_PLAIN(event_ptr, emitter_ptr, key, "true"); \
+    } else if DIRTY(_def, value) { \
+        YAML_NONNULL_STRING_PLAIN(event_ptr, emitter_ptr, key, "false"); \
+    } \
+}\
+
+#define YAML_BOOL_FALSE(_def, event_ptr, emitter_ptr, key, value) {\
+    if (!value) { \
+        YAML_NONNULL_STRING_PLAIN(event_ptr, emitter_ptr, key, "false"); \
+    } else if DIRTY(_def, value) { \
+        YAML_NONNULL_STRING_PLAIN(event_ptr, emitter_ptr, key, "true"); \
+    } \
+}\
+
+static gboolean
+complex_object_is_dirty(const NetplanNetDefinition* def, char* obj, size_t obj_size) {
+    /* We literally check every address in the object! Ugly, but it works. */
+    for (size_t i = 0; i < obj_size; ++i) {
+        if (DIRTY_REF(def, obj+i))
+            return TRUE;
+    }
+    return FALSE;
+}
+
+#define DIRTY_COMPLEX(_def, _data) complex_object_is_dirty(_def, (char*)(&_data), sizeof(_data))
+
 static gboolean
 write_match(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     YAML_SCALAR_PLAIN(event, emitter, "match");
     YAML_MAPPING_OPEN(event, emitter);
-    YAML_STRING(event, emitter, "name", def->match.original_name);
-    YAML_STRING(event, emitter, "macaddress", def->match.mac)
-    YAML_STRING(event, emitter, "driver", def->match.driver)
+    YAML_NONNULL_STRING(event, emitter, "name", def->match.original_name);
+    YAML_NONNULL_STRING(event, emitter, "macaddress", def->match.mac)
+    YAML_NONNULL_STRING(event, emitter, "driver", def->match.driver)
     YAML_MAPPING_CLOSE(event, emitter);
     return TRUE;
 err_path: return FALSE; // LCOV_EXCL_LINE
@@ -49,16 +119,16 @@ write_auth(yaml_event_t* event, yaml_emitter_t* emitter, NetplanAuthenticationSe
 {
     YAML_SCALAR_PLAIN(event, emitter, "auth");
     YAML_MAPPING_OPEN(event, emitter);
-    YAML_STRING(event, emitter, "key-management", netplan_auth_key_management_type_name(auth.key_management));
-    YAML_STRING(event, emitter, "method", netplan_auth_eap_method_name(auth.eap_method));
-    YAML_STRING(event, emitter, "anonymous-identity", auth.anonymous_identity);
-    YAML_STRING(event, emitter, "identity", auth.identity);
-    YAML_STRING(event, emitter, "ca-certificate", auth.ca_certificate);
-    YAML_STRING(event, emitter, "client-certificate", auth.client_certificate);
-    YAML_STRING(event, emitter, "client-key", auth.client_key);
-    YAML_STRING(event, emitter, "client-key-password", auth.client_key_password);
-    YAML_STRING(event, emitter, "phase2-auth", auth.phase2_auth);
-    YAML_STRING(event, emitter, "password", auth.password);
+    YAML_NONNULL_STRING(event, emitter, "key-management", netplan_auth_key_management_type_name(auth.key_management));
+    YAML_NONNULL_STRING(event, emitter, "method", netplan_auth_eap_method_name(auth.eap_method));
+    YAML_NONNULL_STRING(event, emitter, "anonymous-identity", auth.anonymous_identity);
+    YAML_NONNULL_STRING(event, emitter, "identity", auth.identity);
+    YAML_NONNULL_STRING(event, emitter, "ca-certificate", auth.ca_certificate);
+    YAML_NONNULL_STRING(event, emitter, "client-certificate", auth.client_certificate);
+    YAML_NONNULL_STRING(event, emitter, "client-key", auth.client_key);
+    YAML_NONNULL_STRING(event, emitter, "client-key-password", auth.client_key_password);
+    YAML_NONNULL_STRING(event, emitter, "phase2-auth", auth.phase2_auth);
+    YAML_NONNULL_STRING(event, emitter, "password", auth.password);
     YAML_MAPPING_CLOSE(event, emitter);
     return TRUE;
 err_path: return FALSE; // LCOV_EXCL_LINE
@@ -67,7 +137,8 @@ err_path: return FALSE; // LCOV_EXCL_LINE
 static gboolean
 write_bond_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
-    if (def->bond_params.mode
+    if (DIRTY(def, def->bond_params)
+        || def->bond_params.mode
         || def->bond_params.monitor_interval
         || def->bond_params.up_delay
         || def->bond_params.down_delay
@@ -89,35 +160,32 @@ write_bond_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNet
         || def->bond_params.arp_ip_targets) {
         YAML_SCALAR_PLAIN(event, emitter, "parameters");
         YAML_MAPPING_OPEN(event, emitter);
-        YAML_STRING(event, emitter, "mode", def->bond_params.mode);
-        YAML_STRING(event, emitter, "mii-monitor-interval", def->bond_params.monitor_interval);
-        YAML_STRING(event, emitter, "up-delay", def->bond_params.up_delay);
-        YAML_STRING(event, emitter, "down-delay", def->bond_params.down_delay);
-        YAML_STRING(event, emitter, "lacp-rate", def->bond_params.lacp_rate);
-        YAML_STRING(event, emitter, "transmit-hash-policy", def->bond_params.transmit_hash_policy);
-        YAML_STRING(event, emitter, "ad-select", def->bond_params.selection_logic);
-        YAML_STRING(event, emitter, "arp-validate", def->bond_params.arp_validate);
-        YAML_STRING(event, emitter, "arp-all-targets", def->bond_params.arp_all_targets);
-        YAML_STRING(event, emitter, "fail-over-mac-policy", def->bond_params.fail_over_mac_policy);
-        YAML_STRING(event, emitter, "primary-reselect-policy", def->bond_params.primary_reselect_policy);
-        YAML_STRING(event, emitter, "learn-packet-interval", def->bond_params.learn_interval);
-        YAML_STRING(event, emitter, "arp-interval", def->bond_params.arp_interval);
-        YAML_STRING(event, emitter, "primary", def->bond_params.primary_slave);
-        if (def->bond_params.min_links)
-            YAML_UINT(event, emitter, "min-links", def->bond_params.min_links);
-        if (def->bond_params.all_slaves_active)
-            YAML_STRING_PLAIN(event, emitter, "all-slaves-active", "true");
-        if (def->bond_params.gratuitous_arp)
-            YAML_UINT(event, emitter, "gratuitous-arp", def->bond_params.gratuitous_arp);
-        if (def->bond_params.packets_per_slave)
-            YAML_UINT(event, emitter, "packets-per-slave", def->bond_params.packets_per_slave);
-        if (def->bond_params.resend_igmp)
-            YAML_UINT(event, emitter, "resend-igmp", def->bond_params.resend_igmp);
-        if (def->bond_params.arp_ip_targets) {
+        YAML_STRING(def, event, emitter, "mode", def->bond_params.mode);
+        YAML_STRING(def, event, emitter, "mii-monitor-interval", def->bond_params.monitor_interval);
+        YAML_STRING(def, event, emitter, "up-delay", def->bond_params.up_delay);
+        YAML_STRING(def, event, emitter, "down-delay", def->bond_params.down_delay);
+        YAML_STRING(def, event, emitter, "lacp-rate", def->bond_params.lacp_rate);
+        YAML_STRING(def, event, emitter, "transmit-hash-policy", def->bond_params.transmit_hash_policy);
+        YAML_STRING(def, event, emitter, "ad-select", def->bond_params.selection_logic);
+        YAML_STRING(def, event, emitter, "arp-validate", def->bond_params.arp_validate);
+        YAML_STRING(def, event, emitter, "arp-all-targets", def->bond_params.arp_all_targets);
+        YAML_STRING(def, event, emitter, "fail-over-mac-policy", def->bond_params.fail_over_mac_policy);
+        YAML_STRING(def, event, emitter, "primary-reselect-policy", def->bond_params.primary_reselect_policy);
+        YAML_STRING(def, event, emitter, "learn-packet-interval", def->bond_params.learn_interval);
+        YAML_STRING(def, event, emitter, "arp-interval", def->bond_params.arp_interval);
+        YAML_STRING(def, event, emitter, "primary", def->bond_params.primary_slave);
+        YAML_UINT_0(def, event, emitter, "min-links", def->bond_params.min_links);
+        YAML_BOOL_TRUE(def, event, emitter, "all-slaves-active", def->bond_params.all_slaves_active);
+        YAML_UINT_0(def, event, emitter, "gratuitous-arp", def->bond_params.gratuitous_arp);
+        YAML_UINT_0(def, event, emitter, "packets-per-slave", def->bond_params.packets_per_slave);
+        YAML_UINT_0(def, event, emitter, "resend-igmp", def->bond_params.resend_igmp);
+        if (def->bond_params.arp_ip_targets || DIRTY(def, def->bond_params.arp_ip_targets)) {
+            GArray* arr = def->bond_params.arp_ip_targets;
             YAML_SCALAR_PLAIN(event, emitter, "arp-ip-targets");
             YAML_SEQUENCE_OPEN(event, emitter);
-            for (unsigned i = 0; i < def->bond_params.arp_ip_targets->len; ++i)
-                YAML_SCALAR_PLAIN(event, emitter, g_array_index(def->bond_params.arp_ip_targets, char*, i));
+            if (arr)
+                for (unsigned i = 0; i < arr->len; ++i)
+                    YAML_SCALAR_PLAIN(event, emitter, g_array_index(arr, char*, i));
             YAML_SEQUENCE_CLOSE(event, emitter);
         }
         YAML_MAPPING_CLOSE(event, emitter);
@@ -129,7 +197,7 @@ err_path: return FALSE; // LCOV_EXCL_LINE
 static gboolean
 write_bridge_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def, const GArray *interfaces)
 {
-    if (def->custom_bridging) {
+    if (def->custom_bridging || DIRTY_COMPLEX(def, def->bridge_params)) {
         gboolean has_path_cost = FALSE;
         gboolean has_port_priority = FALSE;
         for (unsigned i = 0; i < interfaces->len; ++i) {
@@ -142,23 +210,19 @@ write_bridge_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanN
 
         YAML_SCALAR_PLAIN(event, emitter, "parameters");
         YAML_MAPPING_OPEN(event, emitter);
-        YAML_STRING(event, emitter, "ageing-time", def->bridge_params.ageing_time);
-        YAML_STRING(event, emitter, "forward-delay", def->bridge_params.forward_delay);
-        YAML_STRING(event, emitter, "hello-time", def->bridge_params.hello_time);
-        YAML_STRING(event, emitter, "max-age", def->bridge_params.max_age);
-        if (def->bridge_params.priority)
-            YAML_UINT(event, emitter, "priority", def->bridge_params.priority);
-        if (!def->bridge_params.stp)
-            YAML_STRING_PLAIN(event, emitter, "stp", "false");
+        YAML_STRING(def, event, emitter, "ageing-time", def->bridge_params.ageing_time);
+        YAML_STRING(def, event, emitter, "forward-delay", def->bridge_params.forward_delay);
+        YAML_STRING(def, event, emitter, "hello-time", def->bridge_params.hello_time);
+        YAML_STRING(def, event, emitter, "max-age", def->bridge_params.max_age);
+        YAML_UINT_0(def, event, emitter, "priority", def->bridge_params.priority);
+        YAML_BOOL_FALSE(def, event, emitter, "stp", def->bridge_params.stp);
 
         if (has_port_priority) {
             YAML_SCALAR_PLAIN(event, emitter, "port-priority");
             YAML_MAPPING_OPEN(event, emitter);
             for (unsigned i = 0; i < interfaces->len; ++i) {
                 NetplanNetDefinition *nd = g_array_index(interfaces, NetplanNetDefinition*, i);
-                if (nd->bridge_params.port_priority) {
-                    YAML_UINT(event, emitter, nd->id, nd->bridge_params.port_priority);
-                }
+                YAML_UINT_0(nd, event, emitter, nd->id, nd->bridge_params.port_priority);
             }
             YAML_MAPPING_CLOSE(event, emitter);
         }
@@ -168,9 +232,7 @@ write_bridge_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanN
             YAML_MAPPING_OPEN(event, emitter);
             for (unsigned i = 0; i < interfaces->len; ++i) {
                 NetplanNetDefinition *nd = g_array_index(interfaces, NetplanNetDefinition*, i);
-                if (nd->bridge_params.path_cost) {
-                    YAML_UINT(event, emitter, nd->id, nd->bridge_params.path_cost);
-                }
+                YAML_UINT_0(nd, event, emitter, nd->id, nd->bridge_params.path_cost);
             }
             YAML_MAPPING_CLOSE(event, emitter);
         }
@@ -185,17 +247,16 @@ static gboolean
 write_modem_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     /* some modem settings to auto-detect GSM vs CDMA connections */
-    if (def->modem_params.auto_config)
-        YAML_STRING_PLAIN(event, emitter, "auto-config", "true");
-    YAML_STRING(event, emitter, "apn", def->modem_params.apn);
-    YAML_STRING(event, emitter, "device-id", def->modem_params.device_id);
-    YAML_STRING(event, emitter, "network-id", def->modem_params.network_id);
-    YAML_STRING(event, emitter, "pin", def->modem_params.pin);
-    YAML_STRING(event, emitter, "sim-id", def->modem_params.sim_id);
-    YAML_STRING(event, emitter, "sim-operator-id", def->modem_params.sim_operator_id);
-    YAML_STRING(event, emitter, "username", def->modem_params.username);
-    YAML_STRING(event, emitter, "password", def->modem_params.password);
-    YAML_STRING(event, emitter, "number", def->modem_params.number);
+    YAML_BOOL_TRUE(def, event, emitter, "auto-config", def->modem_params.auto_config);
+    YAML_NONNULL_STRING(event, emitter, "apn", def->modem_params.apn);
+    YAML_NONNULL_STRING(event, emitter, "device-id", def->modem_params.device_id);
+    YAML_NONNULL_STRING(event, emitter, "network-id", def->modem_params.network_id);
+    YAML_NONNULL_STRING(event, emitter, "pin", def->modem_params.pin);
+    YAML_NONNULL_STRING(event, emitter, "sim-id", def->modem_params.sim_id);
+    YAML_NONNULL_STRING(event, emitter, "sim-operator-id", def->modem_params.sim_operator_id);
+    YAML_NONNULL_STRING(event, emitter, "username", def->modem_params.username);
+    YAML_NONNULL_STRING(event, emitter, "password", def->modem_params.password);
+    YAML_NONNULL_STRING(event, emitter, "number", def->modem_params.number);
     return TRUE;
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
@@ -210,7 +271,7 @@ _passthrough_handler(GQuark key_id, gpointer value, gpointer user_data)
 {
     _passthrough_handler_data *d = user_data;
     const gchar* key = g_quark_to_string(key_id);
-    YAML_STRING(d->event, d->emitter, key, value);
+    YAML_NONNULL_STRING(d->event, d->emitter, key, value);
 err_path: return; // LCOV_EXCL_LINE
 }
 
@@ -219,8 +280,8 @@ write_backend_settings(yaml_event_t* event, yaml_emitter_t* emitter, NetplanBack
     if (s.nm.uuid || s.nm.name || s.nm.passthrough) {
         YAML_SCALAR_PLAIN(event, emitter, "networkmanager");
         YAML_MAPPING_OPEN(event, emitter);
-        YAML_STRING(event, emitter, "uuid", s.nm.uuid);
-        YAML_STRING(event, emitter, "name", s.nm.name);
+        YAML_NONNULL_STRING(event, emitter, "uuid", s.nm.uuid);
+        YAML_NONNULL_STRING(event, emitter, "name", s.nm.name);
         if (s.nm.passthrough) {
             YAML_SCALAR_PLAIN(event, emitter, "passthrough");
             YAML_MAPPING_OPEN(event, emitter);
@@ -249,20 +310,19 @@ write_access_points(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanN
         ap = value;
         YAML_SCALAR_QUOTED(event, emitter, ap->ssid);
         YAML_MAPPING_OPEN(event, emitter);
-        if (ap->hidden)
-            YAML_STRING_PLAIN(event, emitter, "hidden", "true");
-        YAML_STRING(event, emitter, "bssid", ap->bssid);
+        YAML_BOOL_TRUE(def, event, emitter, "hidden", ap->hidden);
+        YAML_STRING(def, event, emitter, "bssid", ap->bssid);
         if (ap->band == NETPLAN_WIFI_BAND_5) {
-            YAML_STRING(event, emitter, "band", "5GHz");
+            YAML_NONNULL_STRING(event, emitter, "band", "5GHz");
         } else if (ap->band == NETPLAN_WIFI_BAND_24) {
-            YAML_STRING(event, emitter, "band", "2.4GHz");
+            YAML_NONNULL_STRING(event, emitter, "band", "2.4GHz");
         }
-        if (ap->channel)
-            YAML_UINT(event, emitter, "channel", ap->channel);
-        if (ap->has_auth)
+
+        YAML_UINT_0(def, event, emitter, "channel", ap->channel);
+        if (ap->has_auth || DIRTY(def, ap->auth))
             write_auth(event, emitter, ap->auth);
-        if (ap->mode != NETPLAN_WIFI_MODE_INFRASTRUCTURE)
-            YAML_STRING(event, emitter, "mode", netplan_wifi_mode_name(ap->mode));
+        if (ap->mode != NETPLAN_WIFI_MODE_INFRASTRUCTURE || DIRTY(def, ap->mode))
+            YAML_NONNULL_STRING(event, emitter, "mode", netplan_wifi_mode_name(ap->mode));
         if (!write_backend_settings(event, emitter, ap->backend_settings)) goto err_path;
         YAML_MAPPING_CLOSE(event, emitter);
     }
@@ -282,8 +342,8 @@ write_addresses(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDe
             YAML_MAPPING_OPEN(event, emitter);
             YAML_SCALAR_QUOTED(event, emitter, opts->address);
             YAML_MAPPING_OPEN(event, emitter);
-            YAML_STRING(event, emitter, "label", opts->label);
-            YAML_STRING(event, emitter, "lifetime", opts->lifetime);
+            YAML_NONNULL_STRING(event, emitter, "label", opts->label);
+            YAML_NONNULL_STRING(event, emitter, "lifetime", opts->lifetime);
             YAML_MAPPING_CLOSE(event, emitter);
             YAML_MAPPING_CLOSE(event, emitter);
         }
@@ -320,7 +380,7 @@ write_nameservers(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNet
         }
         YAML_SEQUENCE_CLOSE(event, emitter);
     }
-    if (def->search_domains){
+    if (def->search_domains || DIRTY(def, def->search_domains)){
         YAML_SCALAR_PLAIN(event, emitter, "search");
         YAML_SEQUENCE_OPEN(event, emitter);
         if (def->search_domains) {
@@ -335,37 +395,29 @@ err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
 static gboolean
-write_dhcp_overrides(yaml_event_t* event, yaml_emitter_t* emitter, const char* key, const NetplanDHCPOverrides data)
+write_dhcp_overrides(yaml_event_t* event, yaml_emitter_t* emitter, const char* key, const NetplanNetDefinition* def, const NetplanDHCPOverrides* data)
 {
-    if (   !data.use_dns
-        || !data.use_ntp
-        || !data.send_hostname
-        || !data.use_hostname
-        || !data.use_mtu
-        || !data.use_routes
-        || data.use_domains
-        || data.hostname
-        || data.metric != NETPLAN_METRIC_UNSPEC) {
+    if (DIRTY_COMPLEX(def, *data)
+        || !data->use_dns
+        || !data->use_ntp
+        || !data->send_hostname
+        || !data->use_hostname
+        || !data->use_mtu
+        || !data->use_routes
+        || data->use_domains
+        || data->hostname
+        || data->metric != NETPLAN_METRIC_UNSPEC) {
         YAML_SCALAR_PLAIN(event, emitter, key);
         YAML_MAPPING_OPEN(event, emitter);
-        if (!data.use_dns)
-            YAML_STRING_PLAIN(event, emitter, "use-dns", "false");
-        if (!data.use_ntp)
-            YAML_STRING_PLAIN(event, emitter, "use-ntp", "false");
-        if (!data.send_hostname)
-            YAML_STRING_PLAIN(event, emitter, "send-hostname", "false");
-        if (!data.use_hostname)
-            YAML_STRING_PLAIN(event, emitter, "use-hostname", "false");
-        if (!data.use_mtu)
-            YAML_STRING_PLAIN(event, emitter, "use-mtu", "false");
-        if (!data.use_routes)
-            YAML_STRING_PLAIN(event, emitter, "use-routes", "false");
-        if (data.use_domains)
-            YAML_STRING(event, emitter, "use-domains", data.use_domains);
-        if (data.hostname)
-            YAML_STRING(event, emitter, "hostname", data.hostname);
-        if (data.metric != NETPLAN_METRIC_UNSPEC)
-            YAML_UINT(event, emitter, "route-metric", data.metric);
+        YAML_BOOL_FALSE(def, event, emitter, "use-dns", data->use_dns);
+        YAML_BOOL_FALSE(def, event, emitter, "use-ntp", data->use_ntp);
+        YAML_BOOL_FALSE(def, event, emitter, "send-hostname", data->send_hostname);
+        YAML_BOOL_FALSE(def, event, emitter, "use-hostname", data->use_hostname);
+        YAML_BOOL_FALSE(def, event, emitter, "use-mtu", data->use_mtu);
+        YAML_BOOL_FALSE(def, event, emitter, "use-routes", data->use_routes);
+        YAML_STRING_PLAIN(def, event, emitter, "use-domains", data->use_domains);
+        YAML_STRING(def, event, emitter, "hostname", data->hostname);
+        YAML_UINT_DEFAULT(def, event, emitter, "route-metric", data->metric, NETPLAN_METRIC_UNSPEC);
         YAML_MAPPING_CLOSE(event, emitter);
     }
     return TRUE;
@@ -375,27 +427,24 @@ err_path: return FALSE; // LCOV_EXCL_LINE
 static gboolean
 write_tunnel_settings(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
-    YAML_STRING(event, emitter, "mode", netplan_tunnel_mode_name(def->tunnel.mode));
-    YAML_STRING(event, emitter, "local", def->tunnel.local_ip);
-    YAML_STRING(event, emitter, "remote", def->tunnel.remote_ip);
-    if (def->tunnel.fwmark)
-        YAML_UINT(event, emitter, "mark", def->tunnel.fwmark);
-    if (def->tunnel.port)
-        YAML_UINT(event, emitter, "port", def->tunnel.port);
-    if (def->tunnel_ttl)
-        YAML_UINT(event, emitter, "ttl", def->tunnel_ttl);
+    YAML_NONNULL_STRING(event, emitter, "mode", netplan_tunnel_mode_name(def->tunnel.mode));
+    YAML_STRING(def, event, emitter, "local", def->tunnel.local_ip);
+    YAML_STRING(def, event, emitter, "remote", def->tunnel.remote_ip);
+    YAML_UINT_0(def, event, emitter, "mark", def->tunnel.fwmark);
+    YAML_UINT_0(def, event, emitter, "port", def->tunnel.port);
+    YAML_UINT_0(def, event, emitter, "ttl", def->tunnel_ttl);
 
     if (def->tunnel.input_key || def->tunnel.output_key || def->tunnel.private_key) {
         if (   g_strcmp0(def->tunnel.input_key, def->tunnel.output_key) == 0
             && g_strcmp0(def->tunnel.input_key, def->tunnel.private_key) == 0) {
             /* use short form if all keys are the same */
-            YAML_STRING(event, emitter, "key", def->tunnel.input_key);
+            YAML_STRING(def, event, emitter, "key", def->tunnel.input_key);
         } else {
             YAML_SCALAR_PLAIN(event, emitter, "keys");
             YAML_MAPPING_OPEN(event, emitter);
-            YAML_STRING(event, emitter, "input", def->tunnel.input_key);
-            YAML_STRING(event, emitter, "output", def->tunnel.output_key);
-            YAML_STRING(event, emitter, "private", def->tunnel.private_key);
+            YAML_STRING(def, event, emitter, "input", def->tunnel.input_key);
+            YAML_STRING(def, event, emitter, "output", def->tunnel.output_key);
+            YAML_STRING(def, event, emitter, "private", def->tunnel.private_key);
             YAML_MAPPING_CLOSE(event, emitter);
         }
     }
@@ -407,14 +456,13 @@ write_tunnel_settings(yaml_event_t* event, yaml_emitter_t* emitter, const Netpla
         for (unsigned i = 0; i < def->wireguard_peers->len; ++i) {
             NetplanWireguardPeer *peer = g_array_index(def->wireguard_peers, NetplanWireguardPeer*, i);
             YAML_MAPPING_OPEN(event, emitter);
-            YAML_STRING(event, emitter, "endpoint", peer->endpoint);
-            if (peer->keepalive)
-                YAML_UINT(event, emitter, "keepalive", peer->keepalive);
+            YAML_STRING(def, event, emitter, "endpoint", peer->endpoint);
+            YAML_UINT_0(def, event, emitter, "keepalive", peer->keepalive);
             if (peer->public_key || peer->preshared_key) {
                 YAML_SCALAR_PLAIN(event, emitter, "keys");
                 YAML_MAPPING_OPEN(event, emitter);
-                YAML_STRING(event, emitter, "public", peer->public_key);
-                YAML_STRING(event, emitter, "shared", peer->preshared_key);
+                YAML_STRING(def, event, emitter, "public", peer->public_key);
+                YAML_STRING(def, event, emitter, "shared", peer->preshared_key);
                 YAML_MAPPING_CLOSE(event, emitter);
             }
             if (peer->allowed_ips && peer->allowed_ips->len > 0) {
@@ -444,27 +492,18 @@ write_routes(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefin
             YAML_MAPPING_OPEN(event, emitter);
             NetplanIPRoute *r = g_array_index(def->routes, NetplanIPRoute*, i);
             if (r->type && g_strcmp0(r->type, "unicast") != 0)
-                YAML_STRING(event, emitter, "type", r->type);
+                YAML_NONNULL_STRING(event, emitter, "type", r->type);
             if (r->scope && g_strcmp0(r->scope, "global") != 0)
-                YAML_STRING(event, emitter, "scope", r->scope);
-            if (r->metric != NETPLAN_METRIC_UNSPEC)
-                YAML_UINT(event, emitter, "metric", r->metric);
-            if (r->table != NETPLAN_ROUTE_TABLE_UNSPEC)
-                YAML_UINT(event, emitter, "table", r->table);
-            if (r->mtubytes)
-                YAML_UINT(event, emitter, "mtu", r->mtubytes);
-            if (r->congestion_window)
-                YAML_UINT(event, emitter, "congestion-window", r->congestion_window);
-            if (r->advertised_receive_window)
-                YAML_UINT(event, emitter, "advertised-receive-window", r->advertised_receive_window);
-            if (r->onlink)
-                YAML_STRING(event, emitter, "on-link", "true");
-            if (r->from)
-                YAML_STRING(event, emitter, "from", r->from);
-            if (r->to)
-                YAML_STRING(event, emitter, "to", r->to);
-            if (r->via)
-                YAML_STRING(event, emitter, "via", r->via);
+                YAML_NONNULL_STRING(event, emitter, "scope", r->scope);
+            YAML_UINT_DEFAULT(def, event, emitter, "metric", r->metric, NETPLAN_METRIC_UNSPEC);
+            YAML_UINT_DEFAULT(def, event, emitter, "table", r->table, NETPLAN_ROUTE_TABLE_UNSPEC);
+            YAML_UINT_0(def, event, emitter, "mtu", r->mtubytes);
+            YAML_UINT_0(def, event, emitter, "congestion-window", r->congestion_window);
+            YAML_UINT_0(def, event, emitter, "advertised-receive-window", r->advertised_receive_window);
+            YAML_BOOL_TRUE(def, event, emitter, "on-link", r->onlink);
+            YAML_STRING(def, event, emitter, "from", r->from);
+            YAML_STRING(def, event, emitter, "to", r->to);
+            YAML_STRING(def, event, emitter, "via", r->via);
             YAML_MAPPING_CLOSE(event, emitter);
         }
         YAML_SEQUENCE_CLOSE(event, emitter);
@@ -476,18 +515,12 @@ write_routes(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefin
         for (unsigned i = 0; i < def->ip_rules->len; ++i) {
             NetplanIPRule *r = g_array_index(def->ip_rules, NetplanIPRule*, i);
             YAML_MAPPING_OPEN(event, emitter);
-            if (r->table != NETPLAN_ROUTE_TABLE_UNSPEC)
-                YAML_UINT(event, emitter, "table", r->table);
-            if (r->priority != NETPLAN_IP_RULE_PRIO_UNSPEC)
-                YAML_UINT(event, emitter, "priority", r->priority);
-            if (r->tos != NETPLAN_IP_RULE_TOS_UNSPEC)
-                YAML_UINT(event, emitter, "type-of-service", r->tos);
-            if (r->fwmark != NETPLAN_IP_RULE_FW_MARK_UNSPEC)
-                YAML_UINT(event, emitter, "mark", r->fwmark);
-            if (r->from)
-                YAML_STRING(event, emitter, "from", r->from);
-            if (r->to)
-                YAML_STRING(event, emitter, "to", r->to);
+            YAML_UINT_DEFAULT(def, event, emitter, "table", r->table, NETPLAN_ROUTE_TABLE_UNSPEC);
+            YAML_UINT_DEFAULT(def, event, emitter, "priority", r->priority, NETPLAN_IP_RULE_PRIO_UNSPEC);
+            YAML_UINT_DEFAULT(def, event, emitter, "type-of-service", r->tos, NETPLAN_IP_RULE_TOS_UNSPEC);
+            YAML_UINT_DEFAULT(def, event, emitter, "mark", r->fwmark, NETPLAN_IP_RULE_FW_MARK_UNSPEC);
+            YAML_STRING(def, event, emitter, "from", r->from);
+            YAML_STRING(def, event, emitter, "to", r->to);
             YAML_MAPPING_CLOSE(event, emitter);
         }
         YAML_SEQUENCE_CLOSE(event, emitter);
@@ -528,7 +561,7 @@ write_openvswitch(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanOVS
             YAML_MAPPING_OPEN(event, emitter);
             g_hash_table_iter_init(&iter, ovs->external_ids);
             while (g_hash_table_iter_next (&iter, &key, &value)) {
-                YAML_STRING(event, emitter, key, value);
+                YAML_NONNULL_STRING(event, emitter, key, value);
             }
             YAML_MAPPING_CLOSE(event, emitter);
         }
@@ -537,16 +570,16 @@ write_openvswitch(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanOVS
             YAML_MAPPING_OPEN(event, emitter);
             g_hash_table_iter_init(&iter, ovs->other_config);
             while (g_hash_table_iter_next (&iter, &key, &value)) {
-                YAML_STRING(event, emitter, key, value);
+                YAML_NONNULL_STRING(event, emitter, key, value);
             }
             YAML_MAPPING_CLOSE(event, emitter);
         }
-        YAML_STRING(event, emitter, "lacp", ovs->lacp);
-        YAML_STRING(event, emitter, "fail-mode", ovs->fail_mode);
+        YAML_NONNULL_STRING(event, emitter, "lacp", ovs->lacp);
+        YAML_NONNULL_STRING(event, emitter, "fail-mode", ovs->fail_mode);
         if (ovs->mcast_snooping)
-            YAML_STRING_PLAIN(event, emitter, "mcast-snooping", "true");
+            YAML_NONNULL_STRING_PLAIN(event, emitter, "mcast-snooping", "true");
         if (ovs->rstp)
-            YAML_STRING_PLAIN(event, emitter, "rstp", "true");
+            YAML_NONNULL_STRING_PLAIN(event, emitter, "rstp", "true");
         if (ovs->protocols && ovs->protocols->len > 0) {
             YAML_SCALAR_PLAIN(event, emitter, "protocols");
             YAML_SEQUENCE_OPEN(event, emitter);
@@ -559,15 +592,15 @@ write_openvswitch(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanOVS
         if (ovs->ssl.ca_certificate || ovs->ssl.client_certificate || ovs->ssl.client_key) {
             YAML_SCALAR_PLAIN(event, emitter, "ssl");
             YAML_MAPPING_OPEN(event, emitter);
-            YAML_STRING(event, emitter, "ca-cert", ovs->ssl.ca_certificate);
-            YAML_STRING(event, emitter, "certificate", ovs->ssl.client_certificate);
-            YAML_STRING(event, emitter, "private-key", ovs->ssl.client_key);
+            YAML_NONNULL_STRING(event, emitter, "ca-cert", ovs->ssl.ca_certificate);
+            YAML_NONNULL_STRING(event, emitter, "certificate", ovs->ssl.client_certificate);
+            YAML_NONNULL_STRING(event, emitter, "private-key", ovs->ssl.client_key);
             YAML_MAPPING_CLOSE(event, emitter);
         }
         if (ovs->controller.connection_mode || ovs->controller.addresses) {
             YAML_SCALAR_PLAIN(event, emitter, "controller");
             YAML_MAPPING_OPEN(event, emitter);
-            YAML_STRING(event, emitter, "connection-mode", ovs->controller.connection_mode);
+            YAML_NONNULL_STRING(event, emitter, "connection-mode", ovs->controller.connection_mode);
             if (ovs->controller.addresses) {
                 YAML_SCALAR_PLAIN(event, emitter, "addresses");
                 YAML_SEQUENCE_OPEN(event, emitter);
@@ -599,12 +632,16 @@ _serialize_yaml(
 
     YAML_SCALAR_PLAIN(event, emitter, def->id);
     YAML_MAPPING_OPEN(event, emitter);
+    /* We write out the renderer in very specific circumstances. There's a special case for VLANs,
+     * and unless explicitly specified, we only write out standard renderers if they don't match the global
+     * one or are the default and the global one isn't specified. */
     if (def->type == NETPLAN_DEF_TYPE_VLAN && def->sriov_vlan_filter) {
-        YAML_STRING_PLAIN(event, emitter, "renderer", "sriov");
-    } else if (def->backend == NETPLAN_BACKEND_NM) {
-        YAML_STRING_PLAIN(event, emitter, "renderer", "NetworkManager");
-    } else if (def->backend == NETPLAN_BACKEND_NETWORKD) {
-        YAML_STRING_PLAIN(event, emitter, "renderer", "networkd");
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "renderer", "sriov");
+    } else if (DIRTY(def, def->backend) ||
+            (   def->backend != get_default_backend_for_type(np_state->backend, def->type)
+             && def->backend != np_state->backend
+             && def->backend != NETPLAN_BACKEND_OVS)) {
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "renderer", netplan_backend_name(def->backend));
     }
 
     if (def->has_match)
@@ -615,61 +652,52 @@ _serialize_yaml(
         goto only_passthrough;
 
     if (def->optional)
-        YAML_STRING_PLAIN(event, emitter, "optional", "true");
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "optional", "true");
     if (def->critical)
-        YAML_STRING_PLAIN(event, emitter, "critical", "true");
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "critical", "true");
 
     if (def->ignore_carrier)
-        YAML_STRING_PLAIN(event, emitter, "ignore-carrier", "true");
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "ignore-carrier", "true");
 
     if (def->ip4_addresses || def->ip6_addresses || def->address_options)
         write_addresses(event, emitter, def);
     if (def->ip4_nameservers || def->ip6_nameservers || def->search_domains)
         write_nameservers(event, emitter, def);
 
-    YAML_STRING_PLAIN(event, emitter, "gateway4", def->gateway4);
-    YAML_STRING_PLAIN(event, emitter, "gateway6", def->gateway6);
+    YAML_STRING_PLAIN(def, event, emitter, "gateway4", def->gateway4);
+    YAML_STRING_PLAIN(def, event, emitter, "gateway6", def->gateway6);
 
-    if (def->dhcp_identifier)
-        YAML_STRING(event, emitter, "dhcp-identifier", def->dhcp_identifier);
-    if (def->dhcp4) {
-        YAML_STRING_PLAIN(event, emitter, "dhcp4", "true");
-        write_dhcp_overrides(event, emitter, "dhcp4-overrides", def->dhcp4_overrides);
-    }
-    if (def->dhcp6) {
-        YAML_STRING_PLAIN(event, emitter, "dhcp6", "true");
-        write_dhcp_overrides(event, emitter, "dhcp6-overrides", def->dhcp6_overrides);
-    }
+    YAML_STRING(def, event, emitter, "dhcp-identifier", def->dhcp_identifier);
+    YAML_BOOL_TRUE(def, event, emitter, "dhcp4", def->dhcp4);
+    write_dhcp_overrides(event, emitter, "dhcp4-overrides", def, &def->dhcp4_overrides);
+    YAML_BOOL_TRUE(def, event, emitter, "dhcp6", def->dhcp6);
+    write_dhcp_overrides(event, emitter, "dhcp6-overrides", def, &def->dhcp6_overrides);
     if (def->accept_ra == NETPLAN_RA_MODE_ENABLED) {
-        YAML_STRING_PLAIN(event, emitter, "accept-ra", "true");
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "accept-ra", "true");
     } else if (def->accept_ra == NETPLAN_RA_MODE_DISABLED) {
-        YAML_STRING_PLAIN(event, emitter, "accept-ra", "false");
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "accept-ra", "false");
     }
 
-    YAML_STRING(event, emitter, "macaddress", def->set_mac);
-    YAML_STRING(event, emitter, "set-name", def->set_name);
-    YAML_STRING(event, emitter, "ipv6-address-generation", netplan_addr_gen_mode_name(def->ip6_addr_gen_mode));
-    YAML_STRING(event, emitter, "ipv6-address-token", def->ip6_addr_gen_token);
-    if (def->ip6_privacy)
-        YAML_STRING_PLAIN(event, emitter, "ipv6-privacy", "true");
-    if (def->ipv6_mtubytes)
-        YAML_UINT(event, emitter, "ipv6-mtu", def->ipv6_mtubytes);
-    if (def->mtubytes)
-        YAML_UINT(event, emitter, "mtu", def->mtubytes);
+    YAML_STRING(def, event, emitter, "macaddress", def->set_mac);
+    YAML_STRING(def, event, emitter, "set-name", def->set_name);
+    YAML_NONNULL_STRING(event, emitter, "ipv6-address-generation", netplan_addr_gen_mode_name(def->ip6_addr_gen_mode));
+    YAML_STRING(def, event, emitter, "ipv6-address-token", def->ip6_addr_gen_token);
+    YAML_BOOL_TRUE(def, event, emitter, "ipv6-privacy", def->ip6_privacy);
+    YAML_UINT_0(def, event, emitter, "ipv6-mtu", def->ipv6_mtubytes);
+    YAML_UINT_0(def, event, emitter, "mtu", def->mtubytes);
     if (def->emit_lldp)
-        YAML_STRING_PLAIN(event, emitter, "emit-lldp", "true");
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "emit-lldp", "true");
 
     if (def->has_auth)
         write_auth(event, emitter, def->auth);
+
     /* activation-mode */
-    if (def->activation_mode)
-        YAML_STRING(event, emitter, "activation-mode", def->activation_mode);
+    YAML_STRING(def, event, emitter, "activation-mode", def->activation_mode);
 
     /* SR-IOV */
     if (def->sriov_link)
-        YAML_STRING(event, emitter, "link", def->sriov_link->id);
-    if (def->sriov_explicit_vf_count < G_MAXUINT)
-        YAML_UINT(event, emitter, "virtual-function-count", def->sriov_explicit_vf_count);
+        YAML_STRING(def, event, emitter, "link", def->sriov_link->id);
+    YAML_UINT_DEFAULT(def, event, emitter, "virtual-function-count", def->sriov_explicit_vf_count, G_MAXUINT);
 
     /* Search interfaces */
     if (def->type == NETPLAN_DEF_TYPE_BRIDGE || def->type == NETPLAN_DEF_TYPE_BOND) {
@@ -694,17 +722,13 @@ _serialize_yaml(
         g_array_free(tmp_arr, TRUE);
     }
 
-    /* Routes */
-    if (def->routes || def->ip_rules) {
-        write_routes(event, emitter, def);
-    }
+    write_routes(event, emitter, def);
 
     /* VLAN settings */
     if (def->type == NETPLAN_DEF_TYPE_VLAN) {
-        if (def->vlan_id != G_MAXUINT)
-            YAML_UINT(event, emitter, "id", def->vlan_id);
+        YAML_UINT_DEFAULT(def, event, emitter, "id", def->vlan_id, G_MAXUINT);
         if (def->vlan_link)
-            YAML_STRING_PLAIN(event, emitter, "link", def->vlan_link->id);
+            YAML_STRING(def, event, emitter, "link", def->vlan_link->id);
     }
 
     /* Tunnel settings */
@@ -713,30 +737,16 @@ _serialize_yaml(
     }
 
     /* wake-on-lan */
-    if (def->wake_on_lan)
-        YAML_STRING_PLAIN(event, emitter, "wakeonlan", "true");
+    YAML_BOOL_TRUE(def, event, emitter, "wakeonlan", def->wake_on_lan);
 
     /* Offload options */
-    if (def->receive_checksum_offload)
-        YAML_STRING_PLAIN(event, emitter, "receive-checksum-offload", "true");
-
-    if (def->transmit_checksum_offload)
-        YAML_STRING_PLAIN(event, emitter, "transmit-checksum-offload", "true");
-
-    if (def->tcp_segmentation_offload)
-        YAML_STRING_PLAIN(event, emitter, "tcp-segmentation-offload", "true");
-
-    if (def->tcp6_segmentation_offload)
-        YAML_STRING_PLAIN(event, emitter, "tcp6-segmentation-offload", "true");
-
-    if (def->generic_segmentation_offload)
-        YAML_STRING_PLAIN(event, emitter, "generic-segmentation-offload", "true");
-
-    if (def->generic_receive_offload)
-        YAML_STRING_PLAIN(event, emitter, "generic-receive-offload", "true");
-
-    if (def->large_receive_offload)
-        YAML_STRING_PLAIN(event, emitter, "large-receive-offload", "true");
+    YAML_BOOL_TRUE(def, event, emitter, "receive-checksum-offload", def->receive_checksum_offload);
+    YAML_BOOL_TRUE(def, event, emitter, "transmit-checksum-offload", def->transmit_checksum_offload);
+    YAML_BOOL_TRUE(def, event, emitter, "tcp-segmentation-offload", def->tcp_segmentation_offload);
+    YAML_BOOL_TRUE(def, event, emitter, "tcp6-segmentation-offload", def->tcp6_segmentation_offload);
+    YAML_BOOL_TRUE(def, event, emitter, "generic-segmentation-offload", def->generic_segmentation_offload);
+    YAML_BOOL_TRUE(def, event, emitter, "generic-receive-offload", def->generic_receive_offload);
+    YAML_BOOL_TRUE(def, event, emitter, "large-receive-offload", def->large_receive_offload);
 
     if (def->wowlan && def->wowlan != NETPLAN_WIFI_WOWLAN_DEFAULT) {
         YAML_SCALAR_PLAIN(event, emitter, "wakeonwlan");
@@ -847,7 +857,7 @@ netplan_netdef_write_yaml(
     /* build the netplan boilerplate YAML structure */
     YAML_SCALAR_PLAIN(event, emitter, "network");
     YAML_MAPPING_OPEN(event, emitter);
-    YAML_STRING_PLAIN(event, emitter, "version", "2");
+    YAML_NONNULL_STRING_PLAIN(event, emitter, "version", "2");
 
     if (netplan_def_type_name(netdef->type)) {
         YAML_SCALAR_PLAIN(event, emitter, netplan_def_type_name(netdef->type));
@@ -904,12 +914,12 @@ netplan_netdef_list_write_yaml(const NetplanState* np_state, GList* netdefs, int
     YAML_SCALAR_PLAIN(event, emitter, "network");
     YAML_MAPPING_OPEN(event, emitter);
     /* We support version 2 only, currently */
-    YAML_STRING_PLAIN(event, emitter, "version", "2");
+    YAML_NONNULL_STRING_PLAIN(event, emitter, "version", "2");
 
     if (netplan_state_get_backend(np_state) == NETPLAN_BACKEND_NM) {
-        YAML_STRING_PLAIN(event, emitter, "renderer", "NetworkManager");
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "renderer", "NetworkManager");
     } else if (netplan_state_get_backend(np_state) == NETPLAN_BACKEND_NETWORKD) {
-        YAML_STRING_PLAIN(event, emitter, "renderer", "networkd");
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "renderer", "networkd");
     }
 
     /* Go through the netdefs type-by-type */
@@ -986,4 +996,3 @@ netplan_state_dump_yaml(const NetplanState* np_state, int out_fd, GError** error
 void write_netplan_conf_finish(const char* rootdir)
 void cleanup_netplan_conf(const char* rootdir)
 */
-

--- a/src/parse.c
+++ b/src/parse.c
@@ -695,11 +695,11 @@ static const mapping_entry_handler auth_handlers[] = {
  * Grammar and handlers for network device definition
  ****************************************************/
 
-static NetplanBackend
-get_default_backend_for_type(const NetplanParser *npp, NetplanDefType type)
+NetplanBackend
+get_default_backend_for_type(NetplanBackend global_backend, NetplanDefType type)
 {
-    if (npp->global_backend != NETPLAN_BACKEND_NONE)
-        return npp->global_backend;
+    if (global_backend != NETPLAN_BACKEND_NONE)
+        return global_backend;
 
     /* networkd can handle all device types at the moment, so nothing
      * type-specific */
@@ -2704,7 +2704,7 @@ finish_iterator(const NetplanParser* npp, NetplanNetDefinition* nd, GError **err
 {
     /* Take more steps to make sure we always have a backend set for netdefs */
     if (nd->backend == NETPLAN_BACKEND_NONE) {
-        nd->backend = get_default_backend_for_type(npp, nd->type);
+        nd->backend = get_default_backend_for_type(npp->global_backend, nd->type);
         g_debug("%s: setting default backend to %i", nd->id, nd->backend);
     }
 

--- a/src/types.c
+++ b/src/types.c
@@ -168,6 +168,15 @@ reset_backend_settings(NetplanBackendSettings* settings, NetplanBackend backend)
     }
 }
 
+static void
+reset_private_netdef_data(struct private_netdef_data* data) {
+    if (!data)
+        return;
+    if (data->dirty_fields)
+        g_hash_table_destroy(data->dirty_fields);
+    data->dirty_fields = NULL;
+}
+
 /* Free a heap-allocated NetplanWifiAccessPoint object.
  * Signature made to match the g_hash_table_foreach function.
  * @key: ignored
@@ -323,6 +332,9 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     netdef->generic_segmentation_offload = FALSE;
     netdef->generic_receive_offload = FALSE;
     netdef->large_receive_offload = FALSE;
+
+    reset_private_netdef_data(netdef->_private);
+    FREE_AND_NULLIFY(netdef->_private);
 }
 
 static void

--- a/src/types.h
+++ b/src/types.h
@@ -339,6 +339,12 @@ struct netplan_net_definition {
     gboolean generic_segmentation_offload;
     gboolean generic_receive_offload;
     gboolean large_receive_offload;
+
+    struct private_netdef_data* _private;
+};
+
+struct private_netdef_data {
+    GHashTable* dirty_fields;
 };
 
 typedef enum {

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -68,6 +68,9 @@ mark_data_as_dirty(NetplanParser* npp, void* data_ptr);
 const char*
 tunnel_mode_to_string(NetplanTunnelMode mode);
 
+NetplanBackend
+get_default_backend_for_type(NetplanBackend global_backend, NetplanDefType type);
+
 NetplanNetDefinition*
 netplan_netdef_new(NetplanParser* npp, const char* id, NetplanDefType type, NetplanBackend renderer);
 

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -62,6 +62,9 @@ systemd_escape(char* string);
 
 #define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"
 
+void
+mark_data_as_dirty(NetplanParser* npp, void* data_ptr);
+
 const char*
 tunnel_mode_to_string(NetplanTunnelMode mode);
 

--- a/src/util.c
+++ b/src/util.c
@@ -588,3 +588,16 @@ has_openvswitch(const NetplanOVSSettings* ovs, NetplanBackend backend, GHashTabl
             || (ovs->controller.connection_mode || ovs->controller.addresses)
             || backend == NETPLAN_BACKEND_OVS;
 }
+
+void
+mark_data_as_dirty(NetplanParser* npp, void* data_ptr)
+{
+    // We don't support dirty tracking for globals yet.
+    if (!npp->current.netdef)
+        return;
+    if (!npp->current.netdef->_private)
+        npp->current.netdef->_private = g_new0(struct private_netdef_data, 1);
+    if (!npp->current.netdef->_private->dirty_fields)
+        npp->current.netdef->_private->dirty_fields = g_hash_table_new(g_direct_hash, g_direct_equal);
+    g_hash_table_insert(npp->current.netdef->_private->dirty_fields, data_ptr, data_ptr);
+}

--- a/src/yaml-helpers.h
+++ b/src/yaml-helpers.h
@@ -55,24 +55,24 @@
     yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t *)YAML_STR_TAG, (yaml_char_t *)scalar, strlen(scalar), 1, 1, YAML_DOUBLE_QUOTED_SCALAR_STYLE); \
     if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto err_path; \
 }
-#define YAML_STRING(event_ptr, emitter_ptr, key, value_ptr) \
+#define YAML_NONNULL_STRING(event_ptr, emitter_ptr, key, value_ptr) \
 { \
     if (value_ptr) { \
         YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, key); \
         YAML_SCALAR_QUOTED(event_ptr, emitter_ptr, value_ptr); \
     } \
 }
-#define YAML_STRING_PLAIN(event_ptr, emitter_ptr, key, value_ptr) \
+#define YAML_NONNULL_STRING_PLAIN(event_ptr, emitter_ptr, key, value_ptr) \
 { \
     if (value_ptr) { \
         YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, key); \
         YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, value_ptr); \
     } \
 }
-#define YAML_UINT(event_ptr, emitter_ptr, key, value) \
+#define _YAML_UINT(event_ptr, emitter_ptr, key, value) \
 { \
     tmp = g_strdup_printf("%u", value); \
-    YAML_STRING_PLAIN(event_ptr, emitter_ptr, key, tmp); \
+    YAML_NONNULL_STRING_PLAIN(event_ptr, emitter_ptr, key, tmp); \
     g_free(tmp); \
 }
 

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -316,7 +316,7 @@ route1_options=unknown=invalid,
         mtu: 1024
         congestion-window: 44
         advertised-receive-window: 33
-        on-link: "true"
+        on-link: true
         from: "10.10.10.11"
         to: "1.1.2.2/16"
         via: "8.8.8.8"


### PR DESCRIPTION
## Description

Port the `netplan get` command to use the internal YAML generator, originally written for the NM-to-netplan system.
In order to make this work, we had to add a notion of "dirtyness" to the input data, as the user would want their explicit settings displayed even if they match the default value.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

