### PR TITLE
parse: fix the handle_match_driver type

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -660,7 +660,7 @@ handle_match_driver(NetplanParser* npp, yaml_node_t* node, const void* _, GError
 }
 
 static const mapping_entry_handler match_handlers[] = {
-    {"driver", YAML_NO_NODE, {.generic=handle_match_driver}},
+    {"driver", YAML_NO_NODE, {.variable=handle_match_driver}},
     {"macaddress", YAML_SCALAR_NODE, {.generic=handle_netdef_mac}, netdef_offset(match.mac)},
     {"name", YAML_SCALAR_NODE, {.generic=handle_netdef_id}, netdef_offset(match.original_name)},
     {NULL}


### PR DESCRIPTION
The YAML_NO_NODE type marker means that the callback called is via the
`.variable` union field, not `.generic`. Since this is a union type, and
both callbacks have the same signature for now, it works, but future
evolutions of the code will make those signatures evolve independently,
leading to hard-to-debug issues.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
