### PR TITLE
manpages: fix long options rendered with an en-dash instead of two dash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,9 @@ install: default
 	pandoc -s --metadata title="Netplan reference" --toc -o $@ $<
 
 doc/netplan.5: doc/manpage-header.md doc/netplan.md doc/manpage-footer.md
-	pandoc -s -o $@ $^
+	pandoc -s -o $@ --from=markdown-smart $^
 
 %.8: %.md
-	pandoc -s -o $@ $^
+	pandoc -s -o $@ --from=markdown-smart $^
 
 .PHONY: clean

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -2,7 +2,7 @@ if pandoc.found()
     custom_target(
         input: ['manpage-header.md', 'netplan.md', 'manpage-footer.md'],
         output: 'netplan.5',
-        command: [pandoc, '-s', '-o', '@OUTPUT@', '@INPUT@'],
+        command: [pandoc, '-s', '-o', '@OUTPUT@', '--from=markdown-smart', '@INPUT@'],
         install: true,
         install_dir: join_paths(get_option('mandir'), 'man5'))
     custom_target(
@@ -17,7 +17,7 @@ if pandoc.found()
         custom_target(
             input: markdown,
             output: manpage,
-            command: [pandoc, '-s', '-o', '@OUTPUT@', '@INPUT@'],
+            command: [pandoc, '-s', '-o', '@OUTPUT@', '--from=markdown-smart', '@INPUT@'],
             install: true,
             install_dir: join_paths(get_option('mandir'), 'man8'))
     endforeach


### PR DESCRIPTION
## Description

Hello,

In generated manpages, the long options look as if they were prefixed with a single-dash "-", as in the following example:

```
 netplan [–debug] generate [–root-dir ROOT_DIR] [–mapping MAPPING]
```

In reality, the double-dash notation was replaced by an en-dash (U+2013) when generating the manpage.

This is caused by the "smart" extension that pandoc enables by default when reading markdown.

Fixed by preventing pandoc from enabling the smart extension when generating manpages. This is only possible when we explicitly specify the input format.

Disabling the smart extension can have a slight impact on how other things like quotes are rendered, but that should not be much of an inconvenience in comparison to the drawbacks that the extension brings.

Thanks,

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented. _(no new or updated key)_
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.