### PR TITLE
cli:apply: fix potential race with rename/creation of netdevs and start networkd if off (LP: #1962095)

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -252,8 +252,13 @@ class NetplanApply(utils.NetplanCommand):
                            if not f.endswith('/' + OVS_CLEANUP_SERVICE)]
             # Run 'systemctl start' command synchronously, to avoid race conditions
             # with 'oneshot' systemd service units, e.g. netplan-ovs-*.service.
-            utils.networkctl_reload()
-            utils.networkctl_reconfigure(utils.networkd_interfaces())
+            try:
+                utils.networkctl_reload()
+                utils.networkctl_reconfigure(utils.networkd_interfaces())
+            except subprocess.CalledProcessError:
+                # (re-)start systemd-networkd if it is not running, yet
+                logging.warning('Falling back to a hard restart of systemd-networkd.service')
+                utils.systemctl('restart', ['systemd-networkd.service'], sync=True)
             # 1st: execute OVS cleanup, to avoid races while applying OVS config
             utils.systemctl('start', [OVS_CLEANUP_SERVICE], sync=True)
             # 2nd: start all other services

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -252,6 +252,7 @@ class NetplanApply(utils.NetplanCommand):
                            if not f.endswith('/' + OVS_CLEANUP_SERVICE)]
             # Run 'systemctl start' command synchronously, to avoid race conditions
             # with 'oneshot' systemd service units, e.g. netplan-ovs-*.service.
+            utils.networkctl_reload()
             utils.networkctl_reconfigure(utils.networkd_interfaces())
             # 1st: execute OVS cleanup, to avoid races while applying OVS config
             utils.systemctl('start', [OVS_CLEANUP_SERVICE], sync=True)

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -95,12 +95,15 @@ def networkd_interfaces():
     for line in out.splitlines():
         s = line.strip().split(' ')
         if s[0].isnumeric() and s[-1] not in ['unmanaged', 'linger']:
-            interfaces.add(s[1])
+            interfaces.add(s[0])
     return interfaces
 
 
-def networkctl_reconfigure(interfaces):
+def networkctl_reload():
     subprocess.check_call(['networkctl', 'reload'])
+
+
+def networkctl_reconfigure(interfaces):
     if len(interfaces) >= 1:
         subprocess.check_call(['networkctl', 'reconfigure'] + list(interfaces))
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -300,7 +300,12 @@ class IntegrationTestsBase(unittest.TestCase):
         cmd = ['netplan', 'apply']
         if state_dir:
             cmd = cmd + ['--state', state_dir]
-        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, universal_newlines=True)
+        out = ''
+        try:
+            out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, universal_newlines=True)
+        except subprocess.CalledProcessError as e:
+            self.assertTrue(False, 'netplan apply failed: {}'.format(e.output))
+
         if 'Run \'systemctl daemon-reload\' to reload units.' in out:
             self.fail('systemd units changed without reload')
         # start NM so that we can verify that it does not manage anything

--- a/tests/integration/bonds.py
+++ b/tests/integration/bonds.py
@@ -315,14 +315,12 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
     ethbn:
       match:
         name: %(ec)s
-        macaddress: %(ec_mac)s
   bonds:
     mybond:
       interfaces: [ethbn]
       macaddress: 00:01:02:03:04:05
       dhcp4: yes''' % {'r': self.backend,
-                       'ec': self.dev_e_client,
-                       'ec_mac': self.dev_e_client_mac})
+                       'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24', '00:01:02:03:04:05'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -215,17 +215,25 @@ class TestUtils(unittest.TestCase):
 174 wwan0           wwan     off        linger''')
         res = utils.networkd_interfaces()
         self.assertEquals(self.mock_networkctl.calls(), [['networkctl', '--no-pager', '--no-legend']])
-        self.assertIn('wlan0', res)
-        self.assertIn('ens3', res)
+        self.assertIn('2', res)
+        self.assertIn('3', res)
+
+    def test_networkctl_reload(self):
+        self.mock_networkctl = MockCmd('networkctl')
+        path_env = os.environ['PATH']
+        os.environ['PATH'] = os.path.dirname(self.mock_networkctl.path) + os.pathsep + path_env
+        utils.networkctl_reload()
+        self.assertEquals(self.mock_networkctl.calls(), [
+            ['networkctl', 'reload']
+        ])
 
     def test_networkctl_reconfigure(self):
         self.mock_networkctl = MockCmd('networkctl')
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_networkctl.path) + os.pathsep + path_env
-        utils.networkctl_reconfigure(['eth0', 'eth1'])
+        utils.networkctl_reconfigure(['3', '5'])
         self.assertEquals(self.mock_networkctl.calls(), [
-            ['networkctl', 'reload'],
-            ['networkctl', 'reconfigure', 'eth0', 'eth1']
+            ['networkctl', 'reconfigure', '3', '5']
         ])
 
     def test_is_nm_snap_enabled(self):


### PR DESCRIPTION
## Description
Calling `networkctl_reload()` before `networkd_interfaces()` makes sure that newly created netdevs will show up in the interface list.

Making use of the index number (instead of interface name) ensures that renamed interfaces are properly reconfigured even if they changed their name.

Starting networkd if not active is making sure we can process network changes even if systemd-networkd was stopped before (e.g. by subiquity), see LP#1962095

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad: LP#1962095

