### PR TITLE
nm: fix rendering of password for unknown/passthrough WPA types (LP: #1972800)

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -431,9 +431,6 @@ write_tunnel_params(const NetplanNetDefinition* def, GKeyFile *kf)
 static void
 write_dot1x_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile *kf)
 {
-    if (auth->eap_method == NETPLAN_AUTH_EAP_NONE)
-        return;
-
     switch (auth->eap_method) {
         case NETPLAN_AUTH_EAP_TLS:
             g_key_file_set_string(kf, "802-1x", "eap", "tls");
@@ -468,14 +465,11 @@ write_dot1x_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile 
 static void
 write_wifi_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile *kf)
 {
-    if (auth->key_management == NETPLAN_AUTH_KEY_MANAGEMENT_NONE)
-        return;
-
     switch (auth->key_management) {
+        case NETPLAN_AUTH_KEY_MANAGEMENT_NONE:
+            break;
         case NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK:
             g_key_file_set_string(kf, "wifi-security", "key-mgmt", "wpa-psk");
-            if (auth->password)
-                g_key_file_set_string(kf, "wifi-security", "psk", auth->password);
             break;
         case NETPLAN_AUTH_KEY_MANAGEMENT_WPA_EAP:
             g_key_file_set_string(kf, "wifi-security", "key-mgmt", "wpa-eap");
@@ -486,7 +480,10 @@ write_wifi_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile *
         default: break; // LCOV_EXCL_LINE
     }
 
-    write_dot1x_auth_parameters(auth, kf);
+    if (auth->eap_method != NETPLAN_AUTH_EAP_NONE)
+        write_dot1x_auth_parameters(auth, kf);
+    else if (auth->password)
+        g_key_file_set_string(kf, "wifi-security", "psk", auth->password);
 }
 
 static void

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1241,3 +1241,54 @@ method=auto
         passthrough:
           ipv6.ip6-privacy: "-1"
 '''.format(UUID, UUID)})
+
+    def test_keyfile_wpa3_sae(self):
+        self.generate_from_keyfile('''[connection]
+id=test2
+uuid={}
+type=wifi
+interface-name=wlan0
+
+[wifi]
+mode=infrastructure
+ssid=ubuntu-wpa2-wpa3-mixed
+
+[wifi-security]
+key-mgmt=sae
+psk=test1234
+
+[ipv4]
+method=auto
+
+[ipv6]
+addr-gen-mode=stable-privacy
+method=auto
+
+[proxy]
+'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  wifis:
+    NM-{}:
+      renderer: NetworkManager
+      match:
+        name: "wlan0"
+      dhcp4: true
+      dhcp6: true
+      ipv6-address-generation: "stable-privacy"
+      access-points:
+        "ubuntu-wpa2-wpa3-mixed":
+          auth:
+            key-management: "none"
+            password: "test1234"
+          networkmanager:
+            uuid: "ff9d6ebc-226d-4f82-a485-b7ff83b9607f"
+            name: "test2"
+            passthrough:
+              wifi-security.key-mgmt: "sae"
+              ipv6.ip6-privacy: "-1"
+              proxy._: ""
+      networkmanager:
+        uuid: "{}"
+        name: "test2"
+'''.format(UUID, UUID)})


### PR DESCRIPTION
## Description
The NetworkManager backend should not take a shortcut and skip rendering the password, in case of an unknown WPA type, as that might be overwritten by a passthrough value.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad. LP#1972800

