### PR TITLE
Have ConfigManager cleanup its temporary directory on destruction (LP #1959729)

### DIFF
--- a/netplan/configmanager.py
+++ b/netplan/configmanager.py
@@ -224,6 +224,13 @@ class ConfigManager(object):
     def cleanup(self):
         shutil.rmtree(self.tempdir)
 
+    def __del__(self):
+        try:
+            self.cleanup()
+        except FileNotFoundError:
+            # If cleanup() was called before, there is nothing to delete
+            pass
+
     def _copy_file(self, src, dst):
         shutil.copy(src, dst)
 

--- a/tests/test_configmanager.py
+++ b/tests/test_configmanager.py
@@ -246,6 +246,22 @@ class TestConfigManager(unittest.TestCase):
         self.configmanager.cleanup()
         self.assertFalse(os.path.exists(backup_dir))
 
+    def test_destruction(self):
+        backup_dir = self.configmanager.tempdir
+        self.assertTrue(os.path.exists(backup_dir))
+        del self.configmanager
+        self.assertFalse(os.path.exists(backup_dir))
+
+    def test_cleanup_and_destruction(self):
+        backup_dir = self.configmanager.tempdir
+        self.assertTrue(os.path.exists(backup_dir))
+        self.configmanager.cleanup()
+        self.assertFalse(os.path.exists(backup_dir))
+        # This tests that the rmtree in the destructor does not throw an error
+        # if cleanup was already called
+        del self.configmanager
+        self.assertFalse(os.path.exists(backup_dir))
+
     def test__copy_tree(self):
         self.configmanager._copy_tree(os.path.join(self.workdir.name, "etc"),
                                       os.path.join(self.workdir.name, "etc2"))


### PR DESCRIPTION
## Description
`ConfigManager` creates a temporary directory on instantiation and relies on the caller to clean up that temporary directory despite never exposed directly to the caller. Due to the code structure in several places, it would be onerous to call `ConfigManager.cleanup()` everywhere it's needed so this patch instead calls `.cleanup()` whenever the ConfigManager instance is garage collected.

This addresses https://bugs.launchpad.net/netplan/+bug/1959729

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

