### PR TITLE
Use pytest instead of deprecated nose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ PYCODE = netplan/ $(wildcard src/*.py) $(wildcard tests/*.py) $(wildcard tests/g
 # Order: Fedora/Mageia/openSUSE || Debian/Ubuntu || null
 PYFLAKES3 ?= $(shell command -v pyflakes-3 || command -v pyflakes3 || echo true)
 PYCODESTYLE3 ?= $(shell command -v pycodestyle-3 || command -v pycodestyle || command -v pep8 || echo true)
-NOSETESTS3 ?= $(shell command -v nosetests-3 || command -v nosetests3 || echo true)
+PYTEST3 ?= $(shell command -v pytest-3 || command -v pytest3 || echo true)
 
 default: netplan/_features.py generate netplan-dbus dbus/io.netplan.Netplan.service doc/netplan.html doc/netplan.5 doc/netplan-generate.8 doc/netplan-apply.8 doc/netplan-try.8 doc/netplan-dbus.8 doc/netplan-get.8 doc/netplan-set.8
 
@@ -87,7 +87,7 @@ clean:
 
 check: default linting
 	PYTHONPATH=. LD_LIBRARY_PATH=. tests/cli.py
-	PYTHONPATH=. LD_LIBRARY_PATH=. $(NOSETESTS3) -v --with-coverage
+	PYTHONPATH=. LD_LIBRARY_PATH=. $(PYTEST3) -s --cov= --cov-append
 	tests/validate_docs.sh
 
 linting:

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@ bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', def
 # Order: Fedora/Mageia/openSUSE || Debian/Ubuntu
 pyflakes = find_program('pyflakes-3', 'pyflakes3', required: false)
 pycodestyle = find_program('pycodestyle-3', 'pycodestyle', 'pep8', required: false)
-nose = find_program('nosetests-3', 'nosetests3')
+pytest = find_program('pytest-3', 'pytest3')  # also requires the pytest-cov plugin
 pandoc = find_program('pandoc', required: false)
 find = find_program('find')
 
@@ -78,8 +78,8 @@ test('legacy-tests',
      env: test_env)
 #TODO: split out dbus tests into own test() instance, to run in parallel
 test('unit-tests',
-     nose,
-     args: ['-v', '--with-coverage', meson.current_source_dir()],
+     pytest,
+     args: ['-s', '--cov=', '--cov-append', meson.current_source_dir()],
      timeout: 600,
      env: test_env)
 

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -45,21 +45,21 @@ class TestTerminal(unittest.TestCase):
         self.terminal.enable_nonblocking_io()
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
         self.assertTrue(flags & os.O_NONBLOCK)
-        self.assertNotEquals(flags, orig_flags)
+        self.assertNotEqual(flags, orig_flags)
         self.terminal.disable_nonblocking_io()
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
         self.assertFalse(flags & os.O_NONBLOCK)
-        self.assertEquals(flags, orig_flags)
+        self.assertEqual(flags, orig_flags)
 
     def test_save(self):
         self.terminal.enable_nonblocking_io()
         flags = self.terminal.orig_flags
         self.terminal.save()
         self.terminal.disable_nonblocking_io()
-        self.assertNotEquals(flags, self.terminal.orig_flags)
+        self.assertNotEqual(flags, self.terminal.orig_flags)
         self.terminal.reset()
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
-        self.assertEquals(flags, self.terminal.orig_flags)
+        self.assertEqual(flags, self.terminal.orig_flags)
         self.terminal.disable_nonblocking_io()
         self.terminal.save()
 
@@ -69,10 +69,10 @@ class TestTerminal(unittest.TestCase):
         self.terminal.save(orig_settings)
         self.terminal.disable_nonblocking_io()
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
-        self.assertNotEquals(flags, orig_settings.get('flags'))
+        self.assertNotEqual(flags, orig_settings.get('flags'))
         self.terminal.reset(orig_settings)
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
-        self.assertEquals(flags, orig_settings.get('flags'))
+        self.assertEqual(flags, orig_settings.get('flags'))
         self.terminal.disable_nonblocking_io()
 
     def test_reset(self):

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -25,7 +25,7 @@ import unittest
 import netplan.terminal
 
 
-@unittest.skipUnless(sys.__stdin__.isatty(), "not supported when run from a script")
+@unittest.skipUnless(sys.__stdout__.isatty(), "not supported when run from a script")
 class TestTerminal(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Description
WIP: Use pytest instead of deprecated nose

FIXME: fix coverage reporting with pytest-3 / pytest-cov / python3-coverage

See also:
https://salsa.debian.org/debian/netplan.io/-/merge_requests/8
https://lists.debian.org/debian-python/2022/08/msg00065.html

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

