### PR TITLE
util: fix dump_yaml_subtree to not insert NULL at the actual end

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -237,14 +237,13 @@ netplan_util_dump_yaml_subtree(const char* prefix, int input_fd, int output_fd, 
         if (!yaml_emitter_emit(&emitter, &event))
             goto err_path; // LCOV_EXCL_LINE
     }
-    void* last_head = emitter.events.head;
 
     if (!emit_yaml_subtree(&parser, &emitter, yaml_path, error)) {
         ret = FALSE;
         goto cleanup;
     }
 
-    if (emitter.events.head == last_head) {
+    if (emitter.events.head != emitter.events.tail) {
         YAML_NULL_PLAIN(&event, &emitter);
     }
 

--- a/tests/test_cli_get_set.py
+++ b/tests/test_cli_get_set.py
@@ -443,3 +443,19 @@ class TestGet(unittest.TestCase):
             f.write('network:\n  version: 2\n  renderer: NetworkManager')
         out = yaml.safe_load(self._get(['networkINVALID']))
         self.assertIsNone(out)
+
+    def test_get_yaml_document_end_failure(self):
+        with open(self.path, 'w') as f:
+            f.write('''network:
+  ethernets:
+    eth0:
+      match:
+        name: "test"
+      mtu: 9000
+      set-name: "yo"
+      dhcp4: true
+      virtual-function-count: 2
+''')
+        # this shall not throw any (YAML DOCUMENT-END) exception
+        out = yaml.safe_load(self._get(['ethernets.eth0']))
+        self.assertListEqual(['match', 'dhcp4', 'set-name', 'mtu', 'virtual-function-count'], list(out))


### PR DESCRIPTION
## Description
In some cases `netplan get` using the new libnetplan YAML parser would try to insert a `NULL` tag even though the emitter already reached the end and was expecting a `DOCUMENT-END` tag. Check for that condition and handle it.

Also adding a reproducer test case, that is now fixed.

```
  File "/home/lukas/canonical/netplan/netplan/cli/commands/get.py", line 72, in command_get
    self.dump_state(self.key, np_state, output_file)
  File "/home/lukas/canonical/netplan/netplan/cli/commands/get.py", line 57, in dump_state
    libnetplan.dump_yaml_subtree(key, tmp_in, output_file=output_file)
  File "/home/lukas/canonical/netplan/netplan/libnetplan.py", line 262, in dump_yaml_subtree
    _checked_lib_call(lib.netplan_util_dump_yaml_subtree,
  File "/home/lukas/canonical/netplan/netplan/libnetplan.py", line 75, in _checked_lib_call
    raise LibNetplanException(err.contents.message.decode('utf-8'))
netplan.libnetplan.LibNetplanException: Error generating YAML: expected DOCUMENT-END
```

(Introduced in https://github.com/canonical/netplan/pull/251 and activated in 331ca01908b68446a9a1f395616136678e617a1a)

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

