### PR TITLE
networkd: rename GatewayOnlink= to GatewayOnLink=

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -483,7 +483,7 @@ write_route(NetplanIPRoute* r, GString* s)
     if (g_strcmp0(r->type, "unicast") != 0)
         g_string_append_printf(s, "Type=%s\n", r->type);
     if (r->onlink)
-        g_string_append_printf(s, "GatewayOnlink=true\n");
+        g_string_append_printf(s, "GatewayOnLink=true\n");
     if (r->metric != NETPLAN_METRIC_UNSPEC)
         g_string_append_printf(s, "Metric=%d\n", r->metric);
     if (r->table != NETPLAN_ROUTE_TABLE_UNSPEC)

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -176,7 +176,7 @@ Address=192.168.14.2/24
 [Route]
 Destination=10.10.10.0/24
 Gateway=192.168.14.20
-GatewayOnlink=true
+GatewayOnLink=true
 Metric=100
 '''})
 


### PR DESCRIPTION
## Description
As of systemd v242 the "GatewayOnlink" spelling was deprecated and replaced by
"GatewayOnLink", while still being available in compat mode.

We've waited long enough and can switch to the proper spelling now.

https://github.com/systemd/systemd/commit/9cb8c5593443d24c19e40bfd4fc06d672f8c554c

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

