### PR TITLE
Fix running the autopkgtests, by working around a LXD issue

### DIFF
--- a/.github/workflows/autopkgtest.patch
+++ b/.github/workflows/autopkgtest.patch
@@ -1,0 +1,9 @@
+@@ -70,6 +70,8 @@
+ 
+     sleep 5
+     if lxc exec "$CONTAINER" -- systemctl mask serial-getty@getty.service; then
++       lxc exec "$CONTAINER" -- systemctl mask snapd.service
++       lxc exec "$CONTAINER" -- systemctl mask snapd.seeded.service
+        lxc exec "$CONTAINER" -- reboot
+     fi
+ 

--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -27,13 +27,17 @@ jobs:
           sudo apt install autopkgtest ubuntu-dev-tools devscripts openvswitch-switch
           sudo snap install lxd
           sudo lxd init --auto --storage-backend=dir
+      # work around LP: #1878225 as fallback
+      - name: Preparing autopkgtest-build-lxd
+        run: |
+          sudo patch /usr/bin/autopkgtest-build-lxd .github/workflows/autopkgtest.patch
+          sudo autopkgtest-build-lxd ubuntu-daily:jammy
       - name: Prepare test
         run: |
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
           dch -v $(git describe --tags) "Autopkgtest CI testing (Jammy)"
-          sudo autopkgtest-build-lxd ubuntu-daily:jammy
       - name: Run autopkgtest (incl. build)
         run: |
           sudo autopkgtest . -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 -- lxd autopkgtest/ubuntu/jammy/amd64

--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -40,4 +40,4 @@ jobs:
           dch -v $(git describe --tags) "Autopkgtest CI testing (Jammy)"
       - name: Run autopkgtest (incl. build)
         run: |
-          sudo autopkgtest . -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 -- lxd autopkgtest/ubuntu/jammy/amd64
+          sudo autopkgtest . -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/jammy/amd64


### PR DESCRIPTION
## Description
Working around an issue with `snapd.seeded.service` taking too long to start, delaying the boot and thus failing setup of the test container (`autopkgtest-build-lxc`).

https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1878225

Also, disable the unit-tests during autopkgtest build (`DEB_BUILD_OPTIONS=nocheck`) to save some time, we're already running the unit-tests in another Github action.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

