### PR TITLE
YAML consolidation: `netplan set` (FR-702)

### DIFF
--- a/include/netplan.h
+++ b/include/netplan.h
@@ -54,6 +54,16 @@ netplan_state_get_netdefs_size(const NetplanState* np_state);
 NETPLAN_PUBLIC NetplanNetDefinition*
 netplan_state_get_netdef(const NetplanState* np_state, const char* id);
 
+/* Write the selected yaml file. All definitions that originate from this file,
+ * as well as those without any given origin, are written to it.
+ */
+NETPLAN_PUBLIC gboolean
+netplan_state_write_yaml_file(
+        const NetplanState* np_state,
+        const char* filename,
+        const char* rootdir,
+        GError** error);
+
 /* Dump the whole yaml configuration into the given file, regardless of the origin
  * of each definition.
  */

--- a/include/netplan.h
+++ b/include/netplan.h
@@ -64,6 +64,16 @@ netplan_state_write_yaml_file(
         const char* rootdir,
         GError** error);
 
+/* Update all the YAML files that were used to create this state.
+ * The definitions without clear origin are written to @default_filename.
+ */
+NETPLAN_PUBLIC gboolean
+netplan_state_update_yaml_hierarchy(
+        const NetplanState* np_state,
+        const char* default_filename,
+        const char* rootdir,
+        GError** error);
+
 /* Dump the whole yaml configuration into the given file, regardless of the origin
  * of each definition.
  */

--- a/include/parse.h
+++ b/include/parse.h
@@ -62,6 +62,9 @@ netplan_parser_load_yaml(NetplanParser* npp, const char* filename, GError** erro
 NETPLAN_PUBLIC gboolean
 netplan_state_import_parser_results(NetplanState* np_state, NetplanParser* npp, GError** error);
 
+NETPLAN_PUBLIC gboolean
+netplan_parser_load_yaml_from_fd(NetplanParser* npp, int input_fd, GError** error);
+
 /********** Old API below this ***********/
 
 NETPLAN_PUBLIC gboolean

--- a/include/parse.h
+++ b/include/parse.h
@@ -65,6 +65,9 @@ netplan_state_import_parser_results(NetplanState* np_state, NetplanParser* npp, 
 NETPLAN_PUBLIC gboolean
 netplan_parser_load_yaml_from_fd(NetplanParser* npp, int input_fd, GError** error);
 
+NETPLAN_PUBLIC gboolean
+netplan_parser_load_nullable_fields(NetplanParser* npp, int input_fd, GError** error);
+
 /********** Old API below this ***********/
 
 NETPLAN_PUBLIC gboolean

--- a/netplan/cli/commands/set.py
+++ b/netplan/cli/commands/set.py
@@ -17,19 +17,14 @@
 
 '''netplan set command line'''
 
-import os
-import yaml
 import tempfile
 import re
-import logging
-import shutil
-import glob
+import io
 
 from netplan.cli.utils import NetplanCommand
 import netplan.libnetplan as libnetplan
-from netplan.configmanager import ConfigManager
 
-FALLBACK_HINT = '70-netplan-set'
+FALLBACK_FILENAME = '70-netplan-set.yaml'
 GLOBAL_KEYS = ['renderer', 'version']
 
 
@@ -54,151 +49,37 @@ class NetplanSet(NetplanCommand):
         self.parse_args()
         self.run_command()
 
-    def is_emtpy_yaml(self, tree):
-        if isinstance(tree, dict) and list(tree.keys()) == ['network'] and tree['network'] is None:
-            return True
-        return False
-
-    def split_tree_by_hint(self, set_tree) -> (str, dict):
-        network = set_tree.get('network', {})
-        # A mapping of 'origin-hint' -> YAML tree (one subtree per netdef)
-        subtrees = dict()
-        for devtype in network:
-            if devtype in GLOBAL_KEYS:
-                continue  # special handling of global keys down below
-            devtype_content = network.get(devtype, [])
-            # Special case: removal of a whole devtype.
-            # We replace the devtype null node with a dict of all defined netdefs
-            # set to None.
-            if devtype_content is None:
-                devtype_content = {dev: None for dev in libnetplan.netplan_get_ids_for_devtype(devtype, self.root_dir)}
-                network[devtype] = devtype_content
-            for netdef in devtype_content:
-                hint = FALLBACK_HINT
-                filename = libnetplan.netplan_get_filename_by_id(netdef, self.root_dir)
-                if filename:
-                    hint = os.path.basename(filename)[:-5]  # strip prefix and .yaml
-                netdef_tree = {'network': {devtype: {netdef: network.get(devtype).get(netdef)}}}
-                # Merge all netdef trees which are going to be written to the same file/hint
-                subtrees[hint] = self.merge(subtrees.get(hint, {}), netdef_tree)
-
-        # Merge GLOBAL_KEYS into one of the available subtrees
-        # Write to same file (if only one hint/subtree is available)
-        # Write to FALLBACK_HINT if multiple hints/subtrees are available, as we do not know where it is supposed to go
-        if any(network.get(key) for key in GLOBAL_KEYS):
-            # Write to the same file, if we have only one file-hint or to FALLBACK_HINT otherwise
-            hint = list(subtrees)[0] if len(subtrees) == 1 else FALLBACK_HINT
-            for key in GLOBAL_KEYS:
-                tree = {'network': {key: network.get(key)}}
-                subtrees[hint] = self.merge(subtrees.get(hint, {}), tree)
-
-        # return a list of (str:hint, dict:subtree) tuples
-        return subtrees.items()
-
     def command_set(self):
         if self.origin_hint is not None and len(self.origin_hint) == 0:
             raise Exception('Invalid/empty origin-hint')
+        if self.origin_hint:
+            filename = '.'.join((self.origin_hint, 'yaml'))
+        else:
+            filename = None
         split = self.key_value.split('=', 1)
         if len(split) != 2:
             raise Exception('Invalid value specified')
+
         key, value = split
-        set_tree = self.parse_key(key, yaml.safe_load(value))
+        if not key.startswith('network'):
+            key = '.'.join(('network', key))
 
-        # special case: clear all YAML (or a specific hint file) if "network=null" is set
-        if self.is_emtpy_yaml(set_tree):
-            path = os.path.join('etc', 'netplan')
-            if self.origin_hint:  # clear specific hint file, it it does exist
-                hint_path = os.path.join(self.root_dir, path, self.origin_hint + '.yaml')
-                if os.path.isfile(hint_path):
-                    os.remove(hint_path)
-            else:  # clear all YAML files in <ROOT_DIR>/etc/netplan/*.yaml
-                yaml_files = glob.glob(os.path.join(self.root_dir, path, '*.yaml'))
-                for f in yaml_files:
-                    os.remove(f)
-            return
+        # Split the string into a list on the dot separators, and unescape the remaining dots
+        yaml_path = [s.replace(r'\.', '.') for s in re.split(r'(?<!\\)\.', key)]
 
-        hints = [(self.origin_hint, set_tree)]
-        # Override YAML config in each individual netdef file if origin-hint is not set
-        if self.origin_hint is None:
-            hints = self.split_tree_by_hint(set_tree)
+        parser = libnetplan.Parser()
+        with tempfile.TemporaryFile() as tmp:
+            libnetplan.create_yaml_patch(yaml_path, value, tmp)
+            tmp.flush()
+            tmp.seek(0, io.SEEK_SET)
+            parser.load_nullable_fields(tmp)
+            parser.load_yaml_hierarchy(self.root_dir)
+            tmp.seek(0, io.SEEK_SET)
+            parser.load_yaml(tmp)
 
-        for hint, subtree in hints:
-            self.write_file(subtree, hint + '.yaml', self.root_dir)
-
-    def parse_key(self, key, value):
-        # The 'network.' prefix is optional for netsted keys, its always assumed to be there
-        if not key.startswith('network.') and not key == 'network':
-            key = 'network.' + key
-        # Split at '.' but not at '\.' via negative lookbehind expression
-        split = re.split(r'(?<!\\)\.', key)
-        tree = {}
-        i = 1
-        t = tree
-        for part in split:
-            part = part.replace('\\.', '.')  # Unescape interface-ids, containing dots
-            val = {}
-            if i == len(split):
-                val = value
-            t = t.setdefault(part, val)
-            i += 1
-        return tree
-
-    def merge(self, a, b, path=None):
-        """
-        Merges tree/dict 'b' into tree/dict 'a'
-        """
-        if path is None:
-            path = []
-        for key in b:
-            if key in a:
-                if isinstance(a[key], dict) and isinstance(b[key], dict):
-                    self.merge(a[key], b[key], path + [str(key)])
-                elif b[key] is None:
-                    del a[key]
-                else:
-                    # Overwrite existing key with new key/value from 'set' command
-                    a[key] = b[key]
-            else:
-                a[key] = b[key]
-        return a
-
-    def write_file(self, set_tree, name, rootdir='/'):
-        tmproot = tempfile.TemporaryDirectory(prefix='netplan-set_')
-        path = os.path.join('etc', 'netplan')
-        os.makedirs(os.path.join(tmproot.name, path))
-
-        config = {'network': {}}
-        absp = os.path.join(rootdir, path, name)
-        # check stat(absp), as we don't care about empty hint files
-        if os.path.isfile(absp) and os.stat(absp).st_size > 0:
-            with open(absp, 'r') as f:
-                c = yaml.safe_load(f)
-                if c is not None:  # ignore empty file, even if it contains whitespace
-                    config = c
-
-        new_tree = self.merge(config, set_tree)
-        stripped = ConfigManager.strip_tree(new_tree)
-        logging.debug('Writing file {}: {}'.format(name, stripped))
-        if 'network' in stripped and list(stripped['network'].keys()) == ['version']:
-            # Clear file if only 'network: {version: 2}' is left
-            logging.debug('Empty YAML, deleting file {}'.format(absp))
-            if os.path.isfile(absp):
-                os.remove(absp)
-        elif 'network' in stripped:
-            tmpp = os.path.join(tmproot.name, path, name)
-            with open(tmpp, 'w+') as f:
-                new_yaml = yaml.dump(stripped, indent=2, default_flow_style=False)
-                f.write(new_yaml)
-            # Validate the newly created file, by parsing it via libnetplan
-            libnetplan.netplan_parse(tmpp)
-            # Valid, move it to final destination
-            shutil.copy2(tmpp, absp)
-            os.remove(tmpp)
-        elif stripped == {}:
-            # Clear file (if it exists) if the last/only key got removed
-            # do nothing otherwise
-            logging.debug('Removed last key from YAML, deleting file {}'.format(absp))
-            if os.path.isfile(absp):
-                os.remove(absp)
-        else:  # pragma nocover
-            raise Exception('Invalid input: {}'.format(set_tree))
+        state = libnetplan.State()
+        state.import_parser_results(parser)
+        if self.origin_hint:
+            state.write_yaml_file(filename, self.root_dir)
+        else:
+            state.update_yaml_hierarchy(FALLBACK_FILENAME, self.root_dir)

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -209,6 +209,7 @@ class NetplanCommand(argparse.Namespace):
         self.testing = testing
         self._args = None
         self.debug = False
+        self.breakpoint = False
         self.commandclass = None
         self.subcommands = {}
         self.subcommand = None
@@ -219,6 +220,8 @@ class NetplanCommand(argparse.Namespace):
                                               add_help=True)
         self.parser.add_argument('--debug', action='store_true',
                                  help='Enable debug messages')
+        self.parser.add_argument('--breakpoint', action='store_true',
+                                 help=argparse.SUPPRESS)
         if not leaf:
             self.subparsers = self.parser.add_subparsers(title='Available commands',
                                                          metavar='', dest='subcommand')
@@ -245,6 +248,8 @@ class NetplanCommand(argparse.Namespace):
         if self.leaf_command and 'help' in self._args:  # pragma: nocover (covered in autopkgtest)
             self.print_usage()
 
+        if self.breakpoint:  # pragma: nocover (cannot be automatically tested)
+            breakpoint()
         self.func()
 
     def print_usage(self):

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -98,6 +98,9 @@ class Parser:
         lib.netplan_parser_load_yaml_from_fd.argtypes = [_NetplanParserP, c_int, _GErrorPP]
         lib.netplan_parser_load_yaml_from_fd.restype = c_int
 
+        lib.netplan_parser_load_nullable_fields.argtypes = [_NetplanParserP, c_int, _GErrorPP]
+        lib.netplan_parser_load_nullable_fields.restype = c_int
+
         cls._abi_loaded = True
 
     def __init__(self):
@@ -115,6 +118,9 @@ class Parser:
 
     def load_yaml_hierarchy(self, rootdir):
         _checked_lib_call(lib.netplan_parser_load_yaml_hierarchy, self._ptr, rootdir.encode('utf-8'))
+
+    def load_nullable_fields(self, input_file: IO):
+        _checked_lib_call(lib.netplan_parser_load_nullable_fields, self._ptr, input_file.fileno())
 
 
 class State:

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -19,6 +19,7 @@
 import ctypes
 import ctypes.util
 from ctypes import c_char_p, c_void_p, c_int
+from typing import Union, IO
 
 
 class LibNetplanException(Exception):
@@ -94,6 +95,9 @@ class Parser:
         lib.netplan_parser_load_yaml.argtypes = [_NetplanParserP, c_char_p, _GErrorPP]
         lib.netplan_parser_load_yaml.restype = c_int
 
+        lib.netplan_parser_load_yaml_from_fd.argtypes = [_NetplanParserP, c_int, _GErrorPP]
+        lib.netplan_parser_load_yaml_from_fd.restype = c_int
+
         cls._abi_loaded = True
 
     def __init__(self):
@@ -103,8 +107,11 @@ class Parser:
     def __del__(self):
         lib.netplan_parser_clear(ctypes.byref(self._ptr))
 
-    def load_yaml(self, filename):
-        _checked_lib_call(lib.netplan_parser_load_yaml, self._ptr, filename.encode('utf-8'))
+    def load_yaml(self, input_file: Union[str, IO]):
+        if isinstance(input_file, str):
+            _checked_lib_call(lib.netplan_parser_load_yaml, self._ptr, input_file.encode('utf-8'))
+        else:
+            _checked_lib_call(lib.netplan_parser_load_yaml_from_fd, self._ptr, input_file.fileno())
 
     def load_yaml_hierarchy(self, rootdir):
         _checked_lib_call(lib.netplan_parser_load_yaml_hierarchy, self._ptr, rootdir.encode('utf-8'))

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -146,6 +146,9 @@ class State:
         lib.netplan_state_write_yaml_file.argtypes = [_NetplanStateP, c_char_p, c_char_p, _GErrorPP]
         lib.netplan_state_write_yaml_file.restype = c_int
 
+        lib.netplan_state_update_yaml_hierarchy.argtypes = [_NetplanStateP, c_char_p, c_char_p, _GErrorPP]
+        lib.netplan_state_update_yaml_hierarchy.restype = c_int
+
         lib.netplan_state_dump_yaml.argtypes = [_NetplanStateP, c_int, _GErrorPP]
         lib.netplan_state_dump_yaml.restype = c_int
 
@@ -171,6 +174,11 @@ class State:
         name = filename.encode('utf-8') if filename else None
         root = rootdir.encode('utf-8') if rootdir else None
         _checked_lib_call(lib.netplan_state_write_yaml_file, self._ptr, name, root)
+
+    def update_yaml_hierarchy(self, default_filename, rootdir):
+        name = default_filename.encode('utf-8')
+        root = rootdir.encode('utf-8') if rootdir else None
+        _checked_lib_call(lib.netplan_state_update_yaml_hierarchy, self._ptr, name, root)
 
     def dump_yaml(self, output_file):
         fd = output_file.fileno()

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -56,19 +56,6 @@ _NetplanNetDefinitionP = ctypes.POINTER(_netplan_net_definition)
 lib.netplan_get_id_from_nm_filename.restype = ctypes.c_char_p
 
 
-def netplan_parse(path):
-    # Clear old NetplanNetDefinitions from libnetplan memory
-    lib.netplan_clear_netdefs()
-    err = ctypes.POINTER(_GError)()
-    ret = bool(lib.netplan_parse_yaml(path.encode(), ctypes.byref(err)))
-    if not ret:
-        raise Exception(err.contents.message.decode('utf-8'))
-    lib.netplan_finish_parse(ctypes.byref(err))
-    if err:
-        raise Exception(err.contents.message.decode('utf-8'))
-    return True
-
-
 def _checked_lib_call(fn, *args):
     err = ctypes.POINTER(_GError)()
     ret = bool(fn(*args, ctypes.byref(err)))

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -19,7 +19,7 @@
 import ctypes
 import ctypes.util
 from ctypes import c_char_p, c_void_p, c_int
-from typing import Union, IO
+from typing import List, Union, IO
 
 
 class LibNetplanException(Exception):
@@ -298,8 +298,18 @@ def netplan_get_ids_for_devtype(devtype, rootdir):
     return [nd.id for nd in nds]
 
 
+lib.netplan_util_create_yaml_patch.argtypes = [c_char_p, c_char_p, c_int, _GErrorPP]
+lib.netplan_util_create_yaml_patch.restype = c_int
+
 lib.netplan_util_dump_yaml_subtree.argtypes = [c_char_p, c_int, c_int, _GErrorPP]
 lib.netplan_util_dump_yaml_subtree.restype = c_int
+
+
+def create_yaml_patch(patch_object_path: List[str], patch_payload: str, patch_output):
+    _checked_lib_call(lib.netplan_util_create_yaml_patch,
+                      '\t'.join(patch_object_path).encode('utf-8'),
+                      patch_payload.encode('utf-8'),
+                      patch_output.fileno())
 
 
 def dump_yaml_subtree(prefix, input_file, output_file):

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -143,6 +143,9 @@ class State:
         lib.netplan_state_get_netdef.argtypes = [_NetplanStateP, c_char_p]
         lib.netplan_state_get_netdef.restype = _NetplanNetDefinitionP
 
+        lib.netplan_state_write_yaml_file.argtypes = [_NetplanStateP, c_char_p, c_char_p, _GErrorPP]
+        lib.netplan_state_write_yaml_file.restype = c_int
+
         lib.netplan_state_dump_yaml.argtypes = [_NetplanStateP, c_int, _GErrorPP]
         lib.netplan_state_dump_yaml.restype = c_int
 
@@ -163,6 +166,11 @@ class State:
 
     def import_parser_results(self, parser):
         _checked_lib_call(lib.netplan_state_import_parser_results, self._ptr, parser._ptr)
+
+    def write_yaml_file(self, filename, rootdir):
+        name = filename.encode('utf-8') if filename else None
+        root = rootdir.encode('utf-8') if rootdir else None
+        _checked_lib_call(lib.netplan_state_write_yaml_file, self._ptr, name, root)
 
     def dump_yaml(self, output_file):
         fd = output_file.fileno()

--- a/src/abi_compat.c
+++ b/src/abi_compat.c
@@ -98,7 +98,7 @@ netplan_finish_parse(GError** error)
 {
     if (netplan_state_import_parser_results(&global_state, &global_parser, error))
         return global_state.netdefs;
-    return NULL;
+    return NULL; // LCOV_EXCL_LINE
 }
 
 /**

--- a/src/abi_compat.c
+++ b/src/abi_compat.c
@@ -113,9 +113,6 @@ write_netplan_conf(const NetplanNetDefinition* def, const char* rootdir)
     netplan_netdef_write_yaml(&global_state, def, rootdir, NULL);
 }
 
-gboolean
-netplan_state_write_yaml(const NetplanState* np_state, const char* file_hint, const char* rootdir, GError** error);
-
 /**
  * Generate the Netplan YAML configuration for all currently parsed netdefs
  * @file_hint: Name hint for the generated output YAML file

--- a/src/error.c
+++ b/src/error.c
@@ -106,6 +106,7 @@ gboolean
 parser_error(const yaml_parser_t* parser, const char* yaml, GError** error)
 {
     char *error_context = get_parser_error_context(parser, error);
+    yaml = yaml ? yaml : "(unnamed file)";
     if ((char)*parser->buffer.pointer == '\t')
         g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
                     "%s:%zu:%zu: Invalid YAML: tabs are not allowed for indent:\n%s",

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -1061,3 +1061,83 @@ netplan_state_dump_yaml(const NetplanState* np_state, int out_fd, GError** error
 
     return netplan_netdef_list_write_yaml(np_state, np_state->netdefs_ordered, out_fd, error);
 }
+
+/**
+ * Regenerate the YAML configuration files from a given state. Any state that
+ * hasn't an associated filepath will use the default_filename output in the
+ * standard config directory.
+ *
+ * @np_state: the state for which to generate the config
+ * @default_filename: Default config file, cannot be NULL or empty
+ * @rootdir: If not %NULL, generate configuration in this root directory
+ *           (useful for testing).
+ */
+gboolean
+netplan_state_update_yaml_hierarchy(const NetplanState* np_state, const char* default_filename, const char* rootdir, GError** error)
+{
+    g_autofree gchar *default_path = NULL;
+    gboolean ret = FALSE;
+    GHashTableIter hash_iter;
+    gpointer key, value;
+    GHashTable *perfile_netdefs;
+
+    g_assert(default_filename != NULL && *default_filename != '\0');
+
+    perfile_netdefs = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, (GDestroyNotify)g_list_free);
+    default_path = g_build_path(G_DIR_SEPARATOR_S, rootdir ?: G_DIR_SEPARATOR_S, "etc", "netplan", default_filename, NULL);
+    int out_fd = -1;
+
+    /* Dump global conf to the default path */
+    if (!np_state->netdefs || g_hash_table_size(np_state->netdefs) == 0) {
+        if ((np_state->backend != NETPLAN_BACKEND_NONE)
+                || has_openvswitch(&np_state->ovs_settings, NETPLAN_BACKEND_NONE, NULL)) {
+            g_hash_table_insert(perfile_netdefs, default_path, NULL);
+        }
+    } else {
+        GList* iter = np_state->netdefs_ordered;
+        while (iter) {
+            NetplanNetDefinition* netdef = iter->data;
+            const char* filename = netdef->filename ? netdef->filename : default_path;
+            GList* list = NULL;
+            g_hash_table_steal_extended(perfile_netdefs, filename, NULL, (gpointer*)&list);
+            g_hash_table_insert(perfile_netdefs, (gpointer)filename, g_list_append(list, netdef));
+            iter = iter->next;
+        }
+    }
+
+    g_hash_table_iter_init(&hash_iter, perfile_netdefs);
+    while (g_hash_table_iter_next (&hash_iter, &key, &value)) {
+        const char *filename = key;
+        GList* netdefs = value;
+        out_fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0640);
+        if (out_fd < 0)
+            goto file_error;
+        if (!netplan_netdef_list_write_yaml(np_state, netdefs, out_fd, error))
+            goto cleanup; // LCOV_EXCL_LINE
+        close(out_fd);
+    }
+
+    /* Remove any referenced source file that doesn't have any associated data.
+       Presumably, it is data that has been obsoleted by files loaded
+       afterwards, typically via `netplan set`. */
+    if (np_state->sources) {
+        g_hash_table_iter_init(&hash_iter, np_state->sources);
+        while (g_hash_table_iter_next (&hash_iter, &key, &value)) {
+            if (!g_hash_table_contains(perfile_netdefs, key)) {
+                if (unlink(key) && errno != ENOENT)
+                    goto file_error; // LCOV_EXCL_LINE
+            }
+        }
+    }
+    ret = TRUE;
+    goto cleanup;
+
+file_error:
+    g_set_error(error, G_FILE_ERROR, errno, "%s", strerror(errno));
+    ret = FALSE;
+cleanup:
+    if (out_fd >= 0)
+        close(out_fd);
+    g_hash_table_destroy(perfile_netdefs);
+    return ret;
+}

--- a/src/parse.c
+++ b/src/parse.c
@@ -1766,11 +1766,7 @@ handle_ip_rules(NetplanParser* npp, yaml_node_t* node, const void* _, GError** e
         gboolean ret;
 
         NetplanIPRule* ip_rule = g_new0(NetplanIPRule, 1);
-        ip_rule->family = G_MAXUINT; /* 0 is a valid family ID */
-        ip_rule->priority = NETPLAN_IP_RULE_PRIO_UNSPEC;
-        ip_rule->table = NETPLAN_ROUTE_TABLE_UNSPEC;
-        ip_rule->tos = NETPLAN_IP_RULE_TOS_UNSPEC;
-        ip_rule->fwmark = NETPLAN_IP_RULE_FW_MARK_UNSPEC;
+        reset_ip_rule(ip_rule);
 
         npp->current.ip_rule = ip_rule;
         ret = process_mapping(npp, entry, ip_rules_handlers, NULL, error);

--- a/src/types.c
+++ b/src/types.c
@@ -147,6 +147,16 @@ reset_dhcp_overrides(NetplanDHCPOverrides* overrides)
     overrides->metric = NETPLAN_METRIC_UNSPEC;
 }
 
+void
+reset_ip_rule(NetplanIPRule* ip_rule)
+{
+    ip_rule->family = G_MAXUINT; /* 0 is a valid family ID */
+    ip_rule->priority = NETPLAN_IP_RULE_PRIO_UNSPEC;
+    ip_rule->table = NETPLAN_ROUTE_TABLE_UNSPEC;
+    ip_rule->tos = NETPLAN_IP_RULE_TOS_UNSPEC;
+    ip_rule->fwmark = NETPLAN_IP_RULE_FW_MARK_UNSPEC;
+}
+
 /* Reset a backend settings object. The caller needs to specify the actual backend as it is not
  * contained within the object itself! */
 static void

--- a/src/types.c
+++ b/src/types.c
@@ -394,6 +394,12 @@ netplan_state_reset(NetplanState* np_state)
 
     np_state->backend = NETPLAN_BACKEND_NONE;
     reset_ovs_settings(&np_state->ovs_settings);
+
+    if (np_state->sources) {
+        /* Properly configured at creation to clean up after itself. */
+        g_hash_table_destroy(np_state->sources);
+        np_state->sources = NULL;
+    }
 }
 
 NetplanBackend

--- a/src/types.h
+++ b/src/types.h
@@ -141,6 +141,10 @@ struct netplan_state {
     GList *netdefs_ordered;
     NetplanBackend backend;
     NetplanOVSSettings ovs_settings;
+
+    /* Hashset of the source files used to create this state. Owns its data (glib-allocated
+     * char*) and is initialized with g_hash_table_new_full to avoid leaks. */
+    GHashTable* sources;
 };
 
 struct netplan_parser {
@@ -153,6 +157,9 @@ struct netplan_parser {
     GList* ordered;
     NetplanBackend global_backend;
     NetplanOVSSettings global_ovs_settings;
+
+    /* Keep track of the files used as data source */
+    GHashTable* sources;
 
     /* Data currently being processed */
     struct {

--- a/src/types.h
+++ b/src/types.h
@@ -207,6 +207,9 @@ void
 reset_netdef(NetplanNetDefinition* netdef, NetplanDefType type, NetplanBackend renderer);
 
 void
+reset_ip_rule(NetplanIPRule* ip_rule);
+
+void
 reset_ovs_settings(NetplanOVSSettings *settings);
 
 void

--- a/src/types.h
+++ b/src/types.h
@@ -199,6 +199,9 @@ struct netplan_parser {
      * */
     GHashTable* ids_in_file;
     int missing_ids_found;
+
+    /* Which fields have been nullified by a subsequent patch? */
+    GHashTable* null_fields;
 };
 
 #define NETPLAN_ADVERTISED_RECEIVE_WINDOW_UNSPEC 0

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -60,6 +60,9 @@ wifi_get_freq5(int channel);
 NETPLAN_ABI gchar*
 systemd_escape(char* string);
 
+NETPLAN_INTERNAL gboolean
+netplan_util_create_yaml_patch(const char* conf_obj_path, const char* obj_payload, int out_fd, GError** error);
+
 #define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"
 
 void

--- a/src/util.c
+++ b/src/util.c
@@ -482,7 +482,6 @@ systemd_escape(char* string)
 gboolean
 netplan_delete_connection(const char* id, const char* rootdir)
 {
-    g_autofree gchar* filename = NULL;
     g_autofree gchar* del = NULL;
     g_autoptr(GError) error = NULL;
     NetplanNetDefinition* nd = NULL;
@@ -517,15 +516,13 @@ netplan_delete_connection(const char* id, const char* rootdir)
         goto cleanup;
     }
 
-    filename = g_path_get_basename(nd->filename);
-    filename[strlen(filename) - 5] = '\0'; //stip ".yaml" suffix
     del = g_strdup_printf("network.%s.%s=NULL", netplan_def_type_name(nd->type), id);
 
     /* TODO: refactor logic to actually be inside the library instead of spawning another process */
-    const gchar *argv[] = { SBINDIR "/" "netplan", "set", del, "--origin-hint" , filename, NULL, NULL, NULL };
+    const gchar *argv[] = { SBINDIR "/" "netplan", "set", del, NULL, NULL, NULL };
     if (rootdir) {
-        argv[5] = "--root-dir";
-        argv[6] = rootdir;
+        argv[3] = "--root-dir";
+        argv[4] = rootdir;
     }
     if (getenv("TEST_NETPLAN_CMD") != 0)
        argv[0] = getenv("TEST_NETPLAN_CMD");

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -26,6 +26,7 @@ import glob
 import yaml
 
 from tests.test_utils import call_cli
+from netplan.libnetplan import LibNetplanException
 
 
 class TestSet(unittest.TestCase):

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -306,13 +306,13 @@ class TestSet(unittest.TestCase):
         file2 = os.path.join(self.workdir.name, 'etc', 'netplan', 'eth1.yaml')
         with open(file2, 'w') as f:
             f.write(r'network: {ethernets: {eth1: {dhcp4: true}}}')
-        self._set([(r'network={renderer: NetworkManager, version: 2,'
-                    r'ethernets:{'
-                    r'eth1:{dhcp4: false},'
-                    r'eth0.1:{dhcp4: false},'
-                    r'eth0.2:{dhcp4: false}},'
-                    r'bridges:{'
-                    r'br99:{dhcp4: false}}}')])
+        self._set([(r'network={"renderer": "NetworkManager", "version":2,'
+                    r'"ethernets":{'
+                    r'"eth1":{"dhcp4":false},'
+                    r'"eth0.1":{"dhcp4":false},'
+                    r'"eth0.2":{"dhcp4":false}},'
+                    r'"bridges":{'
+                    r'"br99":{"dhcp4":false}}}')])
         self.assertTrue(os.path.isfile(file1))
         with open(file1, 'r') as f:
             self.assertIn('network:\n  ethernets:\n    eth0.1:\n      dhcp4: false', f.read())

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -26,7 +26,6 @@ import glob
 import yaml
 
 from tests.test_utils import call_cli
-from netplan.libnetplan import LibNetplanException
 
 
 class TestSet(unittest.TestCase):

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -183,6 +183,23 @@ class TestNetdefIterator(TestBase):
         self.assertSetEqual(set(["eth0", "eth1"]), set(d.id for d in libnetplan._NetdefIterator(state, "ethernets")))
 
 
+class TestParser(TestBase):
+    def test_load_yaml_from_fd_empty(self):
+        parser = libnetplan.Parser()
+        # We just don't want it to raise an exception
+        with tempfile.TemporaryFile() as f:
+            parser.load_yaml(f)
+
+    def test_load_yaml_from_fd_bad_yaml(self):
+        parser = libnetplan.Parser()
+        with tempfile.TemporaryFile() as f:
+            f.write(b'invalid: {]')
+            f.seek(0, io.SEEK_SET)
+            with self.assertRaises(libnetplan.LibNetplanException) as context:
+                parser.load_yaml(f)
+            self.assertIn('Invalid YAML', str(context.exception))
+
+
 class TestState(TestBase):
     def test_get_netdef(self):
         state = state_from_yaml(self.confdir, '''network:

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -281,6 +281,16 @@ class TestState(TestBase):
         with self.assertRaises(libnetplan.LibNetplanException):
             state.write_yaml_file('target.yml', self.workdir.name)
 
+    def test_update_yaml_hierarchy_no_confdir(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      dhcp4: false''')
+        shutil.rmtree(self.confdir)
+        with self.assertRaises(libnetplan.LibNetplanException) as context:
+            state.update_yaml_hierarchy("bogus", self.workdir.name)
+        self.assertIn('No such file or directory', str(context.exception))
+
     def test_write_yaml_file_remove_directory(self):
         state = libnetplan.State()
         os.makedirs(self.confdir)

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -399,6 +399,14 @@ class TestFreeFunctions(TestBase):
         state = libnetplan.State()
         self.assertSequenceEqual(list(libnetplan._NetdefIterator(state, "ethernets")), [])
 
+    def test_create_yaml_patch_bad_syntax(self):
+        with tempfile.TemporaryFile() as patchfile:
+            with self.assertRaises(libnetplan.LibNetplanException) as context:
+                libnetplan.create_yaml_patch(['network'], '{invalid_yaml]', patchfile)
+            self.assertIn('Error parsing YAML', str(context.exception))
+            patchfile.seek(0, io.SEEK_END)
+            self.assertEqual(patchfile.tell(), 0)
+
     def test_dump_yaml_subtree_bad_file_perms(self):
         input_file = os.path.join(self.workdir.name, 'input.yaml')
         with open(input_file, "w") as f, tempfile.TemporaryFile() as output:

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -130,7 +130,7 @@ class TestRawLibnetplan(TestBase):
         self.assertTrue(os.path.isfile(orig))
         # Verify the file still exists and still contains the other connection
         with open(orig, 'r') as f:
-            self.assertEqual(f.read(), 'network:\n  ethernets:\n    other-id:\n      dhcp6: true\n')
+            self.assertEqual(f.read(), 'network:\n  version: 2\n  ethernets:\n    other-id:\n      dhcp6: true\n')
 
     def test_write_netplan_conf(self):
         netdef_id = 'some-netplan-id'


### PR DESCRIPTION
## Description

As part of the larger PyYAML cleanup effort, this patch set rewrites the `netplan set` to use libnetplan's own YAML parser instead of PyYAML. This meant enriching the parser to deal with null fields, that need to be tracked out-of-band, as well as creating new APIs to create YAML files out of a Netplan state, with different nuances to match the previous behavior.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).

