### PR TITLE
Allow setting the regulatory domain (LP: #1951586)

### DIFF
--- a/abi-compat/jammy_0.104.xml
+++ b/abi-compat/jammy_0.104.xml
@@ -348,7 +348,7 @@
       </data-member>
     </class-decl>
     <typedef-decl name='NetplanBackendSettings' type-id='type-id-62' filepath='../src/abi.h' line='150' column='1' id='type-id-61'/>
-    <class-decl name='netplan_net_definition' size-in-bits='8832' is-struct='yes' visibility='default' filepath='../src/abi.h' line='155' column='1' id='type-id-27'>
+    <class-decl name='netplan_net_definition' size-in-bits='8896' is-struct='yes' visibility='default' filepath='../src/abi.h' line='176' column='1' id='type-id-27'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='type' type-id='type-id-13' visibility='default' filepath='../src/abi.h' line='156' column='1'/>
       </data-member>
@@ -558,6 +558,9 @@
       </data-member>
       <data-member access='public' layout-offset-in-bits='8768'>
         <var-decl name='sriov_delay_virtual_functions_rebind' type-id='type-id-39' visibility='default' filepath='../src/abi.h' line='329' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8832'>
+        <var-decl name='regulatory_domain' type-id='type-id-40' visibility='default' filepath='../src/abi.h' line='353' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' visibility='default' filepath='../src/abi.h' line='188' column='1' id='type-id-67'>

--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -957,6 +957,16 @@ wpasupplicant installed if you let the ``networkd`` renderer handle wifi.
      ``rfkill_release`` or ``tcp`` (NetworkManager only). Or the exclusive
      ``default`` flag (the default).
 
+``regulatory-domain`` (scalar) – since **0.105**
+
+:    This can be used to define the radio's regulatory domain, to make use of
+     additional WiFi channels outside the "world domain". Takes an ISO /
+     IEC 3166 country code (like `GB`) or `00` to reset to the "world domain".
+     See [wireless-regdb](https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt) for available values.
+
+     **Requires dependency: iw**, if it is to be used outside the `networkd`
+     (wpa_supplicant) backend.
+
 ## Properties for device type ``bridges:``
 
 ``interfaces`` (sequence of scalars)

--- a/examples/wireless.yaml
+++ b/examples/wireless.yaml
@@ -3,6 +3,7 @@ network:
   renderer: networkd
   wifis:
     wlp2s0b1:
+      regulatory-domain: "GB"
       dhcp4: no
       dhcp6: no
       addresses: [192.168.0.21/24]

--- a/src/abi.h
+++ b/src/abi.h
@@ -357,4 +357,7 @@ struct netplan_net_definition {
 
     /* netplan-feature: infiniband */
     NetplanInfinibandMode ib_mode; /* IPoIB */
+
+    /* netplan-feature: regdom */
+    char* regulatory_domain;
 };

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -790,6 +790,8 @@ _serialize_yaml(
         YAML_SEQUENCE_CLOSE(event, emitter);
     }
 
+    YAML_STRING(def, event, emitter, "regulatory-domain", def->regulatory_domain);
+
     if (def->optional_addresses) {
         YAML_SCALAR_PLAIN(event, emitter, "optional-addresses");
         YAML_SEQUENCE_OPEN(event, emitter);

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -298,6 +298,32 @@ write_link_file(const NetplanNetDefinition* def, const char* rootdir, const char
     umask(orig_umask);
 }
 
+static gboolean
+write_regdom(const NetplanNetDefinition* def, const char* rootdir, GError** error)
+{
+    g_assert(def->regulatory_domain);
+    g_autofree gchar* id_escaped = NULL;
+    g_autofree char* link = g_strjoin(NULL, rootdir ?: "", "/run/systemd/system/network.target.wants/netplan-regdom.service", NULL);
+    g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-regdom.service", NULL);
+
+    GString* s = g_string_new("[Unit]\n");
+    g_string_append(s, "Description=Netplan regulatory-domain configuration\n");
+    g_string_append(s, "After=network.target\n");
+    g_string_append(s, "ConditionFileIsExecutable="SBINDIR"/iw\n");
+    g_string_append(s, "\n[Service]\nType=oneshot\n");
+    g_string_append_printf(s, "ExecStart="SBINDIR"/iw reg set %s\n", def->regulatory_domain);
+
+    g_string_free_to_file(s, rootdir, path, NULL);
+    safe_mkdir_p_dir(link);
+    if (symlink(path, link) < 0 && errno != EEXIST) {
+        // LCOV_EXCL_START
+        g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_FAILED, "failed to create enablement symlink: %m\n");
+        return FALSE;
+        // LCOV_EXCL_STOP
+    }
+    return TRUE;
+}
+
 
 static gboolean
 interval_has_suffix(const char* param) {
@@ -1129,9 +1155,12 @@ netplan_netdef_write_networkd(
     SET_OPT_OUT_PTR(has_been_written, FALSE);
 
     /* We want this for all backends when renaming, as *.link and *.rules files are
-     * evaluated by udev, not networkd itself or NetworkManager. */
+     * evaluated by udev, not networkd itself or NetworkManager. The regulatory
+     * domain applies to all backends, too. */
     write_link_file(def, rootdir, path_base);
     write_rules_file(def, rootdir);
+    if (def->regulatory_domain)
+        write_regdom(def, rootdir, NULL); /* overwrites global regdom */
 
     if (def->backend != NETPLAN_BACKEND_NETWORKD) {
         g_debug("networkd: definition %s is not for us (backend %i)", def->id, def->backend);
@@ -1189,6 +1218,8 @@ netplan_networkd_cleanup(const char* rootdir)
     unlink_glob(rootdir, "/run/systemd/system/systemd-networkd.service.wants/netplan-wpa-*.service");
     unlink_glob(rootdir, "/run/systemd/system/netplan-wpa-*.service");
     unlink_glob(rootdir, "/run/udev/rules.d/99-netplan-*");
+    unlink_glob(rootdir, "/run/systemd/system/network.target.wants/netplan-regdom.service");
+    unlink_glob(rootdir, "/run/systemd/system/netplan-regdom.service");
     /* Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
      * upgraded system, we need to make sure to clean those up. */
     unlink_glob(rootdir, "/run/systemd/system/systemd-networkd.service.wants/netplan-wpa@*.service");

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1032,6 +1032,10 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir, GError** er
             if (!append_wifi_wowlan_flags(def->wowlan, s, error))
                 return FALSE;
         }
+        /* available as of wpa_supplicant version 0.6.7 */
+        if (def->regulatory_domain) {
+            g_string_append_printf(s, "country=%s\n", def->regulatory_domain);
+        }
         NetplanWifiAccessPoint* ap;
         g_hash_table_iter_init(&iter, def->access_points);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer) &ap)) {

--- a/src/parse.c
+++ b/src/parse.c
@@ -2518,6 +2518,7 @@ static const mapping_entry_handler wifi_def_handlers[] = {
     PHYSICAL_LINK_HANDLERS,
     {"access-points", YAML_MAPPING_NODE, {.map={.custom=handle_wifi_access_points}}},
     {"auth", YAML_MAPPING_NODE, {.map={.custom=handle_auth}}},
+    {"regulatory-domain", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(regulatory_domain)},
     {NULL}
 };
 

--- a/src/types.c
+++ b/src/types.c
@@ -239,6 +239,7 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
 
     FREE_AND_NULLIFY(netdef->gateway4);
     FREE_AND_NULLIFY(netdef->gateway6);
+    FREE_AND_NULLIFY(netdef->regulatory_domain);
     free_garray_with_destructor(&netdef->ip4_nameservers, g_free);
     free_garray_with_destructor(&netdef->ip6_nameservers, g_free);
     free_garray_with_destructor(&netdef->search_domains, g_free);

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -29,6 +29,7 @@ class TestNetworkd(TestBase):
   version: 2
   wifis:
     wl0:
+      regulatory-domain: "DE"
       access-points:
         "Joe's Home":
           password: "s0s3kr1t"
@@ -129,6 +130,7 @@ network={
   psk="s0s3kr1t"
 }
 ''', new_config)
+            self.assertIn('country=DE\n', new_config)
             self.assertEqual(stat.S_IMODE(os.fstat(f.fileno()).st_mode), 0o600)
         self.assertTrue(os.path.isfile(os.path.join(
             self.workdir.name, 'run/systemd/system/netplan-wpa-wl0.service')))


### PR DESCRIPTION
## Description
Allow setting the regulatory domain, using a new `regulatory-domain` setting.
It is implemented in two ways:
* `country=XX` setting in `wpa_supplicant.conf` (networkd/wpasupplicant only)
* oneshot `/run/systemd/system/netplan-regdom.service` calling `iw reg set XX` (works globally)

Example:
```
network:
  version: 2
  renderer: networkd
  wifis:
    wlp2s0b1:
      regulatory-domain: "GB"
      dhcp4: no
      dhcp6: no
      addresses: [192.168.0.21/24]
      access-points:
        "MYSSID":
          password: 12345678
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1951586

