### PR TITLE
Fix infinite timeouts in ovs-vsctl (Closes: #1000137)

### DIFF
--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -59,7 +59,7 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
         g_string_append_printf(s, "After=netplan-ovs-%s.service\n", dependency);
     }
 
-    g_string_append(s, "\n[Service]\nType=oneshot\n");
+    g_string_append(s, "\n[Service]\nType=oneshot\nTimeoutStartSec=10s\n");
     g_string_append(s, cmds->str);
 
     g_string_free_to_file(s, rootdir, path, NULL);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -67,9 +67,9 @@ standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_ena
 Bridge %(iface)s external-ids:netplan/mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
 rstp_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/rstp_enable=false\n'
 OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
-Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
+Type=oneshot\nTimeoutStartSec=10s\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
 OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\
-[Service]\nType=oneshot\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
+[Service]\nType=oneshot\nTimeoutStartSec=10s\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 UDEV_SRIOV_RULE = 'ACTION=="add", SUBSYSTEM=="net", ATTRS{sriov_totalvfs}=="?*", RUN+="/usr/sbin/netplan apply --sriov-only"\n'

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -50,6 +50,7 @@ class TestOpenVSwitch(TestBase):
         self.assert_ovs({'ovs0.service': OVS_VIRTUAL % {'iface': 'ovs0', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs0 eth0
@@ -60,6 +61,7 @@ After=netplan-ovs-ovs0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/external-ids/iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
@@ -71,6 +73,7 @@ After=netplan-ovs-ovs0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
 ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-config/disable-in-band=false
 '''},
@@ -109,6 +112,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-confi
         self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/external-ids/iface-id=myhostname
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
@@ -129,6 +133,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/other-confi
         self.assert_ovs({'ovs0.service': OVS_VIRTUAL % {'iface': 'ovs0', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs0
 ''' + OVS_BR_DEFAULT % {'iface': 'ovs0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs0 protocols=OpenFlow10,OpenFlow11,OpenFlow12
@@ -185,6 +190,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
@@ -253,6 +259,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
@@ -318,6 +325,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
@@ -357,6 +365,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
@@ -408,6 +417,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode=activ
                         '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
@@ -432,6 +442,7 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
@@ -462,6 +473,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/other-config/di
                         '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
@@ -521,6 +533,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/rstp_enable=tru
                         '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
@@ -570,6 +583,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/protocols=OpenF
                         '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 \
@@ -583,6 +597,7 @@ ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-
                          'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
 '''},
@@ -680,6 +695,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
         self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
 ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
 '''},
@@ -784,6 +800,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
@@ -832,6 +849,7 @@ Bond=bond0
                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx -- set Interface patchx type=patch options:peer=patchy
 ''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
@@ -841,6 +859,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0 -- set Interface patchy type=patch options:peer=patchx
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
@@ -852,6 +871,7 @@ After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
 '''},
                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
@@ -860,6 +880,7 @@ After=netplan-ovs-bond0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -887,12 +908,14 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan=true
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1 -- set Interface patch0-1 type=patch options:peer=patch1-0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0 -- set Interface patch1-0 type=patch options:peer=patch0-1
 ''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
@@ -902,6 +925,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
 '''},
                          'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
@@ -910,6 +934,7 @@ After=netplan-ovs-br1.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -934,6 +959,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
                          'br0.100.service': OVS_VIRTUAL % {'iface': 'br0.100', 'extra':
@@ -942,6 +968,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
 '''},
@@ -971,6 +998,7 @@ After=netplan-ovs-br0.service
 
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
 ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
 '''},
@@ -1007,6 +1035,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
         self.assert_ovs({'ovs-br.service': OVS_VIRTUAL % {'iface': 'ovs-br', 'extra': '''
 [Service]
 Type=oneshot
+TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs-br
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs-br non-ovs-bond
 ''' + OVS_BR_DEFAULT % {'iface': 'ovs-br'}},


### PR DESCRIPTION
## Description
`ovs-vsctl` will hang forever if the host is not OVS enabled, blocking the tests. This can especially happen when running tests in a container where the host does not have OVS installed (e.g. ci.debian.net).

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Debian: https://bugs.debian.org/1000137

