### PR TITLE
Enable building via Meson build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ clean:
 	find . | grep -E "(__pycache__|\.pyc)" | xargs rm -rf
 
 check: default linting
-	tests/cli.py
-	LD_LIBRARY_PATH=. $(NOSETESTS3) -v --with-coverage
+	PYTHONPATH=. LD_LIBRARY_PATH=. tests/cli.py
+	PYTHONPATH=. LD_LIBRARY_PATH=. $(NOSETESTS3) -v --with-coverage
 	tests/validate_docs.sh
 
 linting:

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The full documentation for netplan is available in the [doc/netplan.md file](../
 
 Steps to build netplan using the [Meson](https://mesonbuild.com) build system inside the `build/` directory:
 
-* meson setup build --prefix=/usr
+* meson setup build --prefix=/usr -Db_coverage=true
 * meson compile -C build
-* meson install -C build --destdir ../tmp && tree tmp/
-* meson test -C build
+* meson test -C build --verbose [TEST_NAME]
+* meson install -C build --destdir ../tmproot
 
 # Bug reports
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ An overview of the architecture can be found at [netplan.io/design](https://netp
 
 The full documentation for netplan is available in the [doc/netplan.md file](../master/doc/netplan.md)
 
+# Build using Meson
+
+Steps to build netplan using the [Meson](https://mesonbuild.com) build system inside the `build/` directory:
+
+* meson setup build --prefix=/usr
+* meson compile -C build
+* meson install -C build --destdir ../tmp && tree tmp/
+* meson test -C build
+
 # Bug reports
 
 Please file bug reports in [Launchpad](https://bugs.launchpad.net/netplan/+filebug).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The full documentation for netplan is available in the [doc/netplan.md file](../
 
 Steps to build netplan using the [Meson](https://mesonbuild.com) build system inside the `build/` directory:
 
-* meson setup build --prefix=/usr -Db_coverage=true
+* meson setup build --prefix=/usr [-Db_coverage=true]
 * meson compile -C build
 * meson test -C build --verbose [TEST_NAME]
 * meson install -C build --destdir ../tmproot

--- a/dbus/meson.build
+++ b/dbus/meson.build
@@ -1,0 +1,22 @@
+executable(
+    'netplan-dbus',
+    '../src/dbus.c',
+    include_directories: inc,
+    link_with: libnetplan,
+    dependencies: [libsystemd, glib, gio, yaml, uuid],
+    install_dir: join_paths(get_option('libexecdir'), 'netplan'),
+    install: true)
+
+install_data(
+    'io.netplan.Netplan.conf',
+    install_dir: join_paths(get_option('datadir'), 'dbus-1', 'systemd.d'))
+
+conf_data = configuration_data()
+conf_data.set('ROOTLIBEXECDIR', join_paths(get_option('prefix'), get_option('libexecdir')))
+configure_file(
+    input: 'io.netplan.Netplan.service.in',
+    output: 'io.netplan.Netplan.service',
+    configuration: conf_data,
+    install: true,
+    install_dir: join_paths(get_option('datadir'), 'dbus-1', 'system-services'))
+

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,26 @@
+if pandoc.found()
+    custom_target(
+        input: ['manpage-header.md', 'netplan.md', 'manpage-footer.md'],
+        output: 'netplan.5',
+        command: [pandoc, '-s', '-o', '@OUTPUT@', '@INPUT@'],
+        install: true,
+        install_dir: join_paths(get_option('mandir'), 'man5'))
+    custom_target(
+        input: 'netplan.md',
+        output: 'netplan.html',
+        command: [pandoc, '-s', '--metadata', 'title="Netplan reference"', '--toc', '-o', '@OUTPUT@', '@INPUT@'],
+        install: true,
+        install_dir: join_paths(get_option('datadir'), 'doc', 'netplan'))
+    foreach doc : ['netplan-apply', 'netplan-dbus', 'netplan-generate', 'netplan-get', 'netplan-set', 'netplan-try']
+        markdown = files(doc + '.md')
+        manpage = doc + '.8'
+        custom_target(
+            input: markdown,
+            output: manpage,
+            command: [pandoc, '-s', '-o', '@OUTPUT@', '@INPUT@'],
+            install: true,
+            install_dir: join_paths(get_option('mandir'), 'man8'))
+    endforeach
+else
+    warning('Program "pandoc" not found!  Cannot generate documentation/man pages')
+endif

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,6 @@
+#https://mesonbuild.com/FAQ.html#but-i-really-want-to-use-wildcards
+c = run_command(find, '-name', '*.yaml', check: true)
+examples = c.stdout().strip().split('\n')
+install_data(
+    examples,
+    install_dir: join_paths(get_option('datadir'), 'doc', 'netplan', 'examples'))

--- a/features_h_generator.sh
+++ b/features_h_generator.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+OUTPUT=src/_features.h
+INPUT=src/[^_]*.[hc]
+printf "#include <stddef.h>\nstatic const char *feature_flags[] __attribute__((__unused__)) = {\n" > $OUTPUT
+awk 'match ($0, /netplan-feature:.*/ ) { $0=substr($0, RSTART, RLENGTH); print "\""$2"\"," }' $INPUT >> $OUTPUT
+echo "NULL, };" >> $OUTPUT

--- a/features_py_generator.sh
+++ b/features_py_generator.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+OUTPUT=netplan/_features.py
+INPUT=src/[^_]*.[hc]
+echo "# Generated file" > $OUTPUT
+echo "NETPLAN_FEATURE_FLAGS = [" >> $OUTPUT
+awk 'match ($0, /netplan-feature:.*/ ) { $0=substr($0, RSTART, RLENGTH); print "    \""$2"\"," }' $INPUT >> $OUTPUT
+echo "]" >> $OUTPUT

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,2 @@
+install_headers('netplan.h', 'parse.h', 'parse-nm.h', 'util.h',
+                subdir: 'netplan')

--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,11 @@ pkg_mod.generate(
     filebase: 'netplan',
     description: 'YAML network configuration abstraction runtime library')
 
+install_data(
+    'netplan.completions',
+    rename: 'netplan',
+    install_dir: bash_completions_dir)
+
 #TODO: unit tests
 #test_common = find_program('tests/generator/test_common.py')
 #test('common', test_common)

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,8 @@ systemd_generator_dir = systemd.get_variable(pkgconfig: 'systemdsystemgeneratord
 systemd_unit_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
 bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', default_value: '/etc/bash_completion.d')
 
+pandoc = find_program('pandoc', required: false)
+
 add_project_arguments(
     '-DSBINDIR="' + get_option('sbindir') + '"',
     '-D_XOPEN_SOURCE=500',
@@ -34,6 +36,7 @@ inc = include_directories('include')
 subdir('include')
 subdir('src')
 subdir('netplan')
+subdir('doc')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,6 @@ libsystemd = dependency('libsystemd')
 systemd = dependency('systemd')
 completions = dependency('bash-completion')
 systemd_generator_dir = systemd.get_variable(pkgconfig: 'systemdsystemgeneratordir')
-systemd_unit_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
 bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', default_value: '/etc/bash_completion.d')
 
 pandoc = find_program('pandoc', required: false)

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,11 @@ add_project_arguments(
     '-D_XOPEN_SOURCE=500',
     language: 'c')
 
+message('Generating the _features.[py|h] code')
+#XXX: this is ugly as it produces artifacts in the source directory
+run_command('features_h_generator.sh', check: true)
+run_command('features_py_generator.sh', check: true)
+
 inc = include_directories('include')
 subdir('include')
 subdir('src')

--- a/meson.build
+++ b/meson.build
@@ -33,9 +33,13 @@ inc = include_directories('include')
 subdir('include')
 subdir('src')
 
-#TODO: ship pkgconfig
-#pkg_mod = import('pkgconfig')
-#pkg_mod.generate(libraries: libnetplan, ...)
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(
+    libraries: libnetplan,
+    subdirs: ['netplan'],
+    name: 'libnetplan',
+    filebase: 'netplan',
+    description: 'YAML network configuration abstraction runtime library')
 
 #TODO: unit tests
 #test_common = find_program('tests/generator/test_common.py')

--- a/meson.build
+++ b/meson.build
@@ -20,11 +20,15 @@ completions = dependency('bash-completion')
 systemd_generator_dir = systemd.get_variable(pkgconfig: 'systemdsystemgeneratordir')
 bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', default_value: '/etc/bash_completion.d')
 
+# Order: Fedora/Mageia/openSUSE || Debian/Ubuntu
+pyflakes = find_program('pyflakes-3', 'pyflakes3', required: false)
+pycodestyle = find_program('pycodestyle-3', 'pycodestyle', 'pep8', required: false)
+nose = find_program('nosetests-3', 'nosetests3')
 pandoc = find_program('pandoc', required: false)
 find = find_program('find')
 
 add_project_arguments(
-    '-DSBINDIR="' + get_option('sbindir') + '"',
+    '-DSBINDIR="' + join_paths(get_option('prefix'), get_option('sbindir')) + '"',
     '-D_XOPEN_SOURCE=500',
     language: 'c')
 
@@ -54,6 +58,67 @@ install_data(
     rename: 'netplan',
     install_dir: bash_completions_dir)
 
-#TODO: unit tests
-#test_common = find_program('tests/generator/test_common.py')
-#test('common', test_common)
+###########
+# Testing #
+###########
+test_env = [
+    'PYTHONPATH=' + meson.current_source_dir(),
+    'LD_LIBRARY_PATH=' + join_paths(meson.current_build_dir(), 'src'),
+    'NETPLAN_GENERATE_PATH=' + join_paths(meson.current_build_dir(), 'src', 'generate'),
+    'NETPLAN_DBUS_CMD=' + join_paths(meson.current_build_dir(), 'dbus', 'netplan-dbus'),
+]
+test('linting',
+     pyflakes,
+     args: [meson.current_source_dir()])
+test('codestyle',
+     pycodestyle,
+     args: ['--max-line-length=130', meson.current_source_dir()])
+test('documentation',
+     find_program('tests/validate_docs.sh'),
+     workdir: meson.current_source_dir())
+test('legacy-tests',
+     find_program('tests/cli.py'),
+     timeout: 120,
+     env: test_env)
+#TODO: split out dbus tests into own test() instance, to run in parallel
+test('unit-tests',
+     nose,
+     args: ['-v', '--with-coverage', meson.current_source_dir()],
+     timeout: 600,
+     env: test_env)
+
+#TODO: the coverage section should probably be cleaned up a bit
+if get_option('b_coverage')
+    message('Find coverage reports in <BUILDDIR>/meson-logs/coveragereport[-py]/')
+    # Using gcovr instead of lcov/gcov.
+    # The 'ninja coverage' command will produce the html/txt reports for C implicitly
+    #lcov = find_program('lcov')
+    #gcov = find_program('gcov')
+    #genhtml = find_program('genhtml')
+    gcovr = find_program('gcovr')
+    ninja = find_program('ninja')
+    grep  = find_program('grep')
+    pycoverage = find_program('python3-coverage')
+    test('coverage-c-output',
+         find_program('ninja'),
+         args: ['-C', meson.current_build_dir(), 'coverage'],
+         priority: -90, # run before 'coverage-c'
+         is_parallel: false)
+    test('coverage-c',
+         grep,
+         args: ['^TOTAL.*100%$', join_paths(meson.current_build_dir(), 'meson-logs', 'coverage.txt')],
+         priority: -99, # run last
+         is_parallel: false)
+    test('coverage-py-output',
+         pycoverage,
+         args: ['html', '-d', join_paths(meson.current_build_dir(),
+                'meson-logs', 'coveragereport-py'), '--omit=/usr*'],
+         priority: -99, # run last
+         is_parallel: false)
+    test('coverage-py',
+         pycoverage,
+         args: ['report', '--omit=/usr*', '--show-missing', '--fail-under=100'],
+         priority: -99, # run last
+         is_parallel: false)
+endif
+

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,31 @@
+project('netplan', 'c',
+        version: '0.104',
+        license: 'GPL3',
+        default_options: [
+            'c_std=c99',
+            'warning_level=1',
+            'werror=true',
+        ],
+)
+
+glib = dependency('glib-2.0')
+gio  = dependency('gio-2.0')
+yaml = dependency('yaml-0.1')
+uuid = dependency('uuid')
+
+add_project_arguments(
+    '-DSBINDIR="' + get_option('sbindir') + '"',
+    '-D_XOPEN_SOURCE=500',
+    language: 'c')
+
+inc = include_directories('include')
+subdir('include')
+subdir('src')
+
+#TODO: ship pkgconfig
+#pkg_mod = import('pkgconfig')
+#pkg_mod.generate(libraries: libnetplan, ...)
+
+#TODO: unit tests
+#test_common = find_program('tests/generator/test_common.py')
+#test('common', test_common)

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,12 @@ gio  = dependency('gio-2.0')
 yaml = dependency('yaml-0.1')
 uuid = dependency('uuid')
 
+systemd = dependency('systemd')
+completions = dependency('bash-completion')
+systemd_generator_dir = systemd.get_variable(pkgconfig: 'systemdsystemgeneratordir')
+systemd_unit_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
+bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', default_value: '/etc/bash_completion.d')
+
 add_project_arguments(
     '-DSBINDIR="' + get_option('sbindir') + '"',
     '-D_XOPEN_SOURCE=500',

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,7 @@ systemd_unit_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
 bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', default_value: '/etc/bash_completion.d')
 
 pandoc = find_program('pandoc', required: false)
+find = find_program('find')
 
 add_project_arguments(
     '-DSBINDIR="' + get_option('sbindir') + '"',
@@ -36,9 +37,10 @@ run_command('features_py_generator.sh', check: true)
 inc = include_directories('include')
 subdir('include')
 subdir('src')
-subdir('netplan')
-subdir('doc')
 subdir('dbus')
+subdir('netplan')
+subdir('examples')
+subdir('doc')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ glib = dependency('glib-2.0')
 gio  = dependency('gio-2.0')
 yaml = dependency('yaml-0.1')
 uuid = dependency('uuid')
+libsystemd = dependency('libsystemd')
 
 systemd = dependency('systemd')
 completions = dependency('bash-completion')
@@ -37,6 +38,7 @@ subdir('include')
 subdir('src')
 subdir('netplan')
 subdir('doc')
+subdir('dbus')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ project('netplan', 'c',
             'warning_level=1',
             'werror=true',
         ],
+        meson_version: '>= 0.61.0',
 )
 
 glib = dependency('glib-2.0')
@@ -32,6 +33,7 @@ run_command('features_py_generator.sh', check: true)
 inc = include_directories('include')
 subdir('include')
 subdir('src')
+subdir('netplan')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -29,6 +29,7 @@ NM_SNAP_SERVICE_NAME = 'snap.network-manager.networkmanager.service'
 
 
 def get_generator_path():
+    # FIXME: meson build uses proper libexecdir (+symlink)
     return os.environ.get('NETPLAN_GENERATE_PATH', '/lib/netplan/generate')
 
 

--- a/netplan/meson.build
+++ b/netplan/meson.build
@@ -1,0 +1,35 @@
+install_data('../src/netplan.script')
+install_symlink(
+    'netplan',
+    pointing_to: '../share/netplan/netplan.script',
+    install_dir: get_option('sbindir'))
+
+netplan_sources = files(
+    '__init__.py',
+    '_features.py',
+    'configmanager.py',
+    'terminal.py')
+
+cli_sources = files(
+    'cli/__init__.py',
+    'cli/core.py',
+    'cli/ovs.py',
+    'cli/sriov.py',
+    'cli/utils.py')
+
+commands_sources = files(
+    'cli/commands/__init__.py',
+    'cli/commands/apply.py',
+    'cli/commands/generate.py',
+    'cli/commands/get.py',
+    'cli/commands/info.py',
+    'cli/commands/ip.py',
+    'cli/commands/migrate.py',
+    'cli/commands/set.py',
+    'cli/commands/try_command.py')
+
+netplan_module = join_paths(get_option('datadir'), meson.project_name(), 'netplan')
+install_data(netplan_sources, install_dir: netplan_module)
+install_data(cli_sources, install_dir: join_paths(netplan_module, 'cli'))
+install_data(commands_sources, install_dir: join_paths(netplan_module, 'cli', 'commands'))
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,13 +23,17 @@ libnetplan = library(
     soversion: '0.0',
     install: true)
 
-#TODO: symlink to systemd_generator_dir
+libexec_netplan = join_paths(get_option('libexecdir'), 'netplan')
 executable(
     'generate',
     'generate.c',
     include_directories: inc,
     link_with: libnetplan,
     dependencies: [glib, gio, yaml, uuid],
-    install_dir: join_paths(get_option('libexecdir'), 'netplan'),
+    install_dir: libexec_netplan,
     install: true)
+install_symlink(
+    'netplan',
+    pointing_to: join_paths('..', '..', '..', libexec_netplan, 'generate'),
+    install_dir: get_option('prefix') + systemd_generator_dir)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,25 @@
+sources = files(
+    'abi_compat.c',
+    'error.c',
+    'names.c',
+    'netplan.c',
+    'networkd.c',
+    'nm.c',
+    'openvswitch.c',
+    'parse.c',
+    'parse-nm.c',
+    'sriov.c',
+    'types.c',
+    'util.c',
+    'validation.c')
+
+libnetplan = library(
+    'netplan',
+    sources,
+    gnu_symbol_visibility: 'hidden',
+    link_args: ['-T', '../abicompat.lds'],
+    dependencies: [glib, gio, yaml, uuid],
+    include_directories: inc,
+    soversion: '0.0',
+    install: true)
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,4 +36,9 @@ install_symlink(
     'netplan',
     pointing_to: join_paths('..', '..', '..') + join_paths(get_option('prefix'), libexec_netplan, 'generate'),
     install_dir: systemd_generator_dir)
+# Install this symlink for legacy reasons, see netplan/cli/utils.py: get_generator_path()
+install_symlink(
+    'generate',
+    pointing_to: join_paths('..', '..') + join_paths(get_option('prefix'), libexec_netplan, 'generate'),
+    install_dir: join_paths('/', 'lib', 'netplan'))
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,11 +13,13 @@ sources = files(
     'util.c',
     'validation.c')
 
+linker_script = meson.project_source_root() / 'abicompat.lds'
 libnetplan = library(
     'netplan',
     sources,
     gnu_symbol_visibility: 'hidden',
-    link_args: ['-T', '../abicompat.lds'],
+    link_args: ['-T', linker_script],
+    link_depends: linker_script,
     dependencies: [glib, gio, yaml, uuid],
     include_directories: inc,
     soversion: '0.0',

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,3 +23,13 @@ libnetplan = library(
     soversion: '0.0',
     install: true)
 
+#TODO: symlink to systemd_generator_dir
+executable(
+    'generate',
+    'generate.c',
+    include_directories: inc,
+    link_with: libnetplan,
+    dependencies: [glib, gio, yaml, uuid],
+    install_dir: join_paths(get_option('libexecdir'), 'netplan'),
+    install: true)
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,6 +34,6 @@ executable(
     install: true)
 install_symlink(
     'netplan',
-    pointing_to: join_paths('..', '..', '..', libexec_netplan, 'generate'),
-    install_dir: get_option('prefix') + systemd_generator_dir)
+    pointing_to: join_paths('..', '..', '..') + join_paths(get_option('prefix'), libexec_netplan, 'generate'),
+    install_dir: systemd_generator_dir)
 

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -31,8 +31,6 @@ exe_cli = [os.path.join(rootdir, 'src', 'netplan.script')]
 if shutil.which('python3-coverage'):
     exe_cli = ['python3-coverage', 'run', '--append', '--'] + exe_cli
 
-# Make sure we can import our development netplan.
-os.environ.update({'PYTHONPATH': '.'})
 os.environ.update({'LD_LIBRARY_PATH': '.:{}'.format(os.environ.get('LD_LIBRARY_PATH'))})
 
 
@@ -54,7 +52,8 @@ class TestArgs(unittest.TestCase):
         self.assertIn(b'--root-dir', out)
 
     def test_no_command(self):
-        os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        if not os.environ.get('NETPLAN_GENERATE_PATH'):
+            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
         p = subprocess.Popen(exe_cli, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         (out, err) = p.communicate()
@@ -102,7 +101,8 @@ class TestGenerate(unittest.TestCase):
                          ['10-netplan-enlol.network'])
 
     def test_mapping_for_unknown_iface(self):
-        os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        if not os.environ.get('NETPLAN_GENERATE_PATH'):
+            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -118,7 +118,8 @@ class TestGenerate(unittest.TestCase):
         self.assertNotIn(b'nonexistent', out)
 
     def test_mapping_for_interface(self):
-        os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        if not os.environ.get('NETPLAN_GENERATE_PATH'):
+            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -132,7 +133,8 @@ class TestGenerate(unittest.TestCase):
         self.assertIn('enlol', out.decode('utf-8'))
 
     def test_mapping_for_renamed_iface(self):
-        os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        if not os.environ.get('NETPLAN_GENERATE_PATH'):
+            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -609,7 +611,8 @@ class TestIp(unittest.TestCase):
         self.assertNotEqual(p.returncode, 0)
 
     def test_ip_leases_networkd(self):
-        os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        if not os.environ.get('NETPLAN_GENERATE_PATH'):
+            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -640,7 +643,8 @@ class TestIp(unittest.TestCase):
                       "This is tested in integration tests.")
 
     def test_ip_leases_no_networkd_lease(self):
-        os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        if not os.environ.get('NETPLAN_GENERATE_PATH'):
+            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -664,7 +668,8 @@ class TestIp(unittest.TestCase):
         self.assertNotEqual(p.returncode, 0)
 
     def test_ip_leases_no_nm_lease(self):
-        os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        if not os.environ.get('NETPLAN_GENERATE_PATH'):
+            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -52,8 +52,7 @@ class TestArgs(unittest.TestCase):
         self.assertIn(b'--root-dir', out)
 
     def test_no_command(self):
-        if not os.environ.get('NETPLAN_GENERATE_PATH'):
-            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        os.environ.setdefault('NETPLAN_GENERATE_PATH', os.path.join(rootdir, 'generate'))
         p = subprocess.Popen(exe_cli, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         (out, err) = p.communicate()
@@ -101,8 +100,7 @@ class TestGenerate(unittest.TestCase):
                          ['10-netplan-enlol.network'])
 
     def test_mapping_for_unknown_iface(self):
-        if not os.environ.get('NETPLAN_GENERATE_PATH'):
-            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        os.environ.setdefault('NETPLAN_GENERATE_PATH', os.path.join(rootdir, 'generate'))
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -118,8 +116,7 @@ class TestGenerate(unittest.TestCase):
         self.assertNotIn(b'nonexistent', out)
 
     def test_mapping_for_interface(self):
-        if not os.environ.get('NETPLAN_GENERATE_PATH'):
-            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        os.environ.setdefault('NETPLAN_GENERATE_PATH', os.path.join(rootdir, 'generate'))
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -133,8 +130,7 @@ class TestGenerate(unittest.TestCase):
         self.assertIn('enlol', out.decode('utf-8'))
 
     def test_mapping_for_renamed_iface(self):
-        if not os.environ.get('NETPLAN_GENERATE_PATH'):
-            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        os.environ.setdefault('NETPLAN_GENERATE_PATH', os.path.join(rootdir, 'generate'))
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -611,8 +607,7 @@ class TestIp(unittest.TestCase):
         self.assertNotEqual(p.returncode, 0)
 
     def test_ip_leases_networkd(self):
-        if not os.environ.get('NETPLAN_GENERATE_PATH'):
-            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        os.environ.setdefault('NETPLAN_GENERATE_PATH', os.path.join(rootdir, 'generate'))
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -643,8 +638,7 @@ class TestIp(unittest.TestCase):
                       "This is tested in integration tests.")
 
     def test_ip_leases_no_networkd_lease(self):
-        if not os.environ.get('NETPLAN_GENERATE_PATH'):
-            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        os.environ.setdefault('NETPLAN_GENERATE_PATH', os.path.join(rootdir, 'generate'))
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:
@@ -668,8 +662,7 @@ class TestIp(unittest.TestCase):
         self.assertNotEqual(p.returncode, 0)
 
     def test_ip_leases_no_nm_lease(self):
-        if not os.environ.get('NETPLAN_GENERATE_PATH'):
-            os.environ['NETPLAN_GENERATE_PATH'] = os.path.join(rootdir, 'generate')
+        os.environ.setdefault('NETPLAN_GENERATE_PATH', os.path.join(rootdir, 'generate'))
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -28,9 +28,8 @@ exe_cli = [os.path.join(rootdir, 'src', 'netplan.script')]
 if shutil.which('python3-coverage'):
     exe_cli = ['python3-coverage', 'run', '--append', '--'] + exe_cli
 
-# Make sure we can import our development netplan.
-os.environ.update({'PYTHONPATH': '.'})
-NETPLAN_DBUS_CMD = os.path.join(os.path.dirname(__file__), "..", "..", "netplan-dbus")
+NETPLAN_DBUS_CMD = os.environ.get('NETPLAN_DBUS_CMD',
+                                  os.path.join(os.path.dirname(__file__), "..", "..", "netplan-dbus"))
 
 
 class TestNetplanDBus(unittest.TestCase):

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -32,8 +32,9 @@ import ctypes.util
 import yaml
 import difflib
 
-exe_generate = os.path.join(os.path.dirname(os.path.dirname(
-    os.path.dirname(os.path.abspath(__file__)))), 'generate')
+exe_generate = os.environ.get('NETPLAN_GENERATE_PATH',
+                              os.path.join(os.path.dirname(os.path.dirname(
+                                           os.path.dirname(os.path.abspath(__file__)))), 'generate'))
 
 # make sure we point to libnetplan properly.
 os.environ.update({'LD_LIBRARY_PATH': '.:{}'.format(os.environ.get('LD_LIBRARY_PATH'))})

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -75,7 +75,8 @@ class IntegrationTestsBase(unittest.TestCase):
 
         os.makedirs('/etc/NetworkManager/conf.d', exist_ok=True)
         with open('/etc/NetworkManager/conf.d/99-test-ignore.conf', 'w') as f:
-            f.write('[keyfile]\nunmanaged-devices+=interface-name:eth0,interface-name:en*,interface-name:veth42,interface-name:veth43')
+            f.write('''[keyfile]
+unmanaged-devices+=interface-name:eth0,interface-name:en*,interface-name:veth42,interface-name:veth43''')
         subprocess.check_call(['netplan', 'apply'])
         subprocess.call(['/lib/systemd/systemd-networkd-wait-online', '--quiet', '--timeout=30'])
 

--- a/tests/integration/bonds.py
+++ b/tests/integration/bonds.py
@@ -301,7 +301,7 @@ class _CommonTests():
 
 
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -507,7 +507,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
-                     "skipping as NetworkManager backend tests are disabled")
+                 "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/bridges.py
+++ b/tests/integration/bridges.py
@@ -249,7 +249,7 @@ class _CommonTests():
 
 
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -310,7 +310,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
-                     "skipping as NetworkManager backend tests are disabled")
+                 "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -71,7 +71,7 @@ class _CommonTests():
     englob:
       match: {name: "eth?2"}
       addresses: ["172.16.42.99/18", "1234:FFFF::42/64"]
-''' % {'r': self.backend}) # globbing match on "eth42", i.e. self.dev_e_client
+''' % {'r': self.backend})  # globbing match on "eth42", i.e. self.dev_e_client
         self.generate_and_settle([self.dev_e_client])
         self.assert_iface_up(self.dev_e_client, ['inet 172.16.42.99/18', 'inet6 1234:ffff::42/64'])
 
@@ -117,7 +117,7 @@ class _CommonTests():
             self.assertRegex(out, r'%s\s+(ethernet|bridge)\s+%s' % (i, expected_state))
 
         with open('/etc/resolv.conf') as f:
-                resolv_conf = f.read()
+            resolv_conf = f.read()
 
         if self.backend == 'NetworkManager' and nm_uses_dnsmasq:
             sys.stdout.write('[NM with dnsmasq] ')
@@ -238,7 +238,7 @@ class _CommonTests():
 
 
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -312,8 +312,9 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
                           ['inet6 9876:bbbb::11/70', 'inet 172.16.5.3/20'],
                           ['inet6 fe80:', 'inet 169.254.'])
 
+
 @unittest.skipIf("NetworkManager" not in test_backends,
-                     "skipping as NetworkManager backend tests are disabled")
+                 "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -52,12 +52,12 @@ class _CommonTests():
         # Get bond settings
         for col in ('bond_mode', 'lacp'):
             d['%s-Bond' % col] = subprocess.check_output(['ovs-vsctl', '--columns=name,%s' % col, '-f', 'csv', '-d', 'bare',
-                                                           '--no-headings', 'list', 'Port'])
+                                                          '--no-headings', 'list', 'Port'])
         # Get bridge settings
         d['set-fail-mode-Bridge'] = subprocess.check_output(['ovs-vsctl', 'get-fail-mode', bridge0])
         for col in ('mcast_snooping_enable', 'rstp_enable', 'protocols'):
             d['%s-Bridge' % col] = subprocess.check_output(['ovs-vsctl', '--columns=name,%s' % col, '-f', 'csv', '-d', 'bare',
-                                                             '--no-headings', 'list', 'Bridge'])
+                                                            '--no-headings', 'list', 'Bridge'])
         # Get controller settings
         d['set-controller-Bridge'] = subprocess.check_output(['ovs-vsctl', 'get-controller', bridge0])
         for col in ('connection_mode',):
@@ -604,7 +604,7 @@ class _CommonTests():
 
 
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestOVS(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -122,6 +122,7 @@ r'Reverting\.')
         self.setup_eth(None)
         with open(self.config, 'w') as f:
             f.write('''network:
+  renderer: %(r)s
   ethernets:
     %(ec)s:
       dhcp4: true

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# 
+#
 # Regression tests to catch previously-fixed issues.
 #
 # These need to be run in a VM and do change the system
@@ -39,7 +39,7 @@ class _CommonTests():
 
 
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -96,9 +96,9 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         self.assertEqual('', err)
         self.assertNotIn('An error occurred:', out)
         self.assertRegex(out.strip(), r'Do you want to keep these settings\?\n\n\n'
-r'Press ENTER before the timeout to accept the new configuration\n\n\n'
-r'(Changes will revert in \d+ seconds\n)+'
-r'Configuration accepted\.')
+                         r'Press ENTER before the timeout to accept the new configuration\n\n\n'
+                         r'(Changes will revert in \d+ seconds\n)+'
+                         r'Configuration accepted\.')
 
     def test_try_reject_lp1949095(self):
         with open(self.config, 'w') as f:
@@ -114,9 +114,9 @@ r'Configuration accepted\.')
         self.assertEqual('', err)
         self.assertNotIn('An error occurred:', out)
         self.assertRegex(out.strip(), r'Do you want to keep these settings\?\n\n\n'
-r'Press ENTER before the timeout to accept the new configuration\n\n\n'
-r'(Changes will revert in \d+ seconds\n)+'
-r'Reverting\.')
+                         r'Press ENTER before the timeout to accept the new configuration\n\n\n'
+                         r'(Changes will revert in \d+ seconds\n)+'
+                         r'Reverting\.')
 
     def test_apply_networkd_inactive_lp1962095(self):
         self.setup_eth(None)
@@ -137,7 +137,7 @@ r'Reverting\.')
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
-                     "skipping as NetworkManager backend tests are disabled")
+                 "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -78,7 +78,7 @@ class _CommonTests():
     # The table option was introduced as of NM 1.10+
     def test_route_table(self):
         self.setup_eth(None)
-        table_id = '255' # This is the 'local' FIB of /etc/iproute2/rt_tables
+        table_id = '255'  # This is the 'local' FIB of /etc/iproute2/rt_tables
         with open(self.config, 'w') as f:
             f.write('''network:
   renderer: %(r)s
@@ -277,8 +277,9 @@ class _CommonTests():
         self.assertIn(b'metric 99',  # check metric from static route
                       subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
 
+
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -370,7 +371,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
-                     "skipping as NetworkManager backend tests are disabled")
+                 "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/run.py
+++ b/tests/integration/run.py
@@ -29,8 +29,8 @@ import sys
 
 tests_dir = os.path.dirname(os.path.abspath(__file__))
 
-default_backends = [ 'networkd', 'NetworkManager' ]
-fixtures = [ "__init__.py", "base.py", "run.py" ]
+default_backends = ['networkd', 'NetworkManager']
+fixtures = ["__init__.py", "base.py", "run.py"]
 
 possible_tests = []
 testfiles = glob.glob(os.path.join(tests_dir, "*.py"))
@@ -39,6 +39,7 @@ for pyfile in testfiles:
     if filename not in fixtures:
         possible_tests.append(filename.split('.')[0])
 
+
 def dedupe(duped_list):
     deduped = set()
     for item in duped_list:
@@ -46,6 +47,7 @@ def dedupe(duped_list):
         for real_item in real_items:
             deduped.add(real_item)
     return deduped
+
 
 # XXX: omg, this is ugly :)
 parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tests/integration/scenarios.py
+++ b/tests/integration/scenarios.py
@@ -118,7 +118,7 @@ class _CommonTests():
         confdir = os.path.join(tempdir, 'etc', 'netplan')
         os.makedirs(confdir)
         with open(self.config, 'w') as f:
-                    f.write('''network:
+            f.write('''network:
   renderer: %(r)s
   version: 2
   bridges:
@@ -136,13 +136,13 @@ class _CommonTests():
 
 
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
-                     "skipping as NetworkManager backend tests are disabled")
+                 "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/tunnels.py
+++ b/tests/integration/tunnels.py
@@ -27,6 +27,7 @@ import unittest
 
 from base import IntegrationTestsBase, test_backends
 
+
 class _CommonTests():
 
     def test_tunnel_sit(self):
@@ -128,7 +129,7 @@ class _CommonTests():
 
 
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
@@ -196,7 +197,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
-                     "skipping as NetworkManager backend tests are disabled")
+                 "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/tunnels.py
+++ b/tests/integration/tunnels.py
@@ -23,7 +23,6 @@
 
 import sys
 import subprocess
-import time
 import unittest
 
 from base import IntegrationTestsBase, test_backends

--- a/tests/integration/vlans.py
+++ b/tests/integration/vlans.py
@@ -89,13 +89,13 @@ class _CommonTests():
 
 
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsBase, _CommonTests):
     backend = 'networkd'
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
-                     "skipping as NetworkManager backend tests are disabled")
+                 "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/integration/wifi.py
+++ b/tests/integration/wifi.py
@@ -113,13 +113,13 @@ wpa_passphrase=12345678
 
 
 @unittest.skipIf("networkd" not in test_backends,
-                     "skipping as networkd backend tests are disabled")
+                 "skipping as networkd backend tests are disabled")
 class TestNetworkd(IntegrationTestsWifi, _CommonTests):
     backend = 'networkd'
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,
-                     "skipping as NetworkManager backend tests are disabled")
+                 "skipping as NetworkManager backend tests are disabled")
 class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
     backend = 'NetworkManager'
 

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -30,8 +30,9 @@ import ctypes.util
 import contextlib
 import subprocess
 
-exe_generate = os.path.join(os.path.dirname(os.path.dirname(
-    os.path.dirname(os.path.abspath(__file__)))), 'generate')
+exe_generate = os.environ.get('NETPLAN_GENERATE_PATH',
+                              os.path.join(os.path.dirname(os.path.dirname(
+                                           os.path.dirname(os.path.abspath(__file__)))), 'generate'))
 
 # make sure we point to libnetplan properly.
 os.environ.update({'LD_LIBRARY_PATH': '.:{}'.format(os.environ.get('LD_LIBRARY_PATH'))})

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -25,8 +25,6 @@ from .base import TestKeyfileBase
 
 rootdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 exe_cli = os.path.join(rootdir, 'src', 'netplan.script')
-# Make sure we can import our development netplan.
-os.environ.update({'PYTHONPATH': '.'})
 
 lib = ctypes.CDLL(ctypes.util.find_library('netplan'))
 lib.netplan_get_id_from_nm_filename.restype = ctypes.c_char_p

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -600,7 +600,8 @@ mode=ap'''.format(UUID))
         self._template_keyfile_type_wifi('infrastructure', 'mesh')
 
     def test_keyfile_type_wifi_missing_ssid(self):
-        err = self.generate_from_keyfile('''[connection]\ntype=wifi\nuuid={}\nid=myid with spaces'''.format(UUID), expect_fail=True)
+        err = self.generate_from_keyfile('''[connection]\ntype=wifi\nuuid={}\nid=myid with spaces'''
+                                         .format(UUID), expect_fail=True)
         self.assertFalse(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(UUID))))
         self.assertIn('netplan: Keyfile: cannot find SSID for WiFi connection', err)
 

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -34,8 +34,6 @@ import netplan.libnetplan as libnetplan
 lib = libnetplan.lib
 rootdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 exe_cli = os.path.join(rootdir, 'src', 'netplan.script')
-# Make sure we can import our development netplan.
-os.environ.update({'PYTHONPATH': '.'})
 
 
 class TestRawLibnetplan(TestBase):


### PR DESCRIPTION
## Description
Adding a Meson build environment in addition to the plain `Makefile` netplan is using currently.
The new build system should be able to support all the Makefile's features and implement them in a more standard conform way. Furthermore, using Meson we'll be able to extend the build-time features more easily in the future, like implementing build-time options and properly acknowledging dpkg buildflags (hardening/LTO/...).

Meson is easy to use, here are some sample commands, to do the usual netplan stuff:
* meson setup build --prefix=/usr [-Db_coverage=true]
* meson compile -C build
* meson test -C build --verbose [TEST_NAME]
* meson install -C build --destdir ../tmproot

All things are done inside the build directory, specified during the `meson setup` command ("build" in the example above), except the code generated in `src/_features.h` and `python/_features.py`, that is still inside the source directory.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

