### PR TITLE
cli: fix crash on LibNetplanException

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -32,6 +32,7 @@ import netplan.cli.utils as utils
 from netplan.configmanager import ConfigManager, ConfigurationError
 from netplan.cli.sriov import apply_sriov_config
 from netplan.cli.ovs import apply_ovs_cleanup
+from netplan.libnetplan import LibNetplanException
 
 
 OVS_CLEANUP_SERVICE = 'netplan-ovs-cleanup.service'
@@ -388,7 +389,7 @@ class NetplanApply(utils.NetplanCommand):
     def process_sriov_config(config_manager, exit_on_error=True):  # pragma: nocover (covered in autopkgtest)
         try:
             apply_sriov_config(config_manager)
-        except (ConfigurationError, RuntimeError) as e:
+        except (ConfigurationError, RuntimeError, LibNetplanException) as e:
             logging.error(str(e))
             if exit_on_error:
                 sys.exit(1)

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -32,7 +32,6 @@ import netplan.cli.utils as utils
 from netplan.configmanager import ConfigManager, ConfigurationError
 from netplan.cli.sriov import apply_sriov_config
 from netplan.cli.ovs import apply_ovs_cleanup
-from netplan.libnetplan import LibNetplanException
 
 
 OVS_CLEANUP_SERVICE = 'netplan-ovs-cleanup.service'
@@ -389,7 +388,7 @@ class NetplanApply(utils.NetplanCommand):
     def process_sriov_config(config_manager, exit_on_error=True):  # pragma: nocover (covered in autopkgtest)
         try:
             apply_sriov_config(config_manager)
-        except (ConfigurationError, RuntimeError, LibNetplanException) as e:
+        except utils.config_errors as e:
             logging.error(str(e))
             if exit_on_error:
                 sys.exit(1)

--- a/netplan/cli/commands/try_command.py
+++ b/netplan/cli/commands/try_command.py
@@ -25,7 +25,7 @@ import signal
 import sys
 import tempfile
 
-from netplan.configmanager import ConfigManager, ConfigurationError
+from netplan.configmanager import ConfigManager
 import netplan.cli.utils as utils
 from netplan.cli.commands.apply import NetplanApply
 import netplan.terminal
@@ -169,7 +169,7 @@ class NetplanTry(utils.NetplanCommand):
         np_state = None
         try:
             np_state = self.config_manager.parse(extra_config=extra_config)
-        except (libnetplan.LibNetplanException, ConfigurationError) as e:
+        except utils.config_errors as e:
             logging.error(e)
             sys.exit(os.EX_CONFIG)
 

--- a/netplan/cli/commands/try_command.py
+++ b/netplan/cli/commands/try_command.py
@@ -164,9 +164,9 @@ class NetplanTry(utils.NetplanCommand):
         '''
 
         extra_config = []
-        if self.config_file:  # pragma: nocover
+        if self.config_file:
             extra_config.append(self.config_file)
-        np_state = libnetplan.State()
+        np_state = None
         try:
             np_state = self.config_manager.parse(extra_config=extra_config)
         except (libnetplan.LibNetplanException, ConfigurationError) as e:

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -25,9 +25,14 @@ import fnmatch
 import re
 
 import netplan.libnetplan as np
+from netplan.configmanager import ConfigurationError
+from netplan.libnetplan import LibNetplanException
+
 
 NM_SERVICE_NAME = 'NetworkManager.service'
 NM_SNAP_SERVICE_NAME = 'snap.network-manager.networkmanager.service'
+
+config_errors = (ConfigurationError, LibNetplanException, RuntimeError)
 
 
 def get_generator_path():

--- a/tests/test_cli_units.py
+++ b/tests/test_cli_units.py
@@ -115,6 +115,18 @@ class TestCLI(unittest.TestCase):
         cmd = NetplanTry()
         self.assertTrue(cmd.is_revertable())
 
+    def test_netplan_try_is_revertable_fail(self):
+        extra_config = os.path.join(self.tmproot, 'extra.yaml')
+        with open(extra_config, 'w') as f:
+            f.write('''network:
+  bridges:
+    br54:
+      INVALID: kaputt
+''')
+        cmd = NetplanTry()
+        cmd.config_file = extra_config
+        self.assertRaises(SystemExit, cmd.is_revertable)
+
     def test_netplan_try_is_not_revertable(self):
         with open(os.path.join(self.tmproot, 'etc/netplan/test.yaml'), 'w') as f:
             f.write('''network:


### PR DESCRIPTION
## Description
Catch exception on config error (`LibNetplanException` from the libnetplan YAML parser) to exit gracefully on error, without applying any configuration. Display the parsing error on stderr.

As observed via https://errors.ubuntu.com/problem/2f11b72a6028059267c77dc94cfd3c4028cf58ac

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

