### PR TITLE
Fix removal of defunct vlan interfaces (LP #1959147)

### DIFF
--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -144,7 +144,7 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
                     # Skip cleanup if this OVS interface is part of the current netplan OVS config
                     if iface in ovs_ifaces:
                         continue
-                    if t[0] == 'Interface' and subprocess.run([OPENVSWITCH_OVS_VSCTL, 'iface-to-br', iface]).returncode > 0:
+                    if t[0] == 'Interface' and subprocess.run([OPENVSWITCH_OVS_VSCTL, 'br-exists', iface]).returncode > 0:
                         subprocess.check_call([OPENVSWITCH_OVS_VSCTL, '--if-exists', 'del-bond-iface', iface])
                     else:
                         subprocess.check_call([OPENVSWITCH_OVS_VSCTL, '--if-exists', t[1], iface])


### PR DESCRIPTION
## Description
From my [Launchpad bug report](https://bugs.launchpad.net/netplan/+bug/1959147):

netplan fails to delete OVS vlan interfaces that were previously defined but were then removed from the configuration. The underlying problem appears to be that the `ovs-vsctl iface-to-br` [command used](https://github.com/canonical/netplan/blob/331ca01908b68446a9a1f395616136678e617a1a/netplan/cli/ovs.py#L147) to test whether an interface is bonded or a vlan fails on "fake bridges" (this is how OVS defines vlans) which then causes it be treated incorrectly as a bonded interface. My testing seems to indicate the `ovs-vsctl br-exists` command may be a better choice for this test.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`). - Looks like there is a pre-existing lack of coverage on netplan/cli/commands/generate.py
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

