### PR TITLE
Enable eswitch mode setting on SmartNICs

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -814,6 +814,23 @@ Example:
 
      **Requires feature: sriov**
 
+``embedded-switch-mode`` (scalar) – since **0.104**
+
+:    (SR-IOV devices only) Change the operational mode of the embedded switch
+     of a supported SmartNIC PCI device (e.g. Mellanox ConnectX-5). Possible
+     values are ``switchdev`` or ``legacy``, if unspecified the vendor's
+     default configuration is used.
+
+     **Requires feature: eswitch-mode**
+
+``delay-virtual-functions-rebind`` (bool) – since **0.104**
+
+:    (SR-IOV devices only) Delay rebinding of SR-IOV virtual functions to its
+     driver after changing the embedded-switch-mode setting to a later stage.
+     Can be enabled when bonding/VF LAG is in use. Defaults to ``false``.
+
+     **Requires feature: eswitch-mode**
+
 ## Properties for device type ``modems:``
 GSM/CDMA modem configuration is only supported for the ``NetworkManager``
 backend. ``systemd-networkd`` does not support modems.

--- a/examples/sriov.yaml
+++ b/examples/sriov.yaml
@@ -4,6 +4,7 @@ network:
   ethernets:
     eno1:
       mtu: 9000
+      embedded-switch-mode: "switchdev"
     enp1s16f1:
       link: eno1
       addresses : [ "10.15.98.25/24" ]

--- a/netplan/cli/commands/__init__.py
+++ b/netplan/cli/commands/__init__.py
@@ -23,6 +23,7 @@ from netplan.cli.commands.try_command import NetplanTry
 from netplan.cli.commands.info import NetplanInfo
 from netplan.cli.commands.set import NetplanSet
 from netplan.cli.commands.get import NetplanGet
+from netplan.cli.commands.sriov_rebind import NetplanSriovRebind
 
 __all__ = [
     'NetplanApply',
@@ -33,4 +34,5 @@ __all__ = [
     'NetplanInfo',
     'NetplanSet',
     'NetplanGet',
+    'NetplanSriovRebind'
 ]

--- a/netplan/cli/commands/sriov_rebind.py
+++ b/netplan/cli/commands/sriov_rebind.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2022 Canonical, Ltd.
+# Author: Lukas Märdian <slyon@ubuntu.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+'''netplan SR-IOV rebind command line'''
+
+import logging
+
+import netplan.cli.utils as utils
+from netplan.cli.sriov import PCIDevice, bind_vfs, _get_pci_slot_name
+
+
+class NetplanSriovRebind(utils.NetplanCommand):
+
+    def __init__(self):
+        super().__init__(command_id='rebind',
+                         description='Rebind SR-IOV virtual functions of given physical functions to their driver',
+                         leaf=True)
+
+    def run(self):
+        self.parser.add_argument('netdevs', type=str, nargs='*', default=[],
+                                 help='Space separated list of PF interface names')
+        self.func = self.command_rebind
+
+        self.parse_args()
+        self.run_command()
+
+    def command_rebind(self):
+        """Bind virtual functions of SR-IOV devices to their corresponding driver after eswitch mode was changed"""
+        for iface in self.netdevs:
+            pci_addr = _get_pci_slot_name(iface)
+            pcidev = PCIDevice(pci_addr)
+            if not pcidev.is_pf:
+                logging.warning('{} does not seem to be a SR-IOV physical function'.format(iface))
+                continue
+            bound_vfs = bind_vfs(pcidev.vfs, pcidev.driver)
+            logging.info('{}: bound {} VFs'.format(pcidev, len(bound_vfs)))

--- a/netplan/cli/sriov.py
+++ b/netplan/cli/sriov.py
@@ -502,10 +502,6 @@ def apply_sriov_config(config_manager, rootdir='/'):
             # this only works for SR-IOV VF interfaces
             link = settings.get('link')
             vlan_id = settings.get('id')
-            if not vlan_id:
-                raise ConfigurationError(
-                    'no id property defined for SR-IOV vlan %s' % vlan)
-
             vf = vfs.get(link)
             if not vf:
                 # it is possible this is not an error, for instance when

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -133,6 +133,12 @@ class State:
         lib.netplan_state_dump_yaml.argtypes = [_NetplanStateP, c_int, _GErrorPP]
         lib.netplan_state_dump_yaml.restype = c_int
 
+        lib.netplan_netdef_get_embedded_switch_mode.argtypes = [_NetplanNetDefinitionP]
+        lib.netplan_netdef_get_embedded_switch_mode.restype = c_char_p
+
+        lib.netplan_netdef_get_delay_virtual_functions_rebind.argtypes = [_NetplanNetDefinitionP]
+        lib.netplan_netdef_get_delay_virtual_functions_rebind.restype = c_int
+
         cls._abi_loaded = True
 
     def __init__(self):
@@ -187,6 +193,15 @@ class NetDefinition:
     @property
     def id(self):
         return lib.netplan_netdef_get_id(self._ptr).decode('utf-8')
+
+    @property
+    def embedded_switch_mode(self):
+        mode = lib.netplan_netdef_get_embedded_switch_mode(self._ptr)
+        return mode and mode.decode('utf-8')
+
+    @property
+    def delay_virtual_functions_rebind(self):
+        return bool(lib.netplan_netdef_get_delay_virtual_functions_rebind(self._ptr))
 
 
 class _NetdefIterator:

--- a/src/abi_compat.c
+++ b/src/abi_compat.c
@@ -29,6 +29,7 @@
 #include "names.h"
 #include "networkd.h"
 #include "nm.h"
+#include "sriov.h"
 #include "openvswitch.h"
 #include "util.h"
 
@@ -185,6 +186,19 @@ NETPLAN_INTERNAL void
 cleanup_ovs_conf(const char* rootdir)
 {
     netplan_ovs_cleanup(rootdir);
+}
+
+NETPLAN_INTERNAL void
+write_sriov_conf_finish(const char* rootdir)
+{
+    /* Original implementation had no error possible!! */
+    g_assert(netplan_state_finish_sriov_write(&global_state, rootdir, NULL));
+}
+
+NETPLAN_INTERNAL void
+cleanup_sriov_conf(const char* rootdir)
+{
+    netplan_sriov_cleanup(rootdir);
 }
 // LCOV_EXCL_STOP
 

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -707,6 +707,9 @@ _serialize_yaml(
     if (def->sriov_link)
         YAML_STRING(def, event, emitter, "link", def->sriov_link->id);
     YAML_UINT_DEFAULT(def, event, emitter, "virtual-function-count", def->sriov_explicit_vf_count, G_MAXUINT);
+    YAML_STRING(def, event, emitter, "embedded-switch-mode", def->embedded_switch_mode);
+    YAML_BOOL_TRUE(def, event, emitter, "delay-virtual-functions-rebind",
+                   def->sriov_delay_virtual_functions_rebind);
 
     /* Search interfaces */
     if (def->type == NETPLAN_DEF_TYPE_BRIDGE || def->type == NETPLAN_DEF_TYPE_BOND) {

--- a/src/sriov.c
+++ b/src/sriov.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2020 Canonical, Ltd.
+ * Copyright (C) 2020-2022 Canonical, Ltd.
  * Author: Łukasz 'sil2100' Zemczak <lukasz.zemczak@canonical.com>
+ * Author: Lukas Märdian <slyon@ubuntu.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,6 +17,7 @@
  */
 
 #include <unistd.h>
+#include <errno.h>
 
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -24,18 +26,99 @@
 #include "util-internal.h"
 #include "sriov.h"
 
-void
-write_sriov_conf_finish(const char* rootdir)
+static gboolean
+write_sriov_rebind_systemd_unit(const GString* pfs, const char* rootdir, GError** error)
 {
-    /* For now we execute apply --sriov-only everytime there is a new
-       SR-IOV device appearing, which is fine as it's relatively fast */
-    GString *udev_rule = g_string_new("ACTION==\"add\", SUBSYSTEM==\"net\", ATTRS{sriov_totalvfs}==\"?*\", RUN+=\"/usr/sbin/netplan apply --sriov-only\"\n");
-    g_string_free_to_file(udev_rule, rootdir, "run/udev/rules.d/99-sriov-netplan-setup.rules", NULL);
+    g_autofree gchar* id_escaped = NULL;
+    g_autofree char* link = g_strjoin(NULL, rootdir ?: "", "/run/systemd/system/multi-user.target.wants/netplan-sriov-rebind.service", NULL);
+    g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-sriov-rebind.service", NULL);
+    gchar** split = NULL;
+
+    GString* s = g_string_new("[Unit]\n");
+    g_string_append(s, "Description=(Re-)bind SR-IOV Virtual Functions to their driver\n");
+    g_string_append_printf(s, "After=network.target\n");
+
+    /* Run after udev */
+    split = g_strsplit(pfs->str, " ", 0);
+    for (unsigned i = 0; split[i]; ++i)
+        g_string_append_printf(s, "After=sys-subsystem-net-devices-%s.device\n",
+                               split[i]);
+    g_strfreev(split);
+
+    g_string_append(s, "\n[Service]\nType=oneshot\n");
+    g_string_append_printf(s, "ExecStart=" SBINDIR "/netplan rebind %s\n", pfs->str);
+
+    g_string_free_to_file(s, rootdir, path, NULL);
+
+    safe_mkdir_p_dir(link);
+    if (symlink(path, link) < 0 && errno != EEXIST) {
+        // LCOV_EXCL_START
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
+                    "failed to create enablement symlink: %m\n");
+        return FALSE;
+        // LCOV_EXCL_STOP
+    }
+    return TRUE;
 }
 
-void
-cleanup_sriov_conf(const char* rootdir)
+/**
+ * Finalize the SR-IOV configuration (global config)
+ */
+gboolean
+netplan_state_finish_sriov_write(const NetplanState* np_state, const char* rootdir, GError** error)
 {
-    g_autofree char* rulepath = g_strjoin(NULL, rootdir ?: "", "/run/udev/rules.d/99-sriov-netplan-setup.rules", NULL);
-    unlink(rulepath);
+    NetplanNetDefinition* def = NULL;
+    NetplanNetDefinition* pf = NULL;
+    gboolean any_sriov = FALSE;
+    gboolean ret = TRUE;
+
+    if (np_state) {
+        GString* pfs = g_string_new(NULL);
+        /* Find netdev interface names for SR-IOV PFs*/
+        for (GList* iterator = np_state->netdefs_ordered; iterator; iterator = iterator->next) {
+            def = (NetplanNetDefinition*) iterator->data;
+            pf = NULL;
+            if (def->sriov_explicit_vf_count < G_MAXUINT || def->sriov_link) {
+                any_sriov = TRUE;
+                if (def->sriov_explicit_vf_count < G_MAXUINT)
+                    pf = def;
+                else if (def->sriov_link)
+                    pf = def->sriov_link;
+            }
+
+            if (pf && pf->sriov_delay_virtual_functions_rebind) {
+                if (pf->set_name)
+                    g_string_append_printf(pfs, "%s ", pf->set_name);
+                else if (!pf->has_match) /* netdef_id == interface name */
+                    g_string_append_printf(pfs, "%s ", pf->id);
+                else
+                    g_warning("%s: Cannot rebind SR-IOV virtual functions, unknown interface name. "
+                              "Use 'netplan rebind <IFACE>' to rebind manually or use the 'set-name' stanza.",
+                              pf->id);
+            }
+        }
+        if (pfs->len > 0) {
+            g_string_truncate(pfs, pfs->len-1); /* cut trailing whitespace */
+            ret = write_sriov_rebind_systemd_unit(pfs, rootdir, NULL);
+        }
+        g_string_free(pfs, TRUE);
+    }
+
+    if (any_sriov) {
+        /* For now we execute apply --sriov-only everytime there is a new
+        SR-IOV device appearing, which is fine as it's relatively fast */
+        GString *udev_rule = g_string_new("ACTION==\"add\", SUBSYSTEM==\"net\", ATTRS{sriov_totalvfs}==\"?*\", RUN+=\"/usr/sbin/netplan apply --sriov-only\"\n");
+        g_string_free_to_file(udev_rule, rootdir, "run/udev/rules.d/99-sriov-netplan-setup.rules", NULL);
+    }
+
+    return ret;
+}
+
+gboolean
+netplan_sriov_cleanup(const char* rootdir)
+{
+    unlink_glob(rootdir, "/run/udev/rules.d/*-sriov-netplan-*.rules");
+    unlink_glob(rootdir, "/run/systemd/system/netplan-sriov-*.service");
+    return TRUE;
+
 }

--- a/src/sriov.h
+++ b/src/sriov.h
@@ -18,8 +18,17 @@
 #pragma once
 #include "netplan.h"
 
+NETPLAN_INTERNAL gboolean
+netplan_state_finish_sriov_write(
+        const NetplanState* np_state,
+        const char* rootdir,
+        GError** error);
+
+NETPLAN_INTERNAL gboolean
+netplan_sriov_cleanup(const char* rootdir);
+
+/* Deprecated API */
 NETPLAN_INTERNAL void
 write_sriov_conf_finish(const char* rootdir);
-
 NETPLAN_INTERNAL void
 cleanup_sriov_conf(const char* rootdir);

--- a/src/types.c
+++ b/src/types.c
@@ -456,3 +456,17 @@ netplan_state_has_nondefault_globals(const NetplanState* np_state)
         return (np_state->backend != NETPLAN_BACKEND_NONE)
                 || has_openvswitch(&np_state->ovs_settings, NETPLAN_BACKEND_NONE, NULL);
 }
+
+NETPLAN_INTERNAL const char*
+netplan_netdef_get_embedded_switch_mode(const NetplanNetDefinition* netdef)
+{
+    g_assert(netdef);
+    return netdef->embedded_switch_mode;
+}
+
+NETPLAN_INTERNAL gboolean
+netplan_netdef_get_delay_virtual_functions_rebind(const NetplanNetDefinition* netdef)
+{
+    g_assert(netdef);
+    return netdef->sriov_delay_virtual_functions_rebind;
+}

--- a/src/types.h
+++ b/src/types.h
@@ -342,6 +342,10 @@ struct netplan_net_definition {
     gboolean large_receive_offload;
 
     struct private_netdef_data* _private;
+
+    /* netplan-feature: eswitch-mode */
+    char* embedded_switch_mode;
+    gboolean sriov_delay_virtual_functions_rebind;
 };
 
 struct private_netdef_data {

--- a/src/validation.h
+++ b/src/validation.h
@@ -37,4 +37,7 @@ gboolean
 validate_backend_rules(const NetplanParser* npp, NetplanNetDefinition* nd, GError** error);
 
 gboolean
+validate_sriov_rules(const NetplanParser* npp, NetplanNetDefinition* nd, GError** error);
+
+gboolean
 validate_default_route_consistency(const NetplanParser* npp, GHashTable* netdefs, GError** error);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -456,3 +456,10 @@ class TestBase(unittest.TestCase):
                 self.assertEqual(link_target,
                                  os.path.join(
                                     '/', 'run', 'systemd', 'system', fname))
+
+    def assert_sriov(self, file_contents_map):
+        systemd_dir = os.path.join(self.workdir.name, 'run', 'systemd', 'system')
+        sriov_systemd_dir = glob.glob(os.path.join(systemd_dir, '*netplan-sriov-*.service'))
+        self.assertEqual(set(os.path.basename(file) for file in sriov_systemd_dir),
+                         {'netplan-sriov-' + f for f in file_contents_map})
+        self.assertEqual(set(os.listdir(self.workdir.name)) - {'lib'}, {'etc', 'run'})

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -18,29 +18,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 import unittest
 import tempfile
-import io
 import shutil
 import glob
 
 import yaml
 
-from contextlib import redirect_stdout
-from netplan.cli.core import Netplan
-
-
-def _call_cli(args):
-    old_sys_argv = sys.argv
-    sys.argv = [old_sys_argv[0]] + args
-    f = io.StringIO()
-    try:
-        with redirect_stdout(f):
-            Netplan().main()
-            return f.getvalue()
-    finally:
-        sys.argv = old_sys_argv
+from tests.test_utils import call_cli
 
 
 class TestSet(unittest.TestCase):
@@ -56,7 +41,7 @@ class TestSet(unittest.TestCase):
 
     def _set(self, args):
         args.insert(0, 'set')
-        out = _call_cli(args + ['--root-dir', self.workdir.name])
+        out = call_cli(args + ['--root-dir', self.workdir.name])
         self.assertEqual(out, '', msg='netplan set returned unexpected output')
 
     def test_set_scalar(self):
@@ -352,7 +337,7 @@ class TestGet(unittest.TestCase):
 
     def _get(self, args):
         args.insert(0, 'get')
-        return _call_cli(args + ['--root-dir', self.workdir.name])
+        return call_cli(args + ['--root-dir', self.workdir.name])
 
     def test_get_scalar(self):
         with open(self.path, 'w') as f:

--- a/tests/test_sriov.py
+++ b/tests/test_sriov.py
@@ -99,10 +99,10 @@ class TestSRIOV(unittest.TestCase):
                    os.path.join(self.workdir.name, 'sys/class/net/enp2'))
         os.symlink('../../../0000:00:1f.0', os.path.join(self.workdir.name, 'sys/class/net/enp2/device'))
         # the PF additionally has device links to all the VFs defined for it
-        os.symlink('../../../0000:00:1f.4', os.path.join(pf_dev_path, 'virtfn1'))
-        os.symlink('../../../0000:00:1f.5', os.path.join(pf_dev_path, 'virtfn2'))
-        os.symlink('../../../0000:00:1f.6', os.path.join(pf_dev_path, 'virtfn3'))
-        os.symlink('../../../0000:00:1f.7', os.path.join(pf_dev_path, 'virtfn4'))
+        os.symlink('../../../0000:00:1f.4', os.path.join(pf_dev_path, 'virtfn0'))
+        os.symlink('../../../0000:00:1f.5', os.path.join(pf_dev_path, 'virtfn1'))
+        os.symlink('../../../0000:00:1f.6', os.path.join(pf_dev_path, 'virtfn2'))
+        os.symlink('../../../0000:00:1f.7', os.path.join(pf_dev_path, 'virtfn3'))
 
     @patch('netplan.cli.utils.get_interface_driver_name')
     @patch('netplan.cli.utils.get_interface_macaddress')
@@ -407,13 +407,13 @@ class TestSRIOV(unittest.TestCase):
         self.assertEqual(check_call.call_count, 1)
         self.assertListEqual(check_call.call_args[0][0],
                              ['ip', 'link', 'set', 'dev', 'enp2',
-                              'vf', '3', 'vlan', '10'])
+                              'vf', '2', 'vlan', '10'])
 
     @patch('subprocess.check_call')
     def test_apply_vlan_filter_for_vf_failed_no_index(self, check_call):
         self._prepare_sysfs_dir_structure()
         # we remove the PF -> VF link, simulating a system error
-        os.unlink(os.path.join(self.workdir.name, 'sys/class/net/enp2/device/virtfn3'))
+        os.unlink(os.path.join(self.workdir.name, 'sys/class/net/enp2/device/virtfn2'))
 
         with self.assertRaises(RuntimeError) as e:
             sriov.apply_vlan_filter_for_vf('enp2', 'enp2s16f1', 'vlan10', 10, prefix=self.workdir.name)

--- a/tests/test_sriov.py
+++ b/tests/test_sriov.py
@@ -68,41 +68,76 @@ class TestSRIOV(unittest.TestCase):
         os.makedirs(os.path.join(self.workdir.name, 'etc/netplan'))
         self.configmanager = ConfigManager(prefix=self.workdir.name, extra_files={})
 
-    def _prepare_sysfs_dir_structure(self):
+    def _prepare_sysfs_dir_structure(self, pf=('enp2', '0000:00:1f.0'),
+                                     vfs=[('enp2s16f1', '0000:00:1f.6')], pf_driver='dummy_driver'):
+        """
+        Setup sysfs mock for reading certain SR-IOV related files and symlinks
+
+        :param tuple pf: A tuple descibing the physical function (iterface_name, pci_address)
+        :param list vfs: A list of tuples describing the virtual functions related to this PF
+        :param str pf_driver: The driver name to be mocked for this PF
+        """
+        pf_iface, pf_pci_addr = pf
         # prepare a directory hierarchy for testing the matching
         # this might look really scary, but that's how sysfs presents devices
         # such as these
-        os.makedirs(os.path.join(self.workdir.name, 'sys/class/net'))
+        sysfs = os.path.join(self.workdir.name, 'sys')
+        sys_devices = os.path.join(sysfs, 'devices/pci0000:00')
+        pci_devices = os.path.join(sysfs, 'bus/pci/devices')
+        pci_driver = os.path.join(sysfs, 'bus/pci/drivers', pf_driver)
+        os.makedirs(os.path.join(sysfs, 'class/net'), exist_ok=True)
+        os.makedirs(pci_devices, exist_ok=True)
+        os.makedirs(pci_driver, exist_ok=True)  # access to 'bind' and 'unbind' files must be mocked
 
-        # first the VF
-        vf_iface_path = os.path.join(self.workdir.name, 'sys/devices/pci0000:00/0000:00:1f.6/net/enp2s16f1')
-        vf_dev_path = os.path.join(self.workdir.name, 'sys/devices/pci0000:00/0000:00:1f.6')
-        os.makedirs(vf_iface_path)
-        with open(os.path.join(vf_dev_path, 'vendor'), 'w') as f:
-            f.write('0x001f\n')
-        with open(os.path.join(vf_dev_path, 'device'), 'w') as f:
-            f.write('0xb33f\n')
-        os.symlink('../../devices/pci0000:00/0000:00:1f.6/net/enp2s16f1',
-                   os.path.join(self.workdir.name, 'sys/class/net/enp2s16f1'))
-        os.symlink('../../../0000:00:1f.6', os.path.join(self.workdir.name, 'sys/class/net/enp2s16f1/device'))
-
-        # now the PF
-        os.path.join(self.workdir.name, 'sys/class/net/enp2')
-        pf_iface_path = os.path.join(self.workdir.name, 'sys/devices/pci0000:00/0000:00:1f.0/net/enp2')
-        pf_dev_path = os.path.join(self.workdir.name, 'sys/devices/pci0000:00/0000:00:1f.0')
+        # create the PF (enp2) dir
+        # syfs mock in:
+        # sys/devices/pci0000:00/PCI_ADDR
+        # sys/devices/pci0000:00/PCI_ADDR/net/IFACE
+        pf_iface_path = os.path.join(sys_devices, pf_pci_addr, 'net', pf_iface)
+        pf_dev_path = os.path.join(sys_devices, pf_pci_addr)
         os.makedirs(pf_iface_path)
+        # symlink it to /sys/bus/pci/devices
+        os.symlink(os.path.join('../../../devices/pci0000:00', pf_pci_addr),
+                   os.path.join(pci_devices, pf_pci_addr))
+
+        # create VF (enp2s16f1, ...) dirs
+        # sysfs mock in:
+        # sys/devices/pci0000:00/PCI_ADDR and
+        # sys/devices/pci0000:00/PCI_ADDR/net/IFACE
+        for vf_iface, vf_pci_addr in vfs:
+            vf_iface_path = os.path.join(sys_devices, vf_pci_addr, 'net', vf_iface)
+            vf_dev_path = os.path.join(sys_devices, vf_pci_addr)
+            os.makedirs(vf_iface_path)
+            # symlink it to /sys/bus/pci/devices
+            os.symlink(os.path.join('../../../devices/pci0000:00', vf_pci_addr),
+                       os.path.join(pci_devices, vf_pci_addr))
+
+            # populate the VF data
+            with open(os.path.join(vf_dev_path, 'vendor'), 'w') as f:
+                f.write('0x001f\n')
+            with open(os.path.join(vf_dev_path, 'device'), 'w') as f:
+                f.write('0xb33f\n')
+            os.symlink(os.path.join('../../devices/pci0000:00', vf_pci_addr, 'net', vf_iface),
+                       os.path.join(sysfs, 'class/net', vf_iface))
+            os.symlink(os.path.join('../../..', vf_pci_addr),
+                       os.path.join(sysfs, 'class/net', vf_iface, 'device'))
+            # the VFs additionally have a device link to the PF
+            os.symlink(os.path.join('../../..', pf_pci_addr), os.path.join(vf_dev_path, 'physfn'))
+
+        # populate the PF data
         with open(os.path.join(pf_dev_path, 'vendor'), 'w') as f:
             f.write('0x001f\n')
         with open(os.path.join(pf_dev_path, 'device'), 'w') as f:
             f.write('0x1337\n')
-        os.symlink('../../devices/pci0000:00/0000:00:1f.0/net/enp2',
-                   os.path.join(self.workdir.name, 'sys/class/net/enp2'))
-        os.symlink('../../../0000:00:1f.0', os.path.join(self.workdir.name, 'sys/class/net/enp2/device'))
+        with open(os.path.join(pf_dev_path, 'sriov_numvfs'), 'w') as f:
+            f.write(str(len(vfs))+'\n')
+        os.symlink(os.path.join('../../../bus/pci/drivers', pf_driver), os.path.join(pf_dev_path, 'driver'))
+        os.symlink(os.path.join('../../devices/pci0000:00', pf_pci_addr, 'net', pf_iface),
+                   os.path.join(sysfs, 'class/net', pf_iface))
+        os.symlink(os.path.join('../../..', pf_pci_addr), os.path.join(sysfs, 'class/net', pf_iface, 'device'))
         # the PF additionally has device links to all the VFs defined for it
-        os.symlink('../../../0000:00:1f.4', os.path.join(pf_dev_path, 'virtfn0'))
-        os.symlink('../../../0000:00:1f.5', os.path.join(pf_dev_path, 'virtfn1'))
-        os.symlink('../../../0000:00:1f.6', os.path.join(pf_dev_path, 'virtfn2'))
-        os.symlink('../../../0000:00:1f.7', os.path.join(pf_dev_path, 'virtfn3'))
+        for i in range(len(vfs)):
+            os.symlink(os.path.join('../../..', vfs[i][1]), os.path.join(pf_dev_path, 'virtfn'+str(i)))
 
     @patch('netplan.cli.utils.get_interface_driver_name')
     @patch('netplan.cli.utils.get_interface_macaddress')
@@ -407,11 +442,14 @@ class TestSRIOV(unittest.TestCase):
         self.assertEqual(check_call.call_count, 1)
         self.assertListEqual(check_call.call_args[0][0],
                              ['ip', 'link', 'set', 'dev', 'enp2',
-                              'vf', '2', 'vlan', '10'])
+                              'vf', '0', 'vlan', '10'])
 
     @patch('subprocess.check_call')
     def test_apply_vlan_filter_for_vf_failed_no_index(self, check_call):
-        self._prepare_sysfs_dir_structure()
+        self._prepare_sysfs_dir_structure(vfs=[('enp2s14f1', '0000:00:1f.4'),
+                                               ('enp2s15f1', '0000:00:1f.5'),
+                                               ('enp2s16f1', '0000:00:1f.6'),
+                                               ('enp2s17f1', '0000:00:1f.7')])
         # we remove the PF -> VF link, simulating a system error
         os.unlink(os.path.join(self.workdir.name, 'sys/class/net/enp2/device/virtfn2'))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,12 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import io
 import os
+import sys
 import unittest
 import tempfile
 import glob
 import netifaces
 
+from contextlib import redirect_stdout
+from netplan.cli.core import Netplan
 import netplan.cli.utils as utils
 from unittest.mock import patch
 
@@ -91,6 +95,18 @@ fi
     def set_returncode(self, returncode):
         with open(self.path, "a") as fp:
             fp.write("exit %d" % returncode)
+
+
+def call_cli(args):
+    old_sys_argv = sys.argv
+    sys.argv = [old_sys_argv[0]] + args
+    f = io.StringIO()
+    try:
+        with redirect_stdout(f):
+            Netplan().main()
+            return f.getvalue()
+    finally:
+        sys.argv = old_sys_argv
 
 
 class TestUtils(unittest.TestCase):


### PR DESCRIPTION
## Description
Certain types of network cards/SmartNICs allow toggling their low-level (`devlink`) embedded switch mode PCI setting in order to utilize the full hardware offloading capabilities. With this PR we're exposing this functionality to the netplan YAML schema:
* `embedded-switch-mode: [switchdev|legacy]`
  * choose the devlink setting for the embedded switch (eswitch)
  * sticks to the hardware's preset by default
* `delay-virtual-functions-rebind: [false|true]`
  * False by default: SR-IOV virtual functions are re-bind to their driver right after setting the eswitch mode
  * Can be delayed to a later stage during the boot process; useful when OVS/OVN bonding (VF LAG) is to be used

Example:
```
network:
  version: 2
  ethernets:
    engreen:
      embedded-switch-mode: "switchdev"
      delay-virtual-functions-rebind: true
    enblue:
      match:
        driver: "mlx5_core"
      set-name: enblue
      embedded-switch-mode: "legacy"
      virtual-function-count: 4
    sriov_vf0:
      link: engreen
```

This PR builds upon the new libnetplan YAML parser (https://github.com/canonical/netplan/pull/250) for accessing the new settings.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

