### PR TITLE
parse: Add the filepath to OVS ports netdefs

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2842,10 +2842,10 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
         }
 
         if (npp->current.filepath) {
-            if (component->filepath)
-                g_free(component->filepath);
+            if (component1->filepath)
+                g_free(component1->filepath);
 
-            component->filepath = g_strdup(npp->current.filepath);
+            component1->filepath = g_strdup(npp->current.filepath);
         }
 
         if (component1->peer && g_strcmp0(component1->peer, scalar(peer)))
@@ -2861,10 +2861,10 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
         }
 
         if (npp->current.filepath) {
-            if (component->filepath)
-                g_free(component->filepath);
+            if (component2->filepath)
+                g_free(component2->filepath);
 
-            component->filepath = g_strdup(npp->current.filepath);
+            component2->filepath = g_strdup(npp->current.filepath);
         }
 
         if (component2->peer && g_strcmp0(component2->peer, scalar(port)))

--- a/src/parse.c
+++ b/src/parse.c
@@ -2839,6 +2839,7 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
             component1 = netplan_netdef_new(npp, scalar(port), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
             if (g_hash_table_remove(npp->missing_id, scalar(port)))
                 npp->missing_ids_found++;
+            component->filepath = g_strdup(npp->current.filepath);
         }
 
         if (component1->peer && g_strcmp0(component1->peer, scalar(peer)))
@@ -2851,6 +2852,7 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
             component2 = netplan_netdef_new(npp, scalar(peer), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
             if (g_hash_table_remove(npp->missing_id, scalar(peer)))
                 npp->missing_ids_found++;
+            component->filepath = g_strdup(npp->current.filepath);
         }
 
         if (component2->peer && g_strcmp0(component2->peer, scalar(port)))

--- a/src/parse.c
+++ b/src/parse.c
@@ -2839,6 +2839,12 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
             component1 = netplan_netdef_new(npp, scalar(port), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
             if (g_hash_table_remove(npp->missing_id, scalar(port)))
                 npp->missing_ids_found++;
+        }
+
+        if (npp->current.filepath) {
+            if (component->filepath)
+                g_free(component->filepath);
+
             component->filepath = g_strdup(npp->current.filepath);
         }
 
@@ -2852,6 +2858,12 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
             component2 = netplan_netdef_new(npp, scalar(peer), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
             if (g_hash_table_remove(npp->missing_id, scalar(peer)))
                 npp->missing_ids_found++;
+        }
+
+        if (npp->current.filepath) {
+            if (component->filepath)
+                g_free(component->filepath);
+
             component->filepath = g_strdup(npp->current.filepath);
         }
 

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -364,6 +364,25 @@ class TestNetDefinition(TestBase):
         netdef = state['eth0']
         self.assertEqual(os.path.join(self.confdir, "a.yaml"), netdef.filepath)
 
+    def test_filepath_for_ovs_ports(self):
+        state = state_from_yaml(self.confdir, '''network:
+  version: 2
+  renderer: networkd
+  bridges:
+    br0:
+      interfaces:
+        - patch0-2
+    br1:
+      interfaces:
+        - patch2-0
+  openvswitch:
+    ports:
+      - [patch0-2, patch2-0]''', filename="a.yaml")
+        netdef_port1 = state["patch2-0"]
+        netdef_port2 = state["patch0-2"]
+        self.assertEqual(os.path.join(self.confdir, "a.yaml"), netdef_port1.filepath)
+        self.assertEqual(os.path.join(self.confdir, "a.yaml"), netdef_port2.filepath)
+
     def test_set_name(self):
         state = state_from_yaml(self.confdir, '''network:
   ethernets:

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -383,6 +383,51 @@ class TestNetDefinition(TestBase):
         self.assertEqual(os.path.join(self.confdir, "a.yaml"), netdef_port1.filepath)
         self.assertEqual(os.path.join(self.confdir, "a.yaml"), netdef_port2.filepath)
 
+    def test_filepath_for_ovs_ports_when_conf_is_redefined(self):
+        state = libnetplan.State()
+        parser = libnetplan.Parser()
+
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(b'''network:
+  version: 2
+  renderer: networkd
+  bridges:
+    br0:
+      interfaces:
+        - patch0-2
+    br1:
+      interfaces:
+        - patch2-0
+  openvswitch:
+    ports:
+      - [patch0-2, patch2-0]''')
+            f.flush()
+            parser.load_yaml(f.name)
+
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(b'''network:
+  version: 2
+  renderer: networkd
+  bridges:
+    br0:
+      interfaces:
+        - patch0-2
+    br1:
+      interfaces:
+        - patch2-0
+  openvswitch:
+    ports:
+      - [patch0-2, patch2-0]''')
+            f.flush()
+            parser.load_yaml(f.name)
+            yaml_redefinition_filepath = f.name
+
+        state.import_parser_results(parser)
+        netdef_port1 = state["patch2-0"]
+        netdef_port2 = state["patch0-2"]
+        self.assertEqual(os.path.join(self.confdir, yaml_redefinition_filepath), netdef_port1.filepath)
+        self.assertEqual(os.path.join(self.confdir, yaml_redefinition_filepath), netdef_port2.filepath)
+
     def test_set_name(self):
         state = state_from_yaml(self.confdir, '''network:
   ethernets:


### PR DESCRIPTION
The filepath isn't being populated for OVS ports netdefs.

Add a unit test to catch this issue.


New unit test outcome without the fix:
```
======================================================================                                                                 
FAIL: test_filepath_for_ovs_ports (test_libnetplan.TestNetDefinition)                                                                                                    
----------------------------------------------------------------------                                                                 
Traceback (most recent call last):
  File "/workspace/netplan-filepath/tests/test_libnetplan.py", line 382, in test_filepath_for_ovs_ports
    self.assertEqual(os.path.join(self.confdir, "a.yaml"), netdef.filepath)
    AssertionError: '/tmp/tmpp3mx4zw6/etc/netplan/a.yaml' != None

```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

