### PR TITLE
Allow key configuration for [ip6]gre[tap] tunnels (LP: #1966476)

### DIFF
--- a/src/validation.c
+++ b/src/validation.c
@@ -244,6 +244,10 @@ validate_tunnel_backend_rules(const NetplanParser* npp, NetplanNetDefinition* nd
                 case NETPLAN_TUNNEL_MODE_VTI:
                 case NETPLAN_TUNNEL_MODE_VTI6:
                 case NETPLAN_TUNNEL_MODE_WIREGUARD:
+                case NETPLAN_TUNNEL_MODE_GRE:
+                case NETPLAN_TUNNEL_MODE_IP6GRE:
+                case NETPLAN_TUNNEL_MODE_GRETAP:
+                case NETPLAN_TUNNEL_MODE_IP6GRETAP:
                     break;
 
                 /* TODO: Remove this exception and fix ISATAP handling with the

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -799,7 +799,7 @@ ConfigureWithoutCarrier=yes
 
     def test_ip6gre(self):
         """[networkd] Validate generation of IP6GRE tunnels"""
-        config = prepare_config_for_mode('networkd', 'ip6gre')
+        config = prepare_config_for_mode('networkd', 'ip6gre', '33490175')
         self.generate(config)
         self.assert_networkd({'tun0.netdev': '''[NetDev]
 Name=tun0
@@ -809,6 +809,8 @@ Kind=ip6gre
 Independent=true
 Local=fe80::dead:beef
 Remote=2001:fe:ad:de:ad:be:ef:1
+InputKey=33490175
+OutputKey=33490175
 ''',
                               'tun0.network': '''[Match]
 Name=tun0


### PR DESCRIPTION
## Description
The following example should configure a GRE tunnel between 172.16.4.2 and 172.16.1.2, with key 33490175. The effect should be like manually configured with: sudo ip tunnel add test1 mode gre local 172.16.4.2 remote 172.16.1.2 key 33490175.

However, the following Netplan configuration fails under Ubuntu 22.04 (latest development version, March 25, 2022):
```
network:
  version: 2
  renderer: networkd
  tunnels:
    gre1-255-255:
      mode: gre
      ttl: 255
      local: 172.16.4.2
      remote: 172.16.1.2
      key: 33490175
      addresses:
        - 172.20.82.94/30
```
Result of "sudo netplan generate": Error in network definition: gre1-255-255: 'input-key' is not required for this tunnel type

Some investigation into the sources of Netplan (src/validation.c -> https://github.com/canonical/netplan/blob/main/src/validation.c):
It seems that the cases NETPLAN_TUNNEL_MODE_GRE and NETPLAN_TUNNEL_MODE_IP6GRE are missing for systemd-networkd. According to https://github.com/systemd/systemd/issues/12144, systemd-networkd should support configuration with keys since ca. 2 years.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1966476

