### PR TITLE
Improve NetworkManager's device management/ignore logic, using udev matching rules (LP: #1951653)

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -128,7 +128,9 @@ type_str(const NetplanNetDefinition* def)
             return "ip-tunnel";
         case NETPLAN_DEF_TYPE_NM:
             /* needs to be overriden by passthrough "connection.type" setting */
-            return NULL;
+            g_assert(def->backend_settings.nm.passthrough);
+            GData *passthrough = def->backend_settings.nm.passthrough;
+            return g_datalist_get_data(&passthrough, "connection.type");
         // LCOV_EXCL_START
         default:
             g_assert_not_reached();
@@ -595,7 +597,7 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
     }
 
     nm_type = type_str(def);
-    if (nm_type)
+    if (nm_type && def->type != NETPLAN_DEF_TYPE_NM)
         g_key_file_set_string(kf, "connection", "type", nm_type);
 
     if (ap && ap->backend_settings.nm.uuid)

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -19,7 +19,7 @@
 import os
 import stat
 
-from .base import TestBase, ND_DHCP4, ND_WIFI_DHCP4, SD_WPA
+from .base import TestBase, ND_DHCP4, ND_WIFI_DHCP4, SD_WPA, NM_MANAGED, NM_UNMANAGED
 
 
 class TestNetworkd(TestBase):
@@ -83,10 +83,8 @@ class TestNetworkd(TestBase):
       ''')
 
         self.assert_networkd({'wl0.network': ND_WIFI_DHCP4 % 'wl0'})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:wl0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'wl0')
 
         # generates wpa config and enables wpasupplicant unit
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
@@ -201,10 +199,8 @@ network={
       ''')
 
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:eth0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'eth0')
 
         # generates wpa config and enables wpasupplicant unit
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-eth0.conf')) as f:
@@ -458,7 +454,7 @@ method=ignore
 ssid=peer2peer
 mode=adhoc
 '''})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'wl0')
 
     def test_auth_wired(self):
         self.generate('''network:
@@ -502,7 +498,7 @@ private-key=/etc/ssl/cust-key.pem
 private-key-password=d3cryptPr1v4t3K3y
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eth0')
 
 
 class TestConfigErrors(TestBase):

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase
+from .base import TestBase, NM_MANAGED, NM_UNMANAGED
 
 
 class TestNetworkd(TestBase):
@@ -79,10 +79,8 @@ ConfigureWithoutCarrier=yes
 RouteMetric=100
 UseMTU=true
 '''})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:bn0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'bn0')
 
     def test_bond_components(self):
         self.generate('''network:
@@ -460,7 +458,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eno1' + NM_MANAGED % 'enp2s1' + NM_MANAGED % 'bn0')
 
     def test_bond_empty_params(self):
         self.generate('''network:
@@ -521,7 +519,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eno1' + NM_MANAGED % 'enp2s1' + NM_MANAGED % 'bn0')
 
     def test_bond_with_params(self):
         self.generate('''network:
@@ -625,7 +623,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eno1' + NM_MANAGED % 'enp2s1' + NM_MANAGED % 'bn0')
 
     def test_bond_primary_slave(self):
         self.generate('''network:
@@ -692,7 +690,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eno1' + NM_MANAGED % 'enp2s1' + NM_MANAGED % 'bn0')
 
 
 class TestConfigErrors(TestBase):

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -19,7 +19,7 @@
 import os
 import unittest
 
-from .base import TestBase
+from .base import TestBase, NM_UNMANAGED, NM_MANAGED
 
 
 class TestNetworkd(TestBase):
@@ -108,10 +108,8 @@ ConfigureWithoutCarrier=yes
 RouteMetric=100
 UseMTU=true
 '''})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:br0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'br0')
 
     def test_bridge_type_renderer(self):
         self.generate('''network:
@@ -135,10 +133,8 @@ ConfigureWithoutCarrier=yes
 RouteMetric=100
 UseMTU=true
 '''})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:br0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'br0')
 
     def test_bridge_def_renderer(self):
         self.generate('''network:
@@ -165,10 +161,8 @@ ConfigureWithoutCarrier=yes
 RouteMetric=100
 UseMTU=true
 '''})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:br0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'br0')
 
     def test_bridge_forward_declaration(self):
         self.generate('''network:
@@ -215,9 +209,8 @@ UseMTU=true
     mybr:
       interfaces: [ethbr]
       dhcp4: yes''')
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:eth42,interface-name:eth43,interface-name:mybr,''')
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'eth42' + NM_UNMANAGED % 'eth43' + NM_UNMANAGED % 'mybr')
 
     def test_bridge_components(self):
         self.generate('''network:
@@ -322,7 +315,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'br0')
 
     def test_bridge_type_renderer(self):
         self.generate('''network:
@@ -345,7 +338,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'br0')
 
     def test_bridge_set_mac(self):
         self.generate('''network:
@@ -395,7 +388,7 @@ address1=1.2.3.4/12
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'br0')
 
     def test_bridge_forward_declaration(self):
         self.generate('''network:
@@ -456,7 +449,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'br0' + NM_MANAGED % 'eno1' + NM_MANAGED % 'enp2s1')
 
     def test_bridge_components(self):
         self.generate('''network:
@@ -516,7 +509,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eno1' + NM_MANAGED % 'enp2s1' + NM_MANAGED % 'br0')
 
     def test_bridge_params(self):
         self.generate('''network:
@@ -599,7 +592,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eno1' + NM_MANAGED % 'enp2s1' + NM_MANAGED % 'br0')
 
 
 class TestNetplanYAMLv2(TestBase):

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -19,7 +19,7 @@
 import os
 import textwrap
 
-from .base import TestBase, ND_DHCP4, ND_DHCP6, ND_DHCPYES, ND_EMPTY
+from .base import TestBase, ND_DHCP4, ND_DHCP6, ND_DHCPYES, ND_EMPTY, NM_MANAGED, NM_UNMANAGED
 
 
 class TestNetworkd(TestBase):
@@ -184,10 +184,8 @@ Bond=bond0
       dhcp4: true''')
 
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:eth0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'eth0')
         # should not allow NM to manage everything
         self.assertFalse(os.path.exists(self.nm_enable_all_conf))
 
@@ -201,12 +199,10 @@ unmanaged-devices+=interface-name:eth0,''')
       dhcp4: true''')
 
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:eth0,''')
+        self.assert_nm(None)
         # should allow NM to manage everything else
         self.assertTrue(os.path.exists(self.nm_enable_all_conf))
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'eth0')
 
     def test_eth_def_renderer(self):
         self.generate('''network:
@@ -220,10 +216,8 @@ unmanaged-devices+=interface-name:eth0,''')
 
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
         self.assert_networkd_udev(None)
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:eth0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'eth0')
 
     def test_eth_dhcp6(self):
         self.generate('''network:
@@ -931,7 +925,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eth0')
 
     def test_ipv6_mtu(self):
         self.generate(textwrap.dedent("""
@@ -966,7 +960,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eth0')
 
     def test_eth_type_renderer(self):
         self.generate('''network:
@@ -992,7 +986,7 @@ method=auto
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eth0')
 
     def test_eth_def_renderer(self):
         self.generate('''network:
@@ -1018,7 +1012,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'eth0')
 
     def test_global_renderer_only(self):
         self.generate(None, confs={'01-default-nm.yaml': 'network: {version: 2, renderer: NetworkManager}'})
@@ -1193,7 +1187,7 @@ address1=2001:FFfe::1/64
 ip6-privacy=0
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'engreen')
 
     def test_eth_manual_addresses_dhcp(self):
         self.generate('''network:
@@ -1545,10 +1539,8 @@ class TestMerging(TestBase):
                       confs={'backend': 'network:\n  renderer: networkd'})
 
         self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen'})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:engreen,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'engreen')
 
     def test_add_def(self):
         self.generate('''network:
@@ -1568,10 +1560,8 @@ unmanaged-devices+=interface-name:engreen,''')
         # releases, so we can't depend on the exact order.
         # TODO: (cyphermox) turn this into an "assert_in_nm()" function.
         if "CODECOV_TOKEN" not in os.environ:  # pragma: nocover
-            self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:engreen,interface-name:enblue,''')
-        self.assert_nm_udev(None)
+            self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'engreen' + NM_UNMANAGED % 'enblue')
 
     def test_change_def(self):
         self.generate('''network:
@@ -1608,10 +1598,8 @@ unmanaged-devices+=interface-name:engreen,interface-name:enblue,''')
     engreen: {dhcp4: true}''')
 
         self.assert_networkd({'engreen.network': ND_DHCP4 % 'engreen'})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:engreen,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'engreen')
 
     def test_ref(self):
         self.generate('''network:

--- a/tests/generator/test_modems.py
+++ b/tests/generator/test_modems.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase
+from .base import TestBase, NM_MANAGED
 
 
 class TestNetworkd(TestBase):
@@ -67,7 +67,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_auto_config(self):
         self.generate('''network:
@@ -91,7 +91,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_auto_config_implicit(self):
         self.generate('''network:
@@ -120,7 +120,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_apn(self):
         self.generate('''network:
@@ -144,7 +144,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_apn_username_password(self):
         self.generate('''network:
@@ -172,7 +172,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_device_id(self):
         self.generate('''network:
@@ -197,7 +197,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_network_id(self):
         self.generate('''network:
@@ -222,7 +222,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_pin(self):
         self.generate('''network:
@@ -247,7 +247,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_sim_id(self):
         self.generate('''network:
@@ -272,7 +272,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_sim_operator_id(self):
         self.generate('''network:
@@ -297,7 +297,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_gsm_example(self):
         self.generate('''network:
@@ -339,7 +339,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'cdc-wdm1')
 
     def test_modem_nm_integration(self):
         self.generate('''network:
@@ -366,7 +366,7 @@ method=link-local
 method=ignore
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'mobilephone')
 
     def test_modem_nm_integration_gsm_cdma(self):
         self.generate('''network:
@@ -421,6 +421,8 @@ method=auto
 [ipv6]
 #Netplan: passthrough override
 method=auto
-'''})
+'''}, '''[device-netplan.modems.NM-a08c5805-7cf5-43f7-afb9-12cb30f6eca3]
+match-device=type:gsm
+managed=1\n\n''')
         self.assert_networkd({})
         self.assert_nm_udev(None)

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -56,7 +56,9 @@ method=link-local
 
 [ipv6]
 method=ignore
-'''})
+'''}, '''[device-netplan.ethernets.NM-87749f1d-334f-40b2-98d4-55db58965f5f]
+match-device=type:ethernet
+managed=1\n\n''')
 
     def test_passthrough_wifi(self):
         self.generate('''network:
@@ -107,7 +109,9 @@ method=ignore
 ssid=OTHER-SSID
 mode=infrastructure
 hidden=true
-'''})
+'''}, '''[device-netplan.wifis.NM-87749f1d-334f-40b2-98d4-55db58965f5f]
+match-device=type:wifi
+managed=1\n\n''')
 
     def test_passthrough_type_nm_devices(self):
         self.generate('''network:
@@ -132,7 +136,9 @@ method=link-local
 
 [ipv6]
 method=ignore
-'''})
+'''}, '''[device-netplan.nm-devices.NM-87749f1d-334f-40b2-98d4-55db58965f5f]
+match-device=type:dummy
+managed=1\n\n''')
 
     def test_passthrough_dotted_group(self):
         self.generate('''network:
@@ -159,7 +165,9 @@ method=ignore
 [wireguard-peer.some-key]
 #Netplan: passthrough setting
 endpoint=1.2.3.4
-'''})
+'''}, '''[device-netplan.nm-devices.dotted-group-test]
+match-device=type:wireguard
+managed=1\n\n''')
 
     def test_passthrough_dotted_key(self):
         self.generate('''network:
@@ -193,7 +201,9 @@ qdisc.root=something
 qdisc.fff1=:abc
 #Netplan: passthrough setting
 filters.test=test
-'''})
+'''}, '''[device-netplan.ethernets.dotted-key-test]
+match-device=type:ethernet
+managed=1\n\n''')
 
     def test_passthrough_unsupported_setting(self):
         self.generate('''network:
@@ -221,7 +231,9 @@ method=ignore
 ssid=SOME-SSID
 #Netplan: passthrough override
 mode=mesh
-'''})
+'''}, '''[device-netplan.wifis.test]
+match-device=type:wifi
+managed=1\n\n''')
 
     def test_passthrough_empty_group(self):
         self.generate('''network:
@@ -247,7 +259,9 @@ method=link-local
 method=ignore
 
 [proxy]
-'''})
+'''}, '''[device-netplan.ethernets.test]
+match-device=type:ethernet
+managed=1\n\n''')
 
     def test_passthrough_interface_rename_existing_id(self):
         self.generate('''network:

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -20,7 +20,8 @@ import os
 import re
 import unittest
 
-from .base import TestBase, ND_VLAN, ND_EMPTY, ND_WITHIP, ND_DHCP6_WOCARRIER
+from .base import TestBase, ND_VLAN, ND_EMPTY, ND_WITHIP, ND_DHCP6_WOCARRIER, \
+    NM_MANAGED, NM_UNMANAGED, NM_MANAGED_MAC, NM_UNMANAGED_MAC
 
 
 class TestNetworkd(TestBase):
@@ -66,10 +67,9 @@ Id=3
                               .replace('[Network]', '[Link]\nMACAddress=aa:bb:cc:dd:ee:11\n\n[Network]'),
                               'engreen.network': (ND_DHCP6_WOCARRIER % 'engreen')})
 
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:en1,interface-name:enblue,interface-name:enred,interface-name:engreen,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'en1' + NM_UNMANAGED % 'enblue' + NM_UNMANAGED % 'enred' +
+                            NM_UNMANAGED_MAC % 'aa:bb:cc:dd:ee:11' + NM_UNMANAGED % 'engreen')
 
     def test_vlan_sriov(self):
         # we need to make sure renderer: sriov vlans are not saved as part of
@@ -95,10 +95,8 @@ VLAN=engreen
                               'engreen.netdev': ND_VLAN % ('engreen', 2),
                               'engreen.network': (ND_DHCP6_WOCARRIER % 'engreen')})
 
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:en1,interface-name:enblue,interface-name:engreen,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'en1' + NM_UNMANAGED % 'enblue' + NM_UNMANAGED % 'engreen')
 
     # see LP: #1888726
     def test_vlan_parent_match(self):
@@ -137,10 +135,8 @@ MTUBytes=9000
                               'vlan20.network': ND_EMPTY % ('vlan20', 'ipv6'),
                               'vlan20.netdev': ND_VLAN % ('vlan20', 20)})
 
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=mac:11:22:33:44:55:66,interface-name:lan,interface-name:vlan20,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'lan' + NM_UNMANAGED_MAC % '11:22:33:44:55:66' + NM_UNMANAGED % 'vlan20')
 
 
 class TestNetworkManager(TestBase):
@@ -205,7 +201,7 @@ method=link-local
 method=auto
 ip6-privacy=0
 '''})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'en1' + NM_MANAGED % 'enblue' + NM_MANAGED % 'engreen')
 
     def test_vlan_parent_match(self):
         self.generate('''network:
@@ -256,7 +252,7 @@ method=auto
 [ipv6]
 method=ignore
 ''' % uuid})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED_MAC % '11:22:33:44:55:66' + NM_MANAGED % 'engreen')
 
     def test_vlan_sriov(self):
         # we need to make sure renderer: sriov vlans are not saved as part of
@@ -305,4 +301,4 @@ method=link-local
 method=auto
 ip6-privacy=0
 '''})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'en1' + NM_MANAGED % 'enblue' + NM_MANAGED % 'engreen')

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -19,7 +19,7 @@
 import os
 import stat
 
-from .base import TestBase, ND_WIFI_DHCP4, SD_WPA
+from .base import TestBase, ND_WIFI_DHCP4, SD_WPA, NM_MANAGED, NM_UNMANAGED
 
 
 class TestNetworkd(TestBase):
@@ -57,10 +57,8 @@ class TestNetworkd(TestBase):
       dhcp4: yes''')
 
         self.assert_networkd({'wl0.network': ND_WIFI_DHCP4 % 'wl0'})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:wl0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'wl0')
 
         # generates wpa config and enables wpasupplicant unit
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
@@ -240,10 +238,8 @@ RouteMetric=600
 UseMTU=true
 '''})
 
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:wl0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'wl0')
 
     def test_wifi_match(self):
         err = self.generate('''network:
@@ -292,10 +288,8 @@ Name=wl0
 [Network]
 LinkLocalAddressing=ipv6
 '''})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:wl0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'wl0')
 
         # generates wpa config and enables wpasupplicant unit
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
@@ -328,10 +322,8 @@ Name=wl0
 [Network]
 LinkLocalAddressing=ipv6
 '''})
-        self.assert_nm(None, '''[keyfile]
-# devices managed by networkd
-unmanaged-devices+=interface-name:wl0,''')
-        self.assert_nm_udev(None)
+        self.assert_nm(None)
+        self.assert_nm_udev(NM_UNMANAGED % 'wl0')
 
         # generates wpa config and enables wpasupplicant unit
         with open(os.path.join(self.workdir.name, 'run/netplan/wpa-wl0.conf')) as f:
@@ -495,7 +487,7 @@ mode=infrastructure
 band=a
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'wl0')
 
     def test_wifi_match_mac(self):
         self.generate('''network:
@@ -547,7 +539,9 @@ method=ignore
 [wifi]
 ssid=workplace
 mode=infrastructure
-'''})
+'''}, '''[device-netplan.wifis.all]
+match-device=type:wifi
+managed=1\n\n''')
 
     def test_wifi_ap(self):
         self.generate('''network:
@@ -580,7 +574,7 @@ key-mgmt=wpa-psk
 psk=s0s3cret
 '''})
         self.assert_networkd({})
-        self.assert_nm_udev(None)
+        self.assert_nm_udev(NM_MANAGED % 'wl0')
 
     def test_wifi_adhoc(self):
         self.generate('''network:


### PR DESCRIPTION
## Description
By default, `systemd-networkd` controls only interfaces that it has explicitly been configured for (via a sd-networkd `.network` file); it considers other interfaces as "unmanaged" and ignores them. NetworkManager OTOH tries to claim control of any interface that is UP, which might lead to conflicts if multiple networking daemons are used at the same time.

NetworkManager has different ways to control/avoid this behavior:
* `NM_UNMANAGED=1` udev environment, the weakest condition
* NetworkManager.conf `[keyfile].unmanaged-devices=` setting (affected by some unexpected behavior: LP#1615044)
* NetworkManager.conf `[device].managed=` setting, the strongest condition, overruling all other settings, created a runtime in `/run/NetworkManager/devices/*`

The stronger rules via NetworkManager.conf are unfortunately a bit limited in their matching logic, as multiple checks can only be ORed (e.g. we cannot check for: `interface-name=wl* AND driver=(virt* OR iwlwifi)`). udev OTOH has a very powerful matching logic (but unfortunately cannot match on the interface type: ethernet/wifi/bridge/...).

So we're reimplementing/refactoring the flawed NetworkManager "unmanaged vs managed" logic in netplan, by having an explicit **allow-list** of interfaces that NM is supposed to control (as some udev rules shipped system-wide would otherwise disable certain interfaces in containers and other special conditions, even if configured via netplan, c.f. `/lib/udev/rules.d/85-nm-unmanaged.rules`) in addition to an explicit **deny-list** of interfaces to ignore (e.g. because they are to be managed by sd-networkd) as udev rules in `/run/udev/rules.d/90-netplan.rules` and keeping the special-case of matching a whole class/type of interfaces (e.g. ethernets/wifis/bridges/...) in `/run/NetworkManager/conf.d/netplan.conf` as a NetworkManager.conf `[device*].managed=` rule.
Furthermore, we're applying this matching logic whenever ANY interface (in netplan YAML) is supposed to be controlled by NetworkManager (that is in contrast to only applying it when NetworkManager is selected as the global renderer).

It is worth mentioning that this "managed vs unmanaged" matching logic is slightly different from netplan's usual matching logic (e.g. for configuring the interfaces), as we might ignore an interface based on it's old AND new/renamed interface name, or it's old and new/changed MAC address, while we cannot do this for the normal netplan matching.

Commits:
* generate: ignore 10-globally-managed-devices.conf if any NM config is given in netplan
* cli: re-apply udev rules (NM_UNMANAGED) if needed
  * Also, make sure we clear any runtime state that NetworkManager left in /run/NetworkManager/devices/* as this could overwrite our udev rules.
* nm: extend type_str() to return passthrough types
* nm: tests: improve NM manage/ignore logic, using udev matching rules
* tests:base: cleanup udev quirks
  * We have an explicit NM-managed-devices allow-list, now. So we don't need those quirks anymore.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1951653

