### PR TITLE
Add support for VXLAN tunnels (LP: #1764716)

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -532,6 +532,10 @@ This is a complex example which shows most available features
               via: 192.168.24.254
               metric: 100
       ethernets:
+        lo:
+          addresses:
+            - 172.16.20.20/32
+          link-local: []
         # opaque ID for physical interfaces, only referred to by other stanzas
         id0:
           match:
@@ -609,4 +613,18 @@ This is a complex example which shows most available features
           # IDs of the components; switchports expands into multiple interfaces
           interfaces: [wlp1s0, switchports]
           dhcp4: true
+        br20:
+          interfaces: [vxlan20]
+      tunnels:
+        vxlan20:
+          mode: vxlan
+          link: lo
+          id: 20
+          mtu: 8950
+          accept-ra: no
+          neigh-suppress: true
+          link-local: []
+          mac-learning: false
+          port: 4789
+          local: 172.16.20.20
 ```

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -570,6 +570,11 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
 
   > Configure policy routing for the device; see the `Routing` section below.
 
+- **neigh-suppress** (scalar) – since **0.105**
+
+  > Takes a boolean. Configures whether ARP and ND neighbor suppression is
+  > enabled for this port. When unset, the kernel's default will be used.
+
 ## DHCP Overrides
 Several DHCP behavior overrides are available. Most currently only have any
 effect when using the `networkd` backend, with the exception of `use-routes`
@@ -1343,22 +1348,27 @@ more general information about tunnels.
 - **mode** (scalar)
 
   > Defines the tunnel mode. Valid options are `sit`, `gre`, `ip6gre`,
-  > `ipip`, `ipip6`, `ip6ip6`, `vti`, `vti6` and `wireguard`.
+  > `ipip`, `ipip6`, `ip6ip6`, `vti`, `vti6`, `wireguard` and `vxlan`.
   > Additionally, the `networkd` backend also supports `gretap` and
   > `ip6gretap` modes.
   > In addition, the `NetworkManager` backend supports `isatap` tunnels.
 
 - **local** (scalar)
 
-  > Defines the address of the local endpoint of the tunnel.
+  > Defines the address of the local endpoint of the tunnel. (For VXLAN) This
+  > should match one of the parent's IP addresses or make use of the networkd
+  > special values.
+
 
 - **remote** (scalar)
 
-  > Defines the address of the remote endpoint of the tunnel.
+  > Defines the address of the remote endpoint of the tunnel or multicast group
+  > IP address for VXLAN.
 
 - **ttl** (scalar) – since **0.103**
 
-  > Defines the TTL of the tunnel.
+  > Defines the Time To Live (TTL) of the tunnel.
+  > Takes a number in the range `1..255`.
 
 - **key**  (scalar or mapping)
 
@@ -1510,6 +1520,86 @@ WireGuard specific keys:
       > A base64-encoded preshared key. Optional for WireGuard peers.
       > When the `systemd-networkd` backend (v242+) is used, this can
       > also be an absolute path to a file containing the preshared key.
+
+VXLAN specific keys:
+
+- **id** (scalar) – since **0.105**
+
+  > The VXLAN Network Identifier (VNI or VXLAN Segment ID).
+  > Takes a number in the range `1..16777215`.
+
+- **link** (scalar) – since **0.105**
+
+  > netplan ID of the parent device definition to which this VXLAN gets
+  > connected.
+
+- **type-of-service** (scalar) – since **0.105**
+
+  > The Type Of Service byte value for a vxlan interface.
+
+- **mac-learning** (scalar) – since **0.105**
+
+  > Takes a boolean. When `true`, enables dynamic MAC learning to discover
+  > remote MAC addresses.
+
+- **ageing**, **aging** (scalar) – since **0.105**
+
+  > The lifetime of Forwarding Database entry learnt by the kernel, in
+  > seconds.
+
+- **limit** (scalar) – since **0.105**
+
+  > Configures maximum number of FDB entries.
+
+- **arp-proxy** (scalar) – since **0.105**
+
+  > Takes a boolean. When `true`, bridge-connected VXLAN tunnel endpoint
+  > answers ARP requests from the local bridge on behalf of remote Distributed
+  > Overlay Virtual Ethernet (DOVE) clients. Defaults to `false`.
+
+- **notifications** (sequence of scalars) – since **0.105**
+
+  > Takes the flags `l2-miss` and `l3-miss` to enable netlink LLADDR and/or
+  > netlink IP address miss notifications.
+
+- **short-circuit** (scalar) – since **0.105**
+
+  > Takes a boolean. When `true`, route short circuiting is turned on.
+
+- **checksums** (sequence of scalars) – since **0.105**
+
+  > Takes the flags `udp`, `zero-udp6-tx`, `zero-udp6-rx`, `remote-tx` and
+  > `remote-rx` to enable transmitting UDP checksums in VXLAN/IPv4,
+  > send/receive zero checksums in VXLAN/IPv6 and enable sending/receiving
+  > checksum offloading in VXLAN.
+
+- **extensions** (sequence of scalars) – since **0.105**
+
+  > Takes the flags `group-policy` and `generic-protocol` to enable the "Group
+  > Policy" and/or "Generic Protocol" VXLAN extensions.
+
+- **port** (scalar) – since **0.105**
+
+  > Configures the default destination UDP port. If the destination port is
+  > not specified then Linux kernel default will be used. Set to `4789` to get
+  > the IANA assigned value.
+
+- **port-range** (sequence of scalars) – since **0.105**
+
+  > Configures the source port range for the VXLAN. The kernel assigns the
+  > source UDP port based on the flow to help the receiver to do load
+  > balancing. When this option is not set, the normal range of local UDP
+  > ports is used. Uses the form `[LOWER, UPPER]`.
+
+- **flow-label** (scalar) – since **0.105**
+
+  > Specifies the flow label to use in outgoing packets. The valid range
+  > is `0-1048575`.
+
+- **do-not-fragment** (scalar) – since **0.105**
+
+  > Allows setting the IPv4 Do not Fragment (DF) bit in outgoing packets.
+  > Takes a boolean value. When unset, the kernel's default will be used.
 
 ## Properties for device type `vlans:`
 

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1093,7 +1093,7 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
   > be qualified using a time suffix (such as "s" for seconds, "ms" for
   > milliseconds) to allow for more control over its behavior.
 
-  - **ageing-time** (scalar)
+  - **ageing-time**, **aging-time** (scalar)
 
     > Set the period of time to keep a MAC address in the forwarding
     > database after a packet is received. This maps to the AgeingTimeSec=

--- a/examples/vxlan.yaml
+++ b/examples/vxlan.yaml
@@ -1,0 +1,40 @@
+network:
+  renderer: networkd
+  ethernets:
+    lo:
+      addresses:
+        - 192.168.10.10/32
+  vrfs:
+    vrf1005:
+      table: 1005
+      interfaces:
+        - br1
+        - br1005
+  bridges:
+    br1:
+      interfaces:
+        - vxlan1
+    br1005:
+      interfaces:
+        - vxlan1005
+  tunnels:
+    vxlan1005:
+      mode: vxlan
+      id: 1005
+      link: lo
+      mtu: 8950
+      accept-ra: no
+      neigh-suppress: true
+      mac-learning: false
+      port: 4789
+      local: 192.168.10.10
+    vxlan1:
+      mode: vxlan
+      id: 1
+      link: lo
+      mtu: 8950
+      accept-ra: no
+      neigh-suppress: true
+      mac-learning: false
+      port: 4789
+      local: 192.168.10.10

--- a/src/abi.h
+++ b/src/abi.h
@@ -373,8 +373,6 @@ struct netplan_net_definition {
     NetplanNetDefinition* vrf_link;
     guint vrf_table;
 
-    /* TODO: `link` can also be used for vrf/vlan/sriov/... in the future */
-    NetplanNetDefinition* link;
     NetplanTristate bridge_neigh_suppress;
 
     /* vxlan */

--- a/src/abi.h
+++ b/src/abi.h
@@ -20,6 +20,8 @@
 #include <parse.h>
 #include <uuid.h>
 
+typedef int NetplanFlags;
+
 /* Those types are part of our ABI as they have been exposed in older versions */
 
 typedef enum {

--- a/src/abi.h
+++ b/src/abi.h
@@ -91,6 +91,7 @@ typedef enum {
     NETPLAN_TUNNEL_MODE_IPIP6       = 7,
     NETPLAN_TUNNEL_MODE_IP6GRE      = 8,
     NETPLAN_TUNNEL_MODE_VTI6        = 9,
+    NETPLAN_TUNNEL_MODE_VXLAN       = 10,
 
     /* systemd-only, apparently? */
     NETPLAN_TUNNEL_MODE_GRETAP      = 101,
@@ -179,6 +180,8 @@ typedef enum
     NETPLAN_TRISTATE_FALSE,      /*  0 */
     NETPLAN_TRISTATE_TRUE,       /*  1 */
 } NetplanTristate;
+
+typedef struct netplan_vxlan NetplanVxlan;
 
 /* Keep 'struct netplan_net_definition' in a separate header file, to allow for
  * abidiff to consider it "public API" (although it isn't) and notify us about
@@ -369,4 +372,13 @@ struct netplan_net_definition {
     /* netplan-feature: vrf */
     NetplanNetDefinition* vrf_link;
     guint vrf_table;
+
+    /* TODO: `link` can also be used for vrf/vlan/sriov/... in the future */
+    NetplanNetDefinition* link;
+    NetplanTristate bridge_neigh_suppress;
+
+    /* vxlan */
+    /* netplan-feature: vxlan */
+    gboolean has_vxlans;
+    NetplanVxlan* vxlan;
 };

--- a/src/abi.h
+++ b/src/abi.h
@@ -53,6 +53,8 @@ typedef enum {
     NETPLAN_IB_MODE_KERNEL,
     NETPLAN_IB_MODE_DATAGRAM,
     NETPLAN_IB_MODE_CONNECTED,
+
+    NETPLAN_IB_MODE_MAX_,
 } NetplanInfinibandMode;
 
 typedef enum {

--- a/src/names.c
+++ b/src/names.c
@@ -105,6 +105,14 @@ netplan_infiniband_mode_to_str[NETPLAN_IB_MODE_MAX_] = {
     return (val < sizeof( netplan_ ## _radical ## _to_str )) ?  netplan_ ## _radical ## _to_str [val] : NULL; \
 }
 
+/* @num_flags needs to account for the 0x0 value (index 0), which doesn't
+ * represent any flag, but still exists. So subtract 1 from the array length. */
+#define NAME_FUNCTION_FLAGS(_radical) const char *netplan_ ## _radical ## _name( NetplanFlags val) \
+{ \
+    size_t num_flags = sizeof(netplan_ ## _radical ## _to_str) / sizeof(char *) - 1; \
+    return (val <= 1 << (num_flags - 1)) ?  netplan_ ## _radical ## _to_str [__builtin_ffs(val)] : NULL; \
+}
+
 NAME_FUNCTION(backend, NetplanBackend);
 NAME_FUNCTION(def_type, NetplanDefType);
 NAME_FUNCTION(auth_key_management_type, NetplanAuthKeyManagementType);
@@ -113,6 +121,9 @@ NAME_FUNCTION(tunnel_mode, NetplanTunnelMode);
 NAME_FUNCTION(addr_gen_mode, NetplanAddrGenMode);
 NAME_FUNCTION(wifi_mode, NetplanWifiMode);
 NAME_FUNCTION(infiniband_mode, NetplanInfinibandMode);
+NAME_FUNCTION_FLAGS(vxlan_notification);
+NAME_FUNCTION_FLAGS(vxlan_checksum);
+NAME_FUNCTION_FLAGS(vxlan_extension);
 
 #define ENUM_FUNCTION(_radical, _type) _type netplan_ ## _radical ## _from_name(const char* val) \
 { \

--- a/src/names.c
+++ b/src/names.c
@@ -94,7 +94,7 @@ netplan_addr_gen_mode_to_str[NETPLAN_ADDRGEN_MAX] = {
 };
 
 static const char* const
-netplan_infiniband_mode_to_str[NETPLAN_ADDRGEN_MAX] = {
+netplan_infiniband_mode_to_str[NETPLAN_IB_MODE_MAX_] = {
     [NETPLAN_IB_MODE_KERNEL] = NULL,
     [NETPLAN_IB_MODE_DATAGRAM] = "datagram",
     [NETPLAN_IB_MODE_CONNECTED] = "connected"

--- a/src/names.c
+++ b/src/names.c
@@ -103,7 +103,7 @@ netplan_infiniband_mode_to_str[NETPLAN_IB_MODE_MAX_] = {
 
 #define NAME_FUNCTION(_radical, _type) const char *netplan_ ## _radical ## _name( _type val) \
 { \
-    return (val < sizeof( netplan_ ## _radical ## _to_str )) ?  netplan_ ## _radical ## _to_str [val] : NULL; \
+    return (val < sizeof(netplan_ ## _radical ## _to_str) / sizeof(char *)) ?  netplan_ ## _radical ## _to_str [val] : NULL; \
 }
 
 /* @num_flags needs to account for the 0x0 value (index 0), which doesn't

--- a/src/names.c
+++ b/src/names.c
@@ -81,6 +81,7 @@ netplan_tunnel_mode_to_str[NETPLAN_TUNNEL_MODE_MAX_] = {
     [NETPLAN_TUNNEL_MODE_IPIP6] = "ipip6",
     [NETPLAN_TUNNEL_MODE_IP6GRE] = "ip6gre",
     [NETPLAN_TUNNEL_MODE_VTI6] = "vti6",
+    [NETPLAN_TUNNEL_MODE_VXLAN] = "vxlan",
     [NETPLAN_TUNNEL_MODE_GRETAP] = "gretap",
     [NETPLAN_TUNNEL_MODE_IP6GRETAP] = "ip6gretap",
     [NETPLAN_TUNNEL_MODE_WIREGUARD] = "wireguard",

--- a/src/names.h
+++ b/src/names.h
@@ -44,5 +44,36 @@ netplan_wifi_mode_name(NetplanWifiMode val);
 const char*
 netplan_infiniband_mode_name(NetplanInfinibandMode val);
 
+const char*
+netplan_vxlan_notification_name(int val);
+
+const char*
+netplan_vxlan_checksum_name(int val);
+
+const char*
+netplan_vxlan_extension_name(int val);
+
 NetplanDefType
 netplan_def_type_from_name(const char* val);
+
+/* Netplan flag names */
+static const char* const
+netplan_vxlan_notification_to_str[] = {
+    [__builtin_ffs(NETPLAN_VXLAN_NOTIFICATION_L2_MISS)] = "l2-miss",
+    [__builtin_ffs(NETPLAN_VXLAN_NOTIFICATION_L3_MISS)] = "l3-miss",
+};
+
+static const char* const
+netplan_vxlan_checksum_to_str[] = {
+    [__builtin_ffs(NETPLAN_VXLAN_CHECKSUM_UDP)] = "udp",
+    [__builtin_ffs(NETPLAN_VXLAN_CHECKSUM_ZERO_UDP6_TX)] = "zero-udp6-tx",
+    [__builtin_ffs(NETPLAN_VXLAN_CHECKSUM_ZERO_UDP6_RX)] = "zero-udp6-rx",
+    [__builtin_ffs(NETPLAN_VXLAN_CHECKSUM_REMOTE_TX)] = "remote-tx",
+    [__builtin_ffs(NETPLAN_VXLAN_CHECKSUM_REMOTE_RX)] = "remote-rx",
+};
+
+static const char* const
+netplan_vxlan_extension_to_str[] = {
+    [__builtin_ffs(NETPLAN_VXLAN_EXTENSION_GROUP_POLICY)] = "group-policy",
+    [__builtin_ffs(NETPLAN_VXLAN_EXTENSION_GENERIC_PROTOCOL)] = "generic-protocol",
+};

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -207,8 +207,8 @@ write_vxlan(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefini
     if (def->type == NETPLAN_DEF_TYPE_TUNNEL && def->tunnel.mode == NETPLAN_TUNNEL_MODE_VXLAN) {
         g_assert(def->vxlan);
         YAML_UINT_0(def, event, emitter, "id", def->vxlan->vni);
-        if (def->link)
-            YAML_STRING(def, event, emitter, "link", def->link->id);
+        if (def->vxlan->link)
+            YAML_STRING(def, event, emitter, "link", def->vxlan->link->id);
         if (def->vxlan->source_port_min && def->vxlan->source_port_max) {
             YAML_SCALAR_PLAIN(event, emitter, "port-range");
             YAML_SEQUENCE_OPEN(event, emitter);

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -89,6 +89,14 @@ gchar *tmp = NULL;
     } \
 }\
 
+#define YAML_BOOL_TRISTATE(_def, event_ptr, emitter_ptr, key, value) {\
+    if (value == NETPLAN_TRISTATE_TRUE) { \
+        YAML_NONNULL_STRING_PLAIN(event_ptr, emitter_ptr, key, "true"); \
+    } else if (value == NETPLAN_TRISTATE_FALSE) { \
+        YAML_NONNULL_STRING_PLAIN(event_ptr, emitter_ptr, key, "false"); \
+    } \
+}
+
 #define DIRTY_COMPLEX(_def, _data) complex_object_is_dirty(_def, (char*)(&_data), sizeof(_data))
 
 static gboolean

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -480,7 +480,7 @@ write_vxlan_parameters(const NetplanNetDefinition* def, GString* s)
         g_string_append_printf(params, "\nFlowLabel=%d", def->vxlan->flow_label);
     if (def->vxlan->do_not_fragment != NETPLAN_TRISTATE_UNSET)
         g_string_append_printf(params, "\nIPDoNotFragment=%s", def->vxlan->do_not_fragment ? "true" : "false");
-    if (!def->link)
+    if (!def->vxlan->link)
         g_string_append(params, "\nIndependent=true");
 
     if (params->len)
@@ -953,7 +953,8 @@ netplan_netdef_write_network_file(
         const NetplanNetDefinition* nd;
         for (; l != NULL; l = l->next) {
             nd = l->data;
-            if (nd->link == def && nd->type == NETPLAN_DEF_TYPE_TUNNEL &&
+            if (nd->vxlan && nd->vxlan->link == def &&
+                nd->type == NETPLAN_DEF_TYPE_TUNNEL &&
                 nd->tunnel.mode == NETPLAN_TUNNEL_MODE_VXLAN)
                 g_string_append_printf(network, "VXLAN=%s\n", nd->id);
         }

--- a/src/nm.c
+++ b/src/nm.c
@@ -497,16 +497,16 @@ write_vxlan_parameters(const NetplanNetDefinition* def, GKeyFile* kf)
         g_key_file_set_uint64(kf, "vxlan", "ttl", def->tunnel_ttl);
     if (def->vxlan->short_circuit)
         g_key_file_set_boolean(kf, "vxlan", "rsc", def->vxlan->short_circuit);
-    if (def->link) {
-        if (def->link->has_match) {
+    if (def->vxlan->link) {
+        if (def->vxlan->link->has_match) {
             /* we need to refer to the parent's UUID as we don't have an
              * interface name with match: */
-            maybe_generate_uuid(def->link);
-            uuid_unparse(def->link->uuid, uuidstr);
+            maybe_generate_uuid(def->vxlan->link);
+            uuid_unparse(def->vxlan->link->uuid, uuidstr);
             g_key_file_set_string(kf, "vxlan", "parent", uuidstr);
         } else {
             /* if we have an interface name, use that as parent */
-            g_key_file_set_string(kf, "vxlan", "parent", def->link->id);
+            g_key_file_set_string(kf, "vxlan", "parent", def->vxlan->link->id);
         }
     }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -1778,6 +1778,7 @@ handle_bridge_port_priority(NetplanParser* npp, yaml_node_t* node, const char* k
 
 static const mapping_entry_handler bridge_params_handlers[] = {
     {"ageing-time", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bridge_params.ageing_time)},
+    {"aging-time", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bridge_params.ageing_time)},
     {"forward-delay", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bridge_params.forward_delay)},
     {"hello-time", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bridge_params.hello_time)},
     {"max-age", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bridge_params.max_age)},

--- a/src/types.c
+++ b/src/types.c
@@ -187,6 +187,16 @@ reset_private_netdef_data(struct private_netdef_data* data) {
     data->dirty_fields = NULL;
 }
 
+void
+reset_vxlan(NetplanVxlan* vxlan)
+{
+    if (!vxlan)
+        return;
+    memset(vxlan, 0, sizeof(NetplanVxlan));
+    vxlan->flow_label = G_MAXUINT;
+    vxlan->do_not_fragment = NETPLAN_TRISTATE_UNSET;
+}
+
 /* Free a heap-allocated NetplanWifiAccessPoint object.
  * Signature made to match the g_hash_table_foreach function.
  * @key: ignored
@@ -298,6 +308,11 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     FREE_AND_NULLIFY(netdef->bond_params.primary_slave);
     memset(&netdef->bond_params, 0, sizeof(netdef->bond_params));
 
+    netdef->link = NULL;
+    netdef->has_vxlans = FALSE;
+    reset_vxlan(netdef->vxlan);
+    FREE_AND_NULLIFY(netdef->vxlan);
+
     FREE_AND_NULLIFY(netdef->modem_params.apn);
     FREE_AND_NULLIFY(netdef->modem_params.device_id);
     FREE_AND_NULLIFY(netdef->modem_params.network_id);
@@ -309,6 +324,7 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     FREE_AND_NULLIFY(netdef->modem_params.username);
     memset(&netdef->modem_params, 0, sizeof(netdef->modem_params));
 
+    netdef->bridge_neigh_suppress = NETPLAN_TRISTATE_UNSET;
     FREE_AND_NULLIFY(netdef->bridge_params.ageing_time);
     FREE_AND_NULLIFY(netdef->bridge_params.forward_delay);
     FREE_AND_NULLIFY(netdef->bridge_params.hello_time);

--- a/src/types.c
+++ b/src/types.c
@@ -193,6 +193,7 @@ reset_vxlan(NetplanVxlan* vxlan)
     if (!vxlan)
         return;
     memset(vxlan, 0, sizeof(NetplanVxlan));
+    vxlan->link = NULL;
     vxlan->flow_label = G_MAXUINT;
     vxlan->do_not_fragment = NETPLAN_TRISTATE_UNSET;
 }
@@ -308,7 +309,6 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     FREE_AND_NULLIFY(netdef->bond_params.primary_slave);
     memset(&netdef->bond_params, 0, sizeof(netdef->bond_params));
 
-    netdef->link = NULL;
     netdef->has_vxlans = FALSE;
     reset_vxlan(netdef->vxlan);
     FREE_AND_NULLIFY(netdef->vxlan);

--- a/src/types.h
+++ b/src/types.h
@@ -150,6 +150,7 @@ typedef struct {
 } NetplanIPRule;
 
 struct netplan_vxlan {
+        NetplanNetDefinition* link;
         guint vni;
         guint ageing;
         guint limit;

--- a/src/types.h
+++ b/src/types.h
@@ -39,6 +39,24 @@ struct NetplanOptionalAddressType {
     NetplanOptionalAddressFlag flag;
 };
 
+typedef enum {
+    NETPLAN_VXLAN_NOTIFICATION_L2_MISS = 1<<0,
+    NETPLAN_VXLAN_NOTIFICATION_L3_MISS = 1<<1,
+} NetplanVxlanNotificationFlags;
+
+typedef enum {
+    NETPLAN_VXLAN_CHECKSUM_UDP = 1<<0,
+    NETPLAN_VXLAN_CHECKSUM_ZERO_UDP6_TX = 1<<1,
+    NETPLAN_VXLAN_CHECKSUM_ZERO_UDP6_RX = 1<<2,
+    NETPLAN_VXLAN_CHECKSUM_REMOTE_TX = 1<<3,
+    NETPLAN_VXLAN_CHECKSUM_REMOTE_RX = 1<<4,
+} NetplanVxlanChecksumFlags;
+
+typedef enum {
+    NETPLAN_VXLAN_EXTENSION_GROUP_POLICY = 1<<0,
+    NETPLAN_VXLAN_EXTENSION_GENERIC_PROTOCOL = 1<<1,
+} NetplanVxlanExtensionFlags;
+
 // Not strictly speaking a type, but seems fair to keep it around.
 extern struct NetplanOptionalAddressType NETPLAN_OPTIONAL_ADDRESS_TYPES[];
 

--- a/src/types.h
+++ b/src/types.h
@@ -149,6 +149,24 @@ typedef struct {
     guint tos;
 } NetplanIPRule;
 
+struct netplan_vxlan {
+        guint vni;
+        guint ageing;
+        guint limit;
+        guint tos;
+        guint flow_label;
+        guint source_port_min;
+        guint source_port_max;
+        gboolean mac_learning;
+        gboolean arp_proxy;
+        gboolean short_circuit;
+        gboolean independent;
+        NetplanFlags notifications;
+        NetplanFlags checksums;
+        NetplanFlags extensions;
+        NetplanTristate do_not_fragment;
+};
+
 struct netplan_state {
     /* Since both netdefs and netdefs_ordered store pointers to the same elements,
      * we consider that only netdefs_ordered is owner of this data. One should not
@@ -191,6 +209,7 @@ struct netplan_parser {
         NetplanAddressOptions* addr_options;
         NetplanIPRoute* route;
         NetplanIPRule* ip_rule;
+        NetplanVxlan* vxlan;
         const char *filepath;
 
         /* Plain old data representing the backend for which we are
@@ -239,6 +258,9 @@ reset_ip_rule(NetplanIPRule* ip_rule);
 
 void
 reset_ovs_settings(NetplanOVSSettings *settings);
+
+void
+reset_vxlan(NetplanVxlan* vxlan);
 
 void
 access_point_clear(NetplanWifiAccessPoint** ap, NetplanBackend backend);

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -97,3 +97,6 @@ netplan_copy_string(const char* input, char* out_buffer, size_t out_size);
 
 gboolean
 complex_object_is_dirty(const NetplanNetDefinition* def, const void* obj, size_t obj_size);
+
+gboolean
+is_multicast_address(const char*);

--- a/src/util.c
+++ b/src/util.c
@@ -786,3 +786,20 @@ netplan_netdef_get_set_name(const NetplanNetDefinition* netdef, char* out_buf, s
 {
     return netplan_copy_string(netdef->set_name, out_buf, out_size);
 }
+
+gboolean
+is_multicast_address(const char* address)
+{
+    struct in_addr a4;
+    struct in6_addr a6;
+
+    if (inet_pton(AF_INET, address, &a4) > 0) {
+        if (ntohl(a4.s_addr) >> 28 == 0b1110) /* 224.0.0.0/4 */
+            return TRUE;
+    } else if (inet_pton(AF_INET6, address, &a6) > 0) {
+        if (a6.s6_addr[0] == 0xff) /* FF00::/8 */
+            return TRUE;
+    }
+
+    return FALSE;
+}

--- a/src/yaml-helpers.h
+++ b/src/yaml-helpers.h
@@ -45,6 +45,10 @@
     if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto err_path; \
 }
 
+#define YAML_FLAG(event_ptr, emitter_ptr, flag, flags_ptr, flags_func) \
+    if (flags_ptr & flag) \
+        YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, flags_func(flag));
+
 #define YAML_NULL_PLAIN(event_ptr, emitter_ptr) \
     yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t*)YAML_NULL_TAG, (yaml_char_t*)"null", strlen("null"), 1, 0, YAML_PLAIN_SCALAR_STYLE); \
     if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto err_path; \

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -80,6 +80,7 @@ NM_WG = '[connection]\nid=netplan-wg0\ntype=wireguard\ninterface-name=wg0\n\n[wi
 2001:de:ad:be:ef:ca:fe:1/128\nip6-privacy=0\n'
 ND_WG = '[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey%s\nListenPort=%s\n%s\n'
 ND_VLAN = '[NetDev]\nName=%s\nKind=vlan\n\n[VLAN]\nId=%d\n'
+ND_VXLAN = '[NetDev]\nName=%s\nKind=vxlan\n\n[VXLAN]\nVNI=%d\n'
 ND_VRF = '[NetDev]\nName=%s\nKind=vrf\n\n[VRF]\nTable=%d\n'
 SD_WPA = '''[Unit]
 Description=WPA supplicant for netplan %(iface)s

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -29,6 +29,10 @@ class TestOpenVSwitch(TestBase):
     def test_interface_external_ids_other_config(self):
         self.generate('''network:
   version: 2
+  bridges: # bridges first, to trigger multi-pass processing
+    ovs0:
+      interfaces: [eth0, eth1]
+      openvswitch: {}
   ethernets:
     eth0:
       openvswitch:
@@ -41,12 +45,7 @@ class TestOpenVSwitch(TestBase):
       dhcp4: true
       openvswitch:
         other-config:
-          disable-in-band: false
-  bridges:
-    ovs0:
-      interfaces: [eth0, eth1]
-      openvswitch: {}
-''')
+          disable-in-band: false\n''')
         self.assert_ovs({'ovs0.service': OVS_VIRTUAL % {'iface': 'ovs0', 'extra': '''
 [Service]
 Type=oneshot

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -272,7 +272,7 @@ unmanaged-devices+=interface-name:eth0,interface-name:en*,interface-name:veth42,
     def assert_iface(self, iface, expected_ip_a=None, unexpected_ip_a=None):
         '''Assert that client interface has been created'''
 
-        out = subprocess.check_output(['ip', 'a', 'show', 'dev', iface],
+        out = subprocess.check_output(['ip', '-d', 'a', 'show', 'dev', iface],
                                       universal_newlines=True)
         if expected_ip_a:
             for r in expected_ip_a:


### PR DESCRIPTION
## Description
Adding support for VXLAN tunnels using the sd-networkd and NetworkManager backends.
It builds upon #272 (squashed & rebased), extracted VXLAN bits. Applied on top of #285.
Schema according to (internal) spec FO042.

The first 3 commits e83ea8914223841b231843f630eeb382ee18d601 6d3597e356358de2d9a0f8d5e25af3fb27b2e542 02c4f0081ac5cf43adf8300bf49c28865f98d99a are pretty much unrelated to this PR. Those are drive-by fixes that I had been tracking in a separate branch, but the diff is fairly small, so I thought it'd make sense to include them into this PR instead of doing an extra one just for this.

Example:
```
network:
  ethernets:
    lo:
      addresses: [ 192.168.10.10/32 ]
  tunnels:
    vx1:
      mode: vxlan
      id: 1
      link: lo
      mtu: 8950
      accept-ra: no
      neigh-suppress: true
      mac-learning: false
      port: 4789
      local: 192.168.10.10
  bridges:
    br1:
      interfaces: [ vx1 ]
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1764716