### PR TITLE
Add support for VRF devices (LP: #1773522)

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo sed -i '/deb-src/s/^# //' /etc/apt/sources.list
           sudo apt update
-          sudo apt install autopkgtest ubuntu-dev-tools devscripts openvswitch-switch linux-modules-extra-azure
+          sudo apt install autopkgtest ubuntu-dev-tools devscripts openvswitch-switch linux-modules-extra-$(uname -r)
           sudo snap install lxd
           sudo lxd init --auto --storage-backend=dir
       # work around LP: #1878225 as fallback

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -522,6 +522,15 @@ This is a complex example which shows most available features
       # if specified, can only realistically have that value, as networkd cannot
       # render wifi/3G.
       renderer: NetworkManager
+      vrfs:
+        mgmt-vrf:
+          table: 10
+          interfaces:
+            - id1
+          routes:
+            - to: default
+              via: 192.168.24.254
+              metric: 100
       ethernets:
         # opaque ID for physical interfaces, only referred to by other stanzas
         id0:
@@ -557,6 +566,13 @@ This is a complex example which shows most available features
               priority: 50
           # only networkd can render on-link routes and routing policies
           renderer: networkd
+        id1:
+          match:
+            macaddress: 00:11:22:33:44:56
+          wakeonlan: true
+          dhcp4: true
+          addresses:
+            - 192.168.24.2/24
         lom:
           match:
             driver: ixgbe

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -75,7 +75,7 @@ Physical devices
 
 Virtual devices
 
-> (Examples: veth, bridge, bond) These are fully under the control of the
+> (Examples: veth, bridge, bond, vrf) These are fully under the control of the
 > config file(s) and the network stack. I. e. these devices are being created
 > instead of matched. Thus `match:` and `set-name:` are not applicable for
 > these, and the ID field is the name of the created virtual device.
@@ -1536,6 +1536,46 @@ vlans:
     id: 2
     link: eno1
     addresses: [...]
+```
+
+## Properties for device type `vrfs:`
+
+- **table** (scalar) – since **0.105**
+
+  > The numeric routing table identifier. This setting is compulsory.
+
+- **interfaces** (sequence of scalars) – since **0.105**
+
+  > All devices matching this ID list will be added to the vrf. This may
+  > be an empty list, in which case the vrf will be brought online with
+  > no member interfaces.
+
+- **routes** (sequence of mappings) – since **0.105**
+
+  > Configure static routing for the device; see the `Routing` section.
+  > The `table` value is implicitly set to the VRF's `table`.
+
+- **routing-policy** (sequence of mappings) – since **0.105**
+
+  > Configure policy routing for the device; see the ``Routing`` section.
+  > The `table` value is implicitly set to the VRF's `table`.
+
+Example:
+
+```yaml
+vrfs:
+  vrf20:
+    table: 20
+    interfaces: [ br0 ]
+    routes:
+      - to: default
+        via: 10.10.10.3
+    routing-policy:
+      - from: 10.10.10.42
+  [...]
+  bridges:
+    br0:
+      interfaces: []
 ```
 
 ## Properties for device type `nm-devices:`

--- a/examples/vrf.yaml
+++ b/examples/vrf.yaml
@@ -1,0 +1,18 @@
+network:
+  renderer: networkd
+  vrfs:
+    vrf1005:
+      table: 1005
+      interfaces:
+        - br1
+        - br1005
+      routes:
+        - to: default
+          via: 10.10.10.4
+      routing-policy:
+        - from: 10.10.10.42
+  bridges:
+    br1:
+      interfaces: []
+    br1005:
+      interfaces: []

--- a/include/parse.h
+++ b/include/parse.h
@@ -36,6 +36,7 @@ typedef enum {
     NETPLAN_DEF_TYPE_VLAN,
     NETPLAN_DEF_TYPE_TUNNEL,
     NETPLAN_DEF_TYPE_PORT,
+    NETPLAN_DEF_TYPE_VRF,
     /* Type fallback/passthrough */
     NETPLAN_DEF_TYPE_NM,
     NETPLAN_DEF_TYPE_MAX_

--- a/netplan/configmanager.py
+++ b/netplan/configmanager.py
@@ -60,6 +60,7 @@ class ConfigManager(object):
         interfaces.update(self.np_state.bonds)
         interfaces.update(self.np_state.tunnels)
         interfaces.update(self.np_state.vlans)
+        interfaces.update(self.np_state.vrfs)
         return interfaces
 
     def parse(self, extra_config=None):

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -227,6 +227,10 @@ class State:
         return dict((nd.id, nd) for nd in _NetdefIterator(self, "tunnels"))
 
     @property
+    def vrfs(self):
+        return dict((nd.id, nd) for nd in _NetdefIterator(self, "vrfs"))
+
+    @property
     def ovs_ports(self):
         return dict((nd.id, nd) for nd in _NetdefIterator(self, "_ovs-ports"))
 

--- a/src/abi.h
+++ b/src/abi.h
@@ -360,4 +360,9 @@ struct netplan_net_definition {
 
     /* netplan-feature: regdom */
     char* regulatory_domain;
+
+    /* vrf */
+    /* netplan-feature: vrf */
+    NetplanNetDefinition* vrf_link;
+    guint vrf_table;
 };

--- a/src/names.c
+++ b/src/names.c
@@ -47,6 +47,7 @@ netplan_def_type_to_str[NETPLAN_DEF_TYPE_MAX_] = {
     [NETPLAN_DEF_TYPE_BRIDGE] = "bridges",
     [NETPLAN_DEF_TYPE_BOND] = "bonds",
     [NETPLAN_DEF_TYPE_VLAN] = "vlans",
+    [NETPLAN_DEF_TYPE_VRF] = "vrfs",
     [NETPLAN_DEF_TYPE_TUNNEL] = "tunnels",
     [NETPLAN_DEF_TYPE_PORT] = "_ovs-ports",
     [NETPLAN_DEF_TYPE_NM] = "nm-devices",

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -453,6 +453,10 @@ write_netdev_file(const NetplanNetDefinition* def, const char* rootdir, const ch
             g_string_append_printf(s, "Kind=vlan\n\n[VLAN]\nId=%u\n", def->vlan_id);
             break;
 
+        case NETPLAN_DEF_TYPE_VRF:
+            g_string_append_printf(s, "Kind=vrf\n\n[VRF]\nTable=%u\n", def->vrf_table);
+            break;
+
         case NETPLAN_DEF_TYPE_TUNNEL:
             switch(def->tunnel.mode) {
                 case NETPLAN_TUNNEL_MODE_GRE:
@@ -778,6 +782,10 @@ netplan_netdef_write_network_file(
                 g_string_append_printf(network, "VLAN=%s\n", nd->id);
         }
     }
+
+    /* VRF linkage */
+    if (def->vrf_link)
+        g_string_append_printf(network, "VRF=%s\n", def->vrf_link->id);
 
     if (def->routes != NULL) {
         for (unsigned i = 0; i < def->routes->len; ++i) {

--- a/src/types.c
+++ b/src/types.c
@@ -259,6 +259,9 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     netdef->vlan_link = NULL;
     netdef->has_vlans = FALSE;
 
+    netdef->vrf_link = NULL;
+    netdef->vrf_table = G_MAXUINT;
+
     FREE_AND_NULLIFY(netdef->set_mac);
     netdef->mtubytes = 0;
     netdef->ipv6_mtubytes = 0;

--- a/src/validation.h
+++ b/src/validation.h
@@ -41,3 +41,6 @@ validate_sriov_rules(const NetplanParser* npp, NetplanNetDefinition* nd, GError*
 
 gboolean
 validate_default_route_consistency(const NetplanParser* npp, GHashTable* netdefs, GError** error);
+
+gboolean
+adopt_and_validate_vrf_routes(const NetplanParser* npp, GHashTable* netdefs, GError** error);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -80,6 +80,7 @@ NM_WG = '[connection]\nid=netplan-wg0\ntype=wireguard\ninterface-name=wg0\n\n[wi
 2001:de:ad:be:ef:ca:fe:1/128\nip6-privacy=0\n'
 ND_WG = '[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey%s\nListenPort=%s\n%s\n'
 ND_VLAN = '[NetDev]\nName=%s\nKind=vlan\n\n[VLAN]\nId=%d\n'
+ND_VRF = '[NetDev]\nName=%s\nKind=vrf\n\n[VRF]\nTable=%d\n'
 SD_WPA = '''[Unit]
 Description=WPA supplicant for netplan %(iface)s
 DefaultDependencies=no

--- a/tests/generator/test_vrfs.py
+++ b/tests/generator/test_vrfs.py
@@ -1,0 +1,105 @@
+#
+# Tests for bridge devices config generated via netplan
+#
+# Copyright (C) 2018 Canonical, Ltd.
+# Copyright (C) 2022 Datto, Inc.
+# Author: Anthony Timmins <atimmins@datto.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from .base import TestBase
+
+
+class TestNetplanYAMLv2(TestBase):
+    '''No asserts are needed.
+
+    The generate() method implicitly checks the (re-)generated YAML.
+    '''
+
+    def test_vrf_table(self):
+        self.generate('''network:
+  version: 2
+  vrfs:
+    vrf1005:
+      table: 1005''')
+
+    def test_vrf_routes(self):
+        self.generate('''network:
+  version: 2
+  vrfs:
+    vrf1005:
+      table: 1005
+      routes:
+      - to: default
+        via: 1.2.3.4
+      routing-policy:
+      - from: 1.2.3.4''')
+
+
+class TestConfigErrors(TestBase):
+
+    def test_vrf_missing_table(self):
+        err = self.generate('''network:
+  version: 2
+  vrfs:
+    vrf1005: {}''', expect_fail=True)
+
+        self.assertIn("vrf1005: missing 'table' property", err)
+
+    def test_vrf_already_assigned(self):
+        err = self.generate('''network:
+  version: 2
+  vrfs:
+    vrf0:
+      table: 42
+      interfaces: [eno1]
+    vrf1:
+      table: 43
+      interfaces: [eno1]
+  ethernets:
+    eno1: {}''', expect_fail=True)
+        self.assertIn("vrf1: interface 'eno1' is already assigned to vrf vrf0", err)
+
+    def test_vrf_routes_table_mismatch(self):
+        err = self.generate('''network:
+  version: 2
+  vrfs:
+    vrf0:
+      table: 42
+      routes:
+      - table: 42 # pass
+        to: default
+        via: 1.2.3.4
+      - table: 43 # mismatch
+        to: 99.88.77.66
+        via: 2.3.4.5
+''', expect_fail=True)
+        self.assertIn("vrf0: VRF routes table mismatch (42 != 43)", err)
+
+    def test_vrf_policy_table_mismatch(self):
+        err = self.generate('''network:
+  version: 2
+  vrfs:
+    vrf0:
+      table: 45
+      routes:
+      - to: default
+        via: 3.4.5.6
+      routing-policy:
+      - table: 45 # pass
+        from: 1.2.3.4
+      - table: 46 # mismatch
+        from: 2.3.4.5
+''', expect_fail=True)
+        self.assertIn("vrf0: VRF routing-policy table mismatch (45 != 46)", err)

--- a/tests/test_configmanager.py
+++ b/tests/test_configmanager.py
@@ -113,6 +113,15 @@ class TestConfigManager(unittest.TestCase):
       interfaces: [ ethbr2 ]
       parameters:
         stp: on
+  vrfs:
+    vrf1005:
+      table: 1005
+      interfaces:
+        - br3
+        - br4
+    vrf1006:
+      table: 1006
+      interfaces: []
   bonds:
     bond5:
       interfaces: [ ethbond1 ]
@@ -163,6 +172,7 @@ class TestConfigManager(unittest.TestCase):
         self.assertEqual('networkd', state.backend)
         self.assertIn('fallback',    state.nm_devices)
 
+        self.assertIn('vrf1005', self.configmanager.virtual_interfaces)
         self.assertIn('vlan2',   self.configmanager.virtual_interfaces)
         self.assertIn('br3',     self.configmanager.virtual_interfaces)
         self.assertIn('br4',     self.configmanager.virtual_interfaces)


### PR DESCRIPTION
## Description
Adding support for Virtual Routing and Forwarding devices using the sd-networkd and NetworkManager backends.
Any VRF device is linked to a (new) routing table, specified via the `table` stanza and can define its child interfaces via `interfaces: [...]`. If any `routes:` or `routing-policy:` settings are given, those are implicitly connected to the VRF's routing table.

It builds upon #272 (squashed & rebased), extracted VRF bits.

Example:
```
network:
  version: 2
  [...]
  vrfs:
    vrf1005:
      table: 1005
      interfaces:
        - br1
        - br1005
      routes:  # uses "table: 1005" implicitly
        - to: default
          via: 10.10.10.4
      routing-policy:
        - from: 10.10.10.42
  bridges:
    br1:
      interfaces: [...]
    br1005:
      interfaces: [...]
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. [LP#1773522](https://pad.lv/1773522)

