### PR TITLE
nm:parse-nm: handle differing ip6-privacy default value

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -531,7 +531,12 @@ write_fallback_key_value(GQuark key_id, gpointer value, gpointer user_data)
     /* delete the dummy key, if this was just an empty group */
     if (!g_strcmp0(k, NETPLAN_NM_EMPTY_GROUP))
         g_key_file_remove_key(kf, group, k, NULL);
-    else if (!has_key) {
+    /* handle differing defaults:
+     * ipv6.ip6-privacy is "-1 (unknown)" by default in NM, it is "0 (off)" in netplan */
+    else if (g_strcmp0(key, "ipv6.ip6-privacy") == 0 && g_strcmp0(val, "-1") == 0) {
+        g_debug("NetworkManager: default override: clearing %s.%s", group, k);
+        g_key_file_remove_key(kf, group, k, NULL);
+    } else if (!has_key) {
         g_debug("NetworkManager: passing through fallback key: %s.%s=%s", group, k, val);
         g_key_file_set_comment(kf, group, k, "Netplan: passthrough setting", NULL);
     } else if (!!g_strcmp0(val, old_key)) {

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -284,3 +284,34 @@ method=auto
 [ipv6]
 method=ignore
 '''})
+
+    def test_passthrough_ip6_privacy_default(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    eth0:
+      dhcp4: true
+      dhcp6: true
+      networkmanager:
+        uuid: 626dd384-8b3d-3690-9511-192b2c79b3fd
+        name: "netplan-eth0"
+        passthrough:
+          "ipv6.ip6-privacy": "-1"
+''')
+
+        self.assert_nm({'eth0': '''[connection]
+id=netplan-eth0
+type=ethernet
+uuid=626dd384-8b3d-3690-9511-192b2c79b3fd
+interface-name=eth0
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+'''})

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -69,6 +69,7 @@ method=auto
 [ipv6]
 dns-search=
 method=auto
+ip6-privacy=0
 '''.format(UUID))
         self.assert_netplan({UUID: '''network:
   version: 2
@@ -204,6 +205,7 @@ route-metric=4242
 addr-gen-mode=eui64
 dns-search=
 method=auto
+ip6-privacy=0
 ignore-auto-routes=true
 never-default=true
 route-metric=4242
@@ -280,6 +282,7 @@ addr-gen-mode=stable-privacy
 dns-search=bar.local
 dns=dead:beef::2;
 method=manual
+ip6-privacy=2
 address1=1:2:3::9/128
 gateway=6:6::6
 route1=dead:beef::1/128,2001:1234::2
@@ -310,6 +313,7 @@ route1_options=unknown=invalid,
       gateway4: 6.6.6.6
       gateway6: 6:6::6
       ipv6-address-generation: "stable-privacy"
+      ipv6-privacy: true
       routes:
       - metric: 42
         table: 102
@@ -710,6 +714,7 @@ dns-search=
 method=ignore
 addr-gen-mode=1
 dns-search=
+ip6-privacy=0
 
 [wifi]
 ssid=my-hotspot
@@ -1018,6 +1023,7 @@ dns=8.8.8.8;8.8.4.4;8.8.8.8;8.8.4.4;8.8.8.8;8.8.4.4;
 [ipv6]
 method=auto
 addr-gen-mode=1
+ip6-privacy=0
 '''.format(UUID))
         self.assert_netplan({UUID: '''network:
   version: 2
@@ -1080,6 +1086,7 @@ address2=dcba::beef/56
 dns=1::cafe;2::cafe;
 dns-search=wallaceandgromit.com;
 method=manual
+ip6-privacy=1
 route1=1:2:3:4:5:6:7:8/64,8:7:6:5:4:3:2:1,3
 route2=2001::1000/56,2001::1111,1
 route3=4:5:6:7:8:9:0:1/63,::,5
@@ -1151,6 +1158,7 @@ route4=5:6:7:8:9:0:1:2/62
           ipv4.route4: "3.3.3.3/6,0.0.0.0,4"
           ipv4.route4_options: "cwnd=10,mtu=1492,src=1.2.3.4"
           ipv6.dns-search: "wallaceandgromit.com;"
+          ipv6.ip6-privacy: "1"
           proxy._: ""
 '''.format(UUID, UUID)})
 
@@ -1201,4 +1209,36 @@ method=auto
           ipv6.dns-search: ""
           ipv6.method: "auto"
           proxy._: ""
+'''.format(UUID, UUID)})
+
+    def test_keyfile_ip6_privacy_default_netplan_0104_compat(self):
+        self.generate_from_keyfile('''[connection]
+id=Test
+uuid={}
+type=ethernet
+
+[ethernet]
+mac-address=99:88:77:66:55:44
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  ethernets:
+    NM-{}:
+      renderer: NetworkManager
+      match:
+        macaddress: "99:88:77:66:55:44"
+      dhcp4: true
+      dhcp6: true
+      wakeonlan: true
+      networkmanager:
+        uuid: "{}"
+        name: "Test"
+        passthrough:
+          ipv6.ip6-privacy: "-1"
 '''.format(UUID, UUID)})


### PR DESCRIPTION
## Description
Commit 64e381e22bcc71563644454b41e852ec4eed8a1c (#244) changed netplan's
behaviour to always write out the ipv6-privacy value (default to 0=off),
in order to comply with what is written in our documentation and how it is
implemented in the networkd backend.

This is a problem for our NetworkManager integration, as NM's default value
is -1=unknown. Netplan only supports values 0=off and 2=on while NM supports
-1, 0, 1 and 2. We need to handle unsupported cases (-1 and 1) via passthrough.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

