### PR TITLE
Makefile: fix parallel build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,8 @@ NOSETESTS3 ?= $(shell command -v nosetests-3 || command -v nosetests3 || echo tr
 
 default: netplan/_features.py generate netplan-dbus dbus/io.netplan.Netplan.service doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8 doc/netplan-dbus.8 doc/netplan-get.8 doc/netplan-set.8
 
-%.o: src/%.c
+%.o: src/%.c src/_features.h
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -c $^ `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
-
-dbus.o: src/dbus.c src/_features.h
-	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -c $< `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
 libnetplan.so.$(NETPLAN_SOVER): $(SRCS) abicompat.lds
 	$(CC) -shared -Wl,-soname,libnetplan.so.$(NETPLAN_SOVER) $(BUILDFLAGS) $(CFLAGS) -fvisibility=hidden $(LDFLAGS) -o $@ $(SRCS) -T abicompat.lds `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
@@ -65,7 +62,7 @@ libnetplan.so.$(NETPLAN_SOVER): $(SRCS) abicompat.lds
 generate: libnetplan.so.$(NETPLAN_SOVER) generate.o
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(filter-out $<,$^) -L. -lnetplan `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
-netplan-dbus: libnetplan.so.$(NETPLAN_SOVER) src/_features.h dbus.o
+netplan-dbus: libnetplan.so.$(NETPLAN_SOVER) dbus.o
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -o $@ $(filter-out $<,$(patsubst %.h,,$^)) -L. -lnetplan `pkg-config --cflags --libs libsystemd glib-2.0 gio-2.0 yaml-0.1 uuid`
 
 src/_features.h: src/[^_]*.[hc]

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ default: netplan/_features.py generate netplan-dbus dbus/io.netplan.Netplan.serv
 %.o: src/%.c
 	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -c $^ `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 
+dbus.o: src/dbus.c src/_features.h
+	$(CC) $(BUILDFLAGS) $(CFLAGS) $(LDFLAGS) -c $< `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
+
 libnetplan.so.$(NETPLAN_SOVER): $(SRCS) abicompat.lds
 	$(CC) -shared -Wl,-soname,libnetplan.so.$(NETPLAN_SOVER) $(BUILDFLAGS) $(CFLAGS) -fvisibility=hidden $(LDFLAGS) -o $@ $(SRCS) -T abicompat.lds `pkg-config --cflags --libs glib-2.0 gio-2.0 yaml-0.1 uuid`
 	ln -snf libnetplan.so.$(NETPLAN_SOVER) libnetplan.so


### PR DESCRIPTION
Add src/_features.h as dependency for dbus.o to fix the parallel build
failure:
src/dbus.c:17:10: fatal error: _features.h: No such file or directory

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

