### PR TITLE
[WIP] Add support for gretap/ip6gretap OVS tunnels

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -151,7 +151,7 @@ write_tunnel_params(GString* s, const NetplanNetDefinition* def)
     g_string_printf(params, "Independent=true\n");
     if (def->tunnel.mode == NETPLAN_TUNNEL_MODE_IPIP6 || def->tunnel.mode == NETPLAN_TUNNEL_MODE_IP6IP6)
         g_string_append_printf(params, "Mode=%s\n", netplan_tunnel_mode_name(def->tunnel.mode));
-    g_string_append_printf(params, "Local=%s\n", def->tunnel.local_ip);
+    g_string_append_printf(params, "Local=%s\n", (def->tunnel.local_ip ? def->tunnel.local_ip : "any"));
     g_string_append_printf(params, "Remote=%s\n", def->tunnel.remote_ip);
     if (def->tunnel_ttl)
         g_string_append_printf(params, "TTL=%u\n", def->tunnel_ttl);

--- a/src/nm.c
+++ b/src/nm.c
@@ -418,7 +418,7 @@ static void
 write_tunnel_params(const NetplanNetDefinition* def, GKeyFile *kf)
 {
     g_key_file_set_integer(kf, "ip-tunnel", "mode", def->tunnel.mode);
-    g_key_file_set_string(kf, "ip-tunnel", "local", def->tunnel.local_ip);
+    g_key_file_set_string(kf, "ip-tunnel", "local", (def->tunnel.local_ip ? def->tunnel.local_ip : ""));
     g_key_file_set_string(kf, "ip-tunnel", "remote", def->tunnel.remote_ip);
     if (def->tunnel_ttl)
         g_key_file_set_uint64(kf, "ip-tunnel", "ttl", def->tunnel_ttl);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1215,6 +1215,12 @@ handle_bridge_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data
                 g_debug("%s: Bridge contains openvswitch interface, choosing OVS backend", npp->current.netdef->id);
                 npp->current.netdef->backend = NETPLAN_BACKEND_OVS;
             }
+            /* If the bridge has a OVS backend then any gretap or ip6gretap tunnels attached to the bridge must also be OVS */
+            if (component->type == NETPLAN_DEF_TYPE_TUNNEL &&
+                    (component->tunnel.mode == NETPLAN_TUNNEL_MODE_GRETAP || component->tunnel.mode == NETPLAN_TUNNEL_MODE_IP6GRETAP) &&
+                    npp->current.netdef->backend == NETPLAN_BACKEND_OVS) {
+                component->backend = NETPLAN_BACKEND_OVS;
+            }
         }
     }
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -239,6 +239,10 @@ validate_tunnel_backend_rules(const NetplanParser* npp, NetplanNetDefinition* nd
     switch (nd->backend) {
         case NETPLAN_BACKEND_NETWORKD:
             switch (nd->tunnel.mode) {
+                case NETPLAN_TUNNEL_MODE_GRE:
+                case NETPLAN_TUNNEL_MODE_IP6GRE:
+                case NETPLAN_TUNNEL_MODE_GRETAP:
+                case NETPLAN_TUNNEL_MODE_IP6GRETAP:
                 case NETPLAN_TUNNEL_MODE_VTI:
                 case NETPLAN_TUNNEL_MODE_VTI6:
                 case NETPLAN_TUNNEL_MODE_WIREGUARD:

--- a/src/validation.c
+++ b/src/validation.c
@@ -204,8 +204,6 @@ validate_tunnel_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
     }
 
     /* Validate local/remote IPs */
-    if (!nd->tunnel.local_ip)
-        return yaml_error(npp, node, error, "%s: missing 'local' property for tunnel", nd->id);
     if (!nd->tunnel.remote_ip)
         return yaml_error(npp, node, error, "%s: missing 'remote' property for tunnel", nd->id);
     if (nd->tunnel_ttl && nd->tunnel_ttl > 255)
@@ -224,7 +222,7 @@ validate_tunnel_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
             break;
 
         default:
-            if (!is_ip4_address(nd->tunnel.local_ip))
+            if (nd->tunnel.local_ip && !is_ip4_address(nd->tunnel.local_ip))
                 return yaml_error(npp, node, error, "%s: 'local' must be a valid IPv4 address for this tunnel type", nd->id);
             if (!is_ip4_address(nd->tunnel.remote_ip))
                 return yaml_error(npp, node, error, "%s: 'remote' must be a valid IPv4 address for this tunnel type", nd->id);

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -1242,18 +1242,6 @@ class TestConfigErrors(TestBase):
         out = self.generate(config, expect_fail=True)
         self.assertIn("Error in network definition: address '10.10.10.10/21' should not include /prefixlength", out)
 
-    def test_missing_local_ip(self):
-        """Fail if local IP is missing"""
-        config = '''network:
-  version: 2
-  tunnels:
-    tun0:
-      mode: gre
-      remote: 20.20.20.20
-'''
-        out = self.generate(config, expect_fail=True)
-        self.assertIn("Error in network definition: tun0: missing 'local' property for tunnel", out)
-
     def test_missing_remote_ip(self):
         """Fail if remote IP is missing"""
         config = '''network:


### PR DESCRIPTION
## Description
This adds support for `gretap` and `ip6gretap` Open vSwitch (OVS) tunnels to netplan. I'm hoping to get help/feedback on a few questions:

- OVS calls GRE tunnels between two bridges just `gre` tunnels. However, in the semantics of netplan, it is actually a `gretap` tunnel (i.e. it's putting layer 2 packets through a GRE tunnel). I went with calling these `gretap`/`ip6gretap` tunnels as I feel it's technically correct but I also think this is going to cause confusion. Thoughts?
- For all tunnel types, the `local_ip` is a required YAML key but it's really optional for most tunnels. Is it OK to remove the required check on it? I'm happy to tweak the affected tests.
- I opted for OVS-flavored bridges to make any attached `gretap`/`ip6gretap` tunnels inherit being OVS controlled. I don't have a firm understanding on the order in which interfaces are parsed so am unsure if this method works every time or is dependent on interface order.
  - This raises a secondary question about OVS bonds: if a bond detects one of its members being OVS, it then switches its back-end to OVS.  However, I didn't see any code to make a bridge containing a now OVS bond to then become OVS.

Once/if people are happy with my changes, I'll tack on another commit with tests.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

