### PR TITLE
cli:ip:leases: search for NM's internal DHCP client and dhclient leases (LP: #1979674)

### DIFF
--- a/netplan/cli/commands/ip.py
+++ b/netplan/cli/commands/ip.py
@@ -122,10 +122,15 @@ class NetplanIpLeases(utils.NetplanCommand):
                 # we'll rely on open() throwing an error.
                 # This might happen if networkd doesn't use DHCP for the interface,
                 # for instance.
-                with open(os.path.join('/',
-                                       os.path.abspath(self.root_dir) if self.root_dir else "",
-                                       lease_pattern.format(interface=self.interface,
-                                                            lease_id=lease_id))) as f:
+                path = os.path.join('/',
+                                    os.path.abspath(self.root_dir) if self.root_dir else "",
+                                    lease_pattern.format(interface=self.interface,
+                                                         lease_id=lease_id))
+                # Fallback to 'dhclient' if no lease of NetworkManager's
+                # internal DHCP client is found
+                if not os.path.isfile(path):
+                    path = path.replace('NetworkManager/internal-', 'NetworkManager/dhclient-')
+                with open(path) as f:
                     for line in f.readlines():
                         print(line.rstrip())
             except Exception as e:

--- a/netplan/cli/commands/ip.py
+++ b/netplan/cli/commands/ip.py
@@ -31,7 +31,7 @@ lease_path = {
         'method': 'ifindex',
     },
     'NetworkManager': {
-        'pattern': 'var/lib/NetworkManager/dhclient-{lease_id}-{interface}.lease',
+        'pattern': 'var/lib/NetworkManager/internal-{lease_id}-{interface}.lease',
         'method': 'nm_connection',
     },
 }

--- a/netplan/cli/commands/ip.py
+++ b/netplan/cli/commands/ip.py
@@ -90,21 +90,19 @@ class NetplanIpLeases(utils.NetplanCommand):
                     logging.debug('Cannot read file %s: %s', ifindex_f, str(e))
                     raise
 
-            def lease_method_nm_connection():  # pragma: nocover (covered in autopkgtest)
+            def lease_method_nm_connection():
                 # FIXME: handle older versions of NM where 'nmcli dev show' doesn't exist
                 try:
-                    nmcli_dev_out = subprocess.Popen(['nmcli', 'dev', 'show', self.interface],
-                                                     env=dict(os.environ, LC_ALL='C'),
-                                                     stdout=subprocess.PIPE)
-                    for line in nmcli_dev_out.stdout:
-                        line = line.decode('utf-8')
+                    nmcli_dev_out = subprocess.check_output(['nmcli', 'dev', 'show', self.interface],
+                                                            env=dict(LC_ALL='C', PATH=os.environ.get('PATH', os.defpath)),
+                                                            universal_newlines=True)
+                    for line in nmcli_dev_out.splitlines():
                         if 'GENERAL.CONNECTION' in line:
                             conn_id = line.split(':')[1].rstrip().strip()
-                            nmcli_con_out = subprocess.Popen(['nmcli', 'con', 'show', 'id', conn_id],
-                                                             env=dict(os.environ, LC_ALL='C'),
-                                                             stdout=subprocess.PIPE)
-                            for line in nmcli_con_out.stdout:
-                                line = line.decode('utf-8')
+                            nmcli_con_out = subprocess.check_output(['nmcli', 'con', 'show', 'id', conn_id],
+                                                                    env=dict(LC_ALL='C', PATH=os.environ.get('PATH', os.defpath)),
+                                                                    universal_newlines=True)
+                            for line in nmcli_con_out.splitlines():
                                 if 'connection.uuid' in line:
                                     return line.split(':')[1].rstrip().strip()
                 except Exception as e:

--- a/netplan/cli/commands/ip.py
+++ b/netplan/cli/commands/ip.py
@@ -94,14 +94,14 @@ class NetplanIpLeases(utils.NetplanCommand):
                 # FIXME: handle older versions of NM where 'nmcli dev show' doesn't exist
                 try:
                     nmcli_dev_out = subprocess.Popen(['nmcli', 'dev', 'show', self.interface],
-                                                     env={'LC_ALL': 'C'},
+                                                     env=dict(os.environ, LC_ALL='C'),
                                                      stdout=subprocess.PIPE)
                     for line in nmcli_dev_out.stdout:
                         line = line.decode('utf-8')
                         if 'GENERAL.CONNECTION' in line:
                             conn_id = line.split(':')[1].rstrip().strip()
                             nmcli_con_out = subprocess.Popen(['nmcli', 'con', 'show', 'id', conn_id],
-                                                             env={'LC_ALL': 'C'},
+                                                             env=dict(os.environ, LC_ALL='C'),
                                                              stdout=subprocess.PIPE)
                             for line in nmcli_con_out.stdout:
                                 line = line.decode('utf-8')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,11 +71,11 @@ printf '\\0' >> %(log)s
 
     def set_output(self, output):
         with open(self.path, "a") as fp:
-            fp.write("cat << EOF\n%s\nEOF" % output)
+            fp.write("\ncat << EOF\n%s\nEOF" % output)
 
     def touch(self, stamp_path):
         with open(self.path, "a") as fp:
-            fp.write("touch %s\n" % stamp_path)
+            fp.write("\ntouch %s\n" % stamp_path)
 
     def set_timeout(self, timeout_dsec=10):
         with open(self.path, "a") as fp:
@@ -95,7 +95,7 @@ fi
 
     def set_returncode(self, returncode):
         with open(self.path, "a") as fp:
-            fp.write("exit %d" % returncode)
+            fp.write("\nexit %d" % returncode)
 
 
 def call_cli(args):


### PR DESCRIPTION
## Description
Check for NetworkManager leases in `var/lib/NetworkManager/internal-{UUID}-{INTERFACE}.lease` and fallback to `var/lib/NetworkManager/dhclient-{UUID}-{INTERFACE}.lease` if that does not exist. Dhclient is deprecated, but might still be used in some legacy setups.

Also, use some mocking (custom `MockCmd` class, as used elsewhere in our code) to actually run some unit tests on this code and increase the coverage.

The whole code in `ip.py` is pretty old and in bad shape; it should be refactored, but I don't have the time for that right now, just wanted to fix LP#1979674 as a first step.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.: LP#1979674

