### PR TITLE
Check if the name to set to an interface is already an altname (LP: #1994822)

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -27,6 +27,7 @@ import subprocess
 import shutil
 import netifaces
 import time
+import yaml
 
 import netplan.cli.utils as utils
 from netplan.configmanager import ConfigManager, ConfigurationError
@@ -62,9 +63,11 @@ class NetplanApply(utils.NetplanCommand):
 
     @staticmethod
     def get_alt_names(iface):
-        ret = subprocess.run(['ip', 'link', 'show', iface], capture_output=True)
-        data = ret.stdout.decode('utf-8').split()
-        return [data[i + 1] for i, x in enumerate(data) if x == "altname"]
+        ret = subprocess.run(['ip', '-j', 'link', 'show', iface], capture_output=True)
+        data = yaml.safe_load(ret.stdout.decode('utf-8'))
+        if data and len(data) == 1:
+            return data[0].get('altnames', [])
+        return []
 
     def command_apply(self, run_generate=True, sync=False, exit_on_error=True, state_dir=None):  # pragma: nocover
         config_manager = ConfigManager()

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -243,7 +243,7 @@ class NetplanApply(utils.NetplanCommand):
                 if iface in devices and new_name in devices_after_udev:
                     logging.debug('Interface rename {} -> {} already happened.'.format(iface, new_name))
                     continue  # re-name already happened via 'udevadm test'
-                if new_name in self.get_alt_names(iface):
+                if new_name in NetplanApply.get_alt_names(iface):
                     logging.debug('Interface name {} already present as altname on {}.'.format(new_name, iface))
                     continue  # name already present in interface
                 # bring down the interface, using its current (matched) interface name

--- a/tests/test_cli_units.py
+++ b/tests/test_cli_units.py
@@ -55,6 +55,18 @@ class TestCLI(unittest.TestCase):
         res = NetplanApply.is_composite_member([{'renderer': 'networkd', 'br0': {'interfaces': ['eth0']}}], 'eth0')
         self.assertTrue(res)
 
+    @patch('subprocess.run')
+    def test_get_alt_names(self, mock):
+        stdout_mock = mock.Mock()
+        stdout_mock.stdout = b"""3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8958 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
+    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
+    altname enp0s4
+    altname enp0s41"""
+        mock.return_value = stdout_mock
+        res = NetplanApply.get_alt_names('ens4')
+        mock.assert_called_with(['ip', 'link', 'show', 'ens4'], capture_output=True)
+        self.assertEquals(res, ['enp0s4', 'enp0s41'])
+
     @patch('subprocess.check_call')
     def test_clear_virtual_links(self, mock):
         # simulate as if 'tun3' would have already been delete another way,

--- a/tests/test_cli_units.py
+++ b/tests/test_cli_units.py
@@ -58,10 +58,11 @@ class TestCLI(unittest.TestCase):
     @patch('subprocess.run')
     def test_get_alt_names(self, mock):
         stdout_mock = mock.Mock()
-        stdout_mock.stdout = b"""3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8958 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
-    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
-    altname enp0s4
-    altname enp0s41"""
+        stdout_mock.stdout = "3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8958 qdisc fq_codel state "\
+            "UP mode DEFAULT group default qlen 1000\n"\
+            "    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff\n"\
+            "    altname enp0s4\n"\
+            "    altname enp0s41".encode('utf-8')
         mock.return_value = stdout_mock
         res = NetplanApply.get_alt_names('ens4')
         mock.assert_called_with(['ip', 'link', 'show', 'ens4'], capture_output=True)

--- a/tests/test_cli_units.py
+++ b/tests/test_cli_units.py
@@ -72,6 +72,7 @@ class TestCLI(unittest.TestCase):
         res = NetplanApply.get_alt_names('ens4')
         mock.assert_called_with(['ip', '-j', 'link', 'show', 'ens4'], capture_output=True)
         self.assertEquals(res, [])
+
     @patch('subprocess.check_call')
     def test_clear_virtual_links(self, mock):
         # simulate as if 'tun3' would have already been delete another way,

--- a/tests/test_cli_units.py
+++ b/tests/test_cli_units.py
@@ -58,16 +58,20 @@ class TestCLI(unittest.TestCase):
     @patch('subprocess.run')
     def test_get_alt_names(self, mock):
         stdout_mock = mock.Mock()
-        stdout_mock.stdout = "3: ens4: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8958 qdisc fq_codel state "\
-            "UP mode DEFAULT group default qlen 1000\n"\
-            "    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff\n"\
-            "    altname enp0s4\n"\
-            "    altname enp0s41".encode('utf-8')
+        stdout_mock.stdout = '[{"ifindex":3,"ifname":"ens4","flags":["BROADCAST","MULTICAST","UP","LOWER_UP"],'\
+                             '"mtu":8958,"qdisc":"fq_codel","operstate":"UP","linkmode":"DEFAULT","group":"default",'\
+                             '"txqlen":1000,"link_type":"ether","address":"xx:xx:xx:xx:xx:xx",'\
+                             '"broadcast":"ff:ff:ff:ff:ff:ff","altnames":["enp0s4","enp0s41"]}]'.encode('utf-8')
         mock.return_value = stdout_mock
         res = NetplanApply.get_alt_names('ens4')
-        mock.assert_called_with(['ip', 'link', 'show', 'ens4'], capture_output=True)
+        mock.assert_called_with(['ip', '-j', 'link', 'show', 'ens4'], capture_output=True)
         self.assertEquals(res, ['enp0s4', 'enp0s41'])
 
+        mock.reset_mock()
+        stdout_mock.stdout = ''.encode('utf-8')
+        res = NetplanApply.get_alt_names('ens4')
+        mock.assert_called_with(['ip', '-j', 'link', 'show', 'ens4'], capture_output=True)
+        self.assertEquals(res, [])
     @patch('subprocess.check_call')
     def test_clear_virtual_links(self, mock):
         # simulate as if 'tun3' would have already been delete another way,


### PR DESCRIPTION
When netplan has a set-name configuration option and that name is already defined as an altname in the interface an exception is thrown and the apply process ends prematurely. This patch checks this case and prevents that exception from being thrown. A debug message is written instead.

Closes-Bug: LP#1994822