### PR TITLE
[DRAFT] API: implement APIs from the new specification

### DIFF
--- a/.gcovr
+++ b/.gcovr
@@ -1,0 +1,1 @@
+exclude = 'src/tests/*'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Netplan's [documentation objectives](https://docs.google.com/document/d/1n47hwLm
 
 Steps to build netplan using the [Meson](https://mesonbuild.com) build system inside the `build/` directory:
 
-* meson setup build --prefix=/usr [-Db_coverage=true]
+* meson setup build --prefix=/usr [-Db_coverage=true] [-Dunit_testing=true]
 * meson compile -C build
 * meson test -C build --verbose [TEST_NAME]
 * meson install -C build --destdir ../tmproot

--- a/include/netplan.h
+++ b/include/netplan.h
@@ -59,6 +59,18 @@ netplan_state_get_netdefs_size(const NetplanState* np_state);
 NETPLAN_PUBLIC NetplanNetDefinition*
 netplan_state_get_netdef(const NetplanState* np_state, const char* id);
 
+NETPLAN_PUBLIC gboolean
+netplan_state_finish_nm_write(
+        const NetplanState* np_state,
+        const char* rootdir,
+        GError** error);
+
+NETPLAN_PUBLIC gboolean
+netplan_state_finish_ovs_write(
+        const NetplanState* np_state,
+        const char* rootdir,
+        GError** error);
+
 /* Write the selected yaml file. All definitions that originate from this file,
  * as well as those without any given origin, are written to it.
  */
@@ -66,6 +78,12 @@ NETPLAN_PUBLIC gboolean
 netplan_state_write_yaml_file(
         const NetplanState* np_state,
         const char* filename,
+        const char* rootdir,
+        GError** error);
+
+NETPLAN_PUBLIC gboolean
+netplan_state_finish_sriov_write(
+        const NetplanState* np_state,
         const char* rootdir,
         GError** error);
 

--- a/include/parse.h
+++ b/include/parse.h
@@ -69,6 +69,42 @@ netplan_parser_load_yaml_from_fd(NetplanParser* npp, int input_fd, GError** erro
 NETPLAN_PUBLIC gboolean
 netplan_parser_load_nullable_fields(NetplanParser* npp, int input_fd, GError** error);
 
+NETPLAN_PUBLIC ssize_t
+netplan_netdef_get_filepath(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);
+
+NETPLAN_PUBLIC NetplanBackend
+netplan_netdef_get_backend(const NetplanNetDefinition* netdef);
+
+NETPLAN_PUBLIC NetplanDefType
+netplan_netdef_get_type(const NetplanNetDefinition* netdef);
+
+NETPLAN_PUBLIC ssize_t
+netplan_netdef_get_id(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size);
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_bridge_link(const NetplanNetDefinition* netdef);
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_bond_link(const NetplanNetDefinition* netdef);
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_peer_link(const NetplanNetDefinition* netdef);
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_vlan_link(const NetplanNetDefinition* netdef);
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_sriov_link(const NetplanNetDefinition* netdef);
+
+NETPLAN_PUBLIC ssize_t
+netplan_netdef_get_set_name(const NetplanNetDefinition* netdef, char* out_buf, size_t out_size);
+
+NETPLAN_PUBLIC gboolean
+netplan_netdef_has_match(const NetplanNetDefinition* netdef);
+
+NETPLAN_PUBLIC void
+netplan_error_free(GError** error);
+
 /********** Old API below this ***********/
 
 NETPLAN_PUBLIC gboolean

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ find = find_program('find')
 
 add_project_arguments(
     '-DSBINDIR="' + join_paths(get_option('prefix'), get_option('sbindir')) + '"',
+    '-DFIXTURESDIR="' + meson.global_source_root() + '/src/tests/fixtures"',
     '-D_XOPEN_SOURCE=700',
     language: 'c')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('unit_testing', type: 'boolean', value: false)

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -278,11 +278,20 @@ class NetDefinition:
         lib._netplan_netdef_get_critical.argtypes = [_NetplanNetDefinitionP]
         lib._netplan_netdef_get_critical.restype = c_int
 
-        lib._netplan_netdef_get_sriov_link.argtypes = [_NetplanNetDefinitionP]
-        lib._netplan_netdef_get_sriov_link.restype = _NetplanNetDefinitionP
+        lib.netplan_netdef_get_sriov_link.argtypes = [_NetplanNetDefinitionP]
+        lib.netplan_netdef_get_sriov_link.restype = _NetplanNetDefinitionP
 
-        lib._netplan_netdef_get_vlan_link.argtypes = [_NetplanNetDefinitionP]
-        lib._netplan_netdef_get_vlan_link.restype = _NetplanNetDefinitionP
+        lib.netplan_netdef_get_vlan_link.argtypes = [_NetplanNetDefinitionP]
+        lib.netplan_netdef_get_vlan_link.restype = _NetplanNetDefinitionP
+
+        lib.netplan_netdef_get_bridge_link.argtypes = [_NetplanNetDefinitionP]
+        lib.netplan_netdef_get_bridge_link.restype = _NetplanNetDefinitionP
+
+        lib.netplan_netdef_get_bond_link.argtypes = [_NetplanNetDefinitionP]
+        lib.netplan_netdef_get_bond_link.restype = _NetplanNetDefinitionP
+
+        lib.netplan_netdef_get_peer_link.argtypes = [_NetplanNetDefinitionP]
+        lib.netplan_netdef_get_peer_link.restype = _NetplanNetDefinitionP
 
         lib._netplan_netdef_get_vlan_id.argtypes = [_NetplanNetDefinitionP]
         lib._netplan_netdef_get_vlan_id.restype = c_uint
@@ -333,17 +342,38 @@ class NetDefinition:
 
     @property
     def sriov_link(self):
-        link_ptr = lib._netplan_netdef_get_sriov_link(self._ptr)
+        link_ptr = lib.netplan_netdef_get_sriov_link(self._ptr)
         if link_ptr:
             return NetDefinition(self._parent, link_ptr)
         return None
 
     @property
     def vlan_link(self):
-        link_ptr = lib._netplan_netdef_get_vlan_link(self._ptr)
+        link_ptr = lib.netplan_netdef_get_vlan_link(self._ptr)
         if link_ptr:
             return NetDefinition(self._parent, link_ptr)
         return None
+
+    @property
+    def bridge_link(self):
+        link_ptr = lib.netplan_netdef_get_bridge_link(self._ptr)
+        if link_ptr:
+            return NetDefinition(self._parent, link_ptr)
+        return None
+
+    @property
+    def bond_link(self):
+        link_ptr = lib.netplan_netdef_get_bond_link(self._ptr)
+        if link_ptr:
+            return NetDefinition(self._parent, link_ptr)
+        return None
+
+    @property
+    def peer_link(self):
+        link_ptr = lib.netplan_netdef_get_peer_link(self._ptr)
+        if link_ptr:
+            return NetDefinition(self._parent, link_ptr)
+        return None  # pragma: nocover (ovs ports are always defined in pairs)
 
     @property
     def vlan_id(self):

--- a/src/abi.h
+++ b/src/abi.h
@@ -226,10 +226,13 @@ struct netplan_net_definition {
 
     /* master ID for slave devices */
     char* bridge;
+    NetplanNetDefinition* bridge_link;
     char* bond;
+    NetplanNetDefinition* bond_link;
 
     /* peer ID for OVS patch ports */
     char* peer;
+    NetplanNetDefinition* peer_link;
 
     /* vlan */
     guint vlan_id;
@@ -327,7 +330,7 @@ struct netplan_net_definition {
 
     /* these properties are only valid for SR-IOV NICs */
     /* netplan-feature: sriov */
-    struct netplan_net_definition* sriov_link;
+    NetplanNetDefinition* sriov_link;
     gboolean sriov_vlan_filter;
     guint sriov_explicit_vf_count;
 

--- a/src/error.c
+++ b/src/error.c
@@ -173,3 +173,8 @@ yaml_error(const NetplanParser *npp, const yaml_node_t* node, GError** error, co
     return FALSE;
 }
 
+NETPLAN_PUBLIC void
+netplan_error_free(GError** error) {
+    g_clear_error(error);
+    *error = NULL;
+}

--- a/src/generate.c
+++ b/src/generate.c
@@ -34,6 +34,7 @@
 #include "nm.h"
 #include "openvswitch.h"
 #include "sriov.h"
+#include "netplan.h"
 
 static gchar* rootdir;
 static gchar** files;
@@ -332,6 +333,8 @@ int main(int argc, char** argv)
     }
 
 cleanup:
+    if (error)
+        netplan_error_free(&error);
     if (npp)
         netplan_parser_clear(&npp);
     if (np_state)

--- a/src/meson.build
+++ b/src/meson.build
@@ -44,3 +44,6 @@ install_symlink(
     pointing_to: join_paths('..', '..') + join_paths(get_option('prefix'), libexec_netplan, 'generate'),
     install_dir: join_paths('/', 'lib', 'netplan'))
 
+if get_option('unit_testing')
+  subdir('tests')
+endif

--- a/src/nm.h
+++ b/src/nm.h
@@ -28,10 +28,4 @@ netplan_netdef_write_nm(
         GError** error);
 
 NETPLAN_INTERNAL gboolean
-netplan_state_finish_nm_write(
-        const NetplanState* np_state,
-        const char* rootdir,
-        GError** error);
-
-NETPLAN_INTERNAL gboolean
 netplan_nm_cleanup(const char* rootdir);

--- a/src/openvswitch.h
+++ b/src/openvswitch.h
@@ -28,10 +28,4 @@ netplan_netdef_write_ovs(
         GError** error);
 
 NETPLAN_INTERNAL gboolean
-netplan_state_finish_ovs_write(
-        const NetplanState* np_state,
-        const char* rootdir,
-        GError** error);
-
-NETPLAN_INTERNAL gboolean
 netplan_ovs_cleanup(const char* rootdir);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1366,6 +1366,7 @@ handle_bridge_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data
                 return yaml_error(npp, node, error, "%s: interface '%s' is already assigned to bond %s",
                                   npp->current.netdef->id, scalar(entry), component->bond);
             set_str_if_null(component->bridge, npp->current.netdef->id);
+            component->bridge_link = npp->current.netdef;
             if (component->backend == NETPLAN_BACKEND_OVS) {
                 g_debug("%s: Bridge contains openvswitch interface, choosing OVS backend", npp->current.netdef->id);
                 npp->current.netdef->backend = NETPLAN_BACKEND_OVS;
@@ -1430,6 +1431,7 @@ handle_bond_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data, 
                 return yaml_error(npp, node, error, "%s: interface '%s' is already assigned to bond %s",
                                   npp->current.netdef->id, scalar(entry), component->bond);
             component->bond = g_strdup(npp->current.netdef->id);
+            component->bond_link = npp->current.netdef;
             if (component->backend == NETPLAN_BACKEND_OVS) {
                 g_debug("%s: Bond contains openvswitch interface, choosing OVS backend", npp->current.netdef->id);
                 npp->current.netdef->backend = NETPLAN_BACKEND_OVS;
@@ -2811,7 +2813,8 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
     yaml_node_t* peer = NULL;
     yaml_node_t* pair = NULL;
     yaml_node_item_t *item = NULL;
-    NetplanNetDefinition *component = NULL;
+    NetplanNetDefinition *component1 = NULL;
+    NetplanNetDefinition *component2 = NULL;
 
     for (yaml_node_item_t *iter = node->data.sequence.items.start; iter < node->data.sequence.items.top; iter++) {
         pair = yaml_document_get_node(&npp->doc, *iter);
@@ -2829,31 +2832,33 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
         assert_type(npp, peer, YAML_SCALAR_NODE);
 
         /* Create port 1 netdef */
-        component = npp->parsed_defs ? g_hash_table_lookup(npp->parsed_defs, scalar(port)) : NULL;
-        if (!component) {
-            component = netplan_netdef_new(npp, scalar(port), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
+        component1 = npp->parsed_defs ? g_hash_table_lookup(npp->parsed_defs, scalar(port)) : NULL;
+        if (!component1) {
+            component1 = netplan_netdef_new(npp, scalar(port), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
             if (g_hash_table_remove(npp->missing_id, scalar(port)))
                 npp->missing_ids_found++;
         }
 
-        if (component->peer && g_strcmp0(component->peer, scalar(peer)))
+        if (component1->peer && g_strcmp0(component1->peer, scalar(peer)))
             return yaml_error(npp, port, error, "openvswitch port '%s' is already assigned to peer '%s'",
-                              component->id, component->peer);
-        component->peer = g_strdup(scalar(peer));
+                              component1->id, component1->peer);
+        component1->peer = g_strdup(scalar(peer));
 
         /* Create port 2 (peer) netdef */
-        component = NULL;
-        component = npp->parsed_defs ? g_hash_table_lookup(npp->parsed_defs, scalar(peer)) : NULL;
-        if (!component) {
-            component = netplan_netdef_new(npp, scalar(peer), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
+        component2 = npp->parsed_defs ? g_hash_table_lookup(npp->parsed_defs, scalar(peer)) : NULL;
+        if (!component2) {
+            component2 = netplan_netdef_new(npp, scalar(peer), NETPLAN_DEF_TYPE_PORT, NETPLAN_BACKEND_OVS);
             if (g_hash_table_remove(npp->missing_id, scalar(peer)))
                 npp->missing_ids_found++;
         }
 
-        if (component->peer && g_strcmp0(component->peer, scalar(port)))
+        if (component2->peer && g_strcmp0(component2->peer, scalar(port)))
             return yaml_error(npp, peer, error, "openvswitch port '%s' is already assigned to peer '%s'",
-                              component->id, component->peer);
-        component->peer = g_strdup(scalar(port));
+                              component2->id, component2->peer);
+        component2->peer = g_strdup(scalar(port));
+
+        component1->peer_link = component2;
+        component2->peer_link = component1;
     }
     return TRUE;
 }
@@ -3240,13 +3245,6 @@ netplan_state_import_parser_results(NetplanState* np_state, NetplanParser* npp, 
 
     netplan_parser_reset(npp);
     return TRUE;
-}
-
-static void
-clear_netdef_from_list(void *def)
-{
-    reset_netdef((NetplanNetDefinition *)def, NETPLAN_DEF_TYPE_NONE, NETPLAN_BACKEND_NONE);
-    g_free(def);
 }
 
 NetplanParser*

--- a/src/sriov.h
+++ b/src/sriov.h
@@ -19,10 +19,4 @@
 #include "netplan.h"
 
 NETPLAN_INTERNAL gboolean
-netplan_state_finish_sriov_write(
-        const NetplanState* np_state,
-        const char* rootdir,
-        GError** error);
-
-NETPLAN_INTERNAL gboolean
 netplan_sriov_cleanup(const char* rootdir);

--- a/src/tests/fixtures/bond.yaml
+++ b/src/tests/fixtures/bond.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: false
+  bonds:
+    bond0:
+      dhcp4: yes
+      interfaces:
+        - eth0

--- a/src/tests/fixtures/bridge.yaml
+++ b/src/tests/fixtures/bridge.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp3s0:
+      dhcp4: no
+  bridges:
+    br0:
+      dhcp4: yes
+      interfaces:
+        - enp3s0

--- a/src/tests/fixtures/ovs.yaml
+++ b/src/tests/fixtures/ovs.yaml
@@ -1,0 +1,45 @@
+network:
+  version: 2
+  openvswitch:
+    protocols: [OpenFlow13, OpenFlow14, OpenFlow15]
+    ports:
+      - [patch0-1, patch1-0]
+    ssl:
+      ca-cert: /some/ca-cert.pem
+      certificate: /another/cert.pem
+      private-key: /private/key.pem
+    external-ids:
+      somekey: somevalue
+    other-config:
+      key: value
+  ethernets:
+    eth0:
+      addresses: [10.5.32.26/20]
+      openvswitch:
+        external-ids:
+          iface-id: mylocaliface
+        other-config:
+          disable-in-band: false
+    eth1: {}
+  bonds:
+    bond0:
+      interfaces: [patch1-0, eth1]
+      openvswitch:
+        lacp: passive
+      parameters:
+        mode: balance-tcp
+  bridges:
+    ovs0:
+      addresses: [10.5.48.11/20]
+      interfaces: [patch0-1, eth0, bond0]
+      openvswitch:
+        protocols: [OpenFlow10, OpenFlow11, OpenFlow12]
+        controller:
+          addresses: [unix:/var/run/openvswitch/ovs0.mgmt]
+          connection-mode: out-of-band
+        fail-mode: secure
+        mcast-snooping: true
+        external-ids:
+          iface-id: myhostname
+        other-config:
+          disable-in-band: true

--- a/src/tests/fixtures/ovs2.yaml
+++ b/src/tests/fixtures/ovs2.yaml
@@ -1,0 +1,11 @@
+network:
+  version: 2
+  openvswitch:
+    ports:
+      - [patch0-1, patch1-0]
+  bonds:
+    bond0:
+      interfaces: [patch1-0]
+  bridges:
+    ovs0:
+      interfaces: [patch0-1, bond0]

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -1,0 +1,14 @@
+tests = {
+  'test_netplan_parser': false,
+  'test_netplan_state': false,
+}
+
+cmocka = dependency('cmocka', required: true)
+
+foreach name, should_fail: tests
+  exe = executable(name,
+    '@0@.c'.format(name),
+    include_directories: inc,
+    dependencies: [cmocka, glib, gio, yaml, uuid])
+  test(name, exe, should_fail: should_fail)
+endforeach

--- a/src/tests/test_netplan_parser.c
+++ b/src/tests/test_netplan_parser.c
@@ -1,0 +1,153 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "../../include/netplan.h"
+#include "../../include/parse.h"
+
+#undef __USE_MISC
+#include "../error.c"
+#include "../names.c"
+#include "../validation.c"
+#include "../types.c"
+#include "../util.c"
+#include "../parse.c"
+
+void test_netplan_parser_new_parser(void** state) {
+    NetplanParser* npp = netplan_parser_new();
+    assert_non_null(npp);
+    netplan_parser_clear(&npp);
+}
+
+void test_netplan_parser_load_yaml(void** state) {
+    const char* filename = FIXTURESDIR "/ovs.yaml";
+    GError *error = NULL;
+    NetplanParser* npp = netplan_parser_new();
+
+    gboolean res = netplan_parser_load_yaml(npp, filename, &error);
+
+    assert_true(res);
+
+    netplan_error_free(&error);
+    netplan_parser_clear(&npp);
+}
+
+void
+test_netplan_parser_interface_has_bridge_netdef(void** state) {
+
+    const char* filename = FIXTURESDIR "/bridge.yaml";
+    GError *error = NULL;
+    NetplanParser *npp = netplan_parser_new();
+
+    gboolean res = netplan_parser_load_yaml(npp, filename, &error);
+    netplan_error_free(&error);
+
+    assert_true(res);
+
+    NetplanState *np_state = netplan_state_new();
+    res = netplan_state_import_parser_results(np_state, npp, &error);
+    netplan_error_free(&error);
+    assert_true(res);
+
+    NetplanNetDefinition* interface = g_hash_table_lookup(np_state->netdefs, "enp3s0");
+
+    NetplanNetDefinition* bridge = netplan_netdef_get_bridge_link(interface);
+
+    assert_non_null(interface);
+    assert_non_null(bridge);
+
+    assert_ptr_equal(interface->bridge_link, bridge);
+
+    netplan_state_clear(&np_state);
+    netplan_parser_clear(&npp);
+
+}
+
+void
+test_netplan_parser_interface_has_bond_netdef(void** state) {
+
+    const char* filename = FIXTURESDIR "/bond.yaml";
+    GError *error = NULL;
+    NetplanParser *npp = netplan_parser_new();
+
+    gboolean res = netplan_parser_load_yaml(npp, filename, &error);
+    netplan_error_free(&error);
+
+    assert_true(res);
+
+    NetplanState *np_state = netplan_state_new();
+    res = netplan_state_import_parser_results(np_state, npp, &error);
+    netplan_error_free(&error);
+    assert_true(res);
+
+    NetplanNetDefinition* interface = g_hash_table_lookup(np_state->netdefs, "eth0");
+
+    NetplanNetDefinition* bond = netplan_netdef_get_bond_link(interface);
+
+    assert_non_null(interface);
+    assert_non_null(bond);
+
+    assert_ptr_equal(interface->bond_link, bond);
+
+    netplan_state_clear(&np_state);
+    netplan_parser_clear(&npp);
+
+}
+
+void
+test_netplan_parser_interface_has_peer_netdef(void** state) {
+
+    const char* filename = FIXTURESDIR "/ovs.yaml";
+    GError *error = NULL;
+    NetplanParser *npp = netplan_parser_new();
+
+    gboolean res = netplan_parser_load_yaml(npp, filename, &error);
+    netplan_error_free(&error);
+
+    assert_true(res);
+
+    NetplanState *np_state = netplan_state_new();
+    res = netplan_state_import_parser_results(np_state, npp, &error);
+    netplan_error_free(&error);
+    assert_true(res);
+
+    NetplanNetDefinition* patch0 = g_hash_table_lookup(np_state->netdefs, "patch0-1");
+
+    NetplanNetDefinition* patch1 = netplan_netdef_get_peer_link(patch0);
+    patch0 = netplan_netdef_get_peer_link(patch1);
+
+    assert_non_null(patch0);
+    assert_non_null(patch1);
+
+    assert_ptr_equal(patch0->peer_link, patch1);
+    assert_ptr_equal(patch1->peer_link, patch0);
+
+    netplan_state_clear(&np_state);
+    netplan_parser_clear(&npp);
+
+}
+
+int setup(void** state) {
+    return 0;
+}
+
+int tear_down(void** state) {
+    return 0;
+}
+
+int main() {
+
+       const struct CMUnitTest tests[] = {
+           cmocka_unit_test(test_netplan_parser_new_parser),
+           cmocka_unit_test(test_netplan_parser_load_yaml),
+           cmocka_unit_test(test_netplan_parser_interface_has_bridge_netdef),
+           cmocka_unit_test(test_netplan_parser_interface_has_bond_netdef),
+           cmocka_unit_test(test_netplan_parser_interface_has_peer_netdef),
+       };
+
+       return cmocka_run_group_tests(tests, setup, tear_down);
+
+}

--- a/src/tests/test_netplan_state.c
+++ b/src/tests/test_netplan_state.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "../../include/netplan.h"
+#include "../../include/parse.h"
+
+#undef __USE_MISC
+#include "../error.c"
+#include "../names.c"
+#include "../validation.c"
+#include "../types.c"
+#include "../util.c"
+#include "../parse.c"
+
+void test_netplan_state_new_state(void** state) {
+    NetplanState* np_state = netplan_state_new();
+    assert_non_null(np_state);
+    netplan_state_clear(&np_state);
+}
+
+int setup(void** state) {
+    return 0;
+}
+
+int tear_down(void** state) {
+    return 0;
+}
+
+int main() {
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_netplan_state_new_state),
+    };
+
+    return cmocka_run_group_tests(tests, setup, tear_down);
+
+}

--- a/src/types.c
+++ b/src/types.c
@@ -263,8 +263,10 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
 
     FREE_AND_NULLIFY(netdef->bridge);
     FREE_AND_NULLIFY(netdef->bond);
-
     FREE_AND_NULLIFY(netdef->peer);
+    netdef->bridge_link = NULL;
+    netdef->bond_link = NULL;
+    netdef->peer_link = NULL;
 
     netdef->vlan_id = G_MAXUINT; /* 0 is a valid ID */
     netdef->vlan_link = NULL;
@@ -377,7 +379,7 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     netdef->ib_mode = NETPLAN_IB_MODE_KERNEL;
 }
 
-static void
+void
 clear_netdef_from_list(void *def)
 {
     reset_netdef((NetplanNetDefinition *)def, NETPLAN_DEF_TYPE_NONE, NETPLAN_BACKEND_NONE);
@@ -486,23 +488,55 @@ netplan_netdef_get_filepath(const NetplanNetDefinition* netdef, char* out_buffer
     return netplan_copy_string(netdef->filepath, out_buffer, out_buf_size);
 }
 
-NETPLAN_INTERNAL NetplanBackend
+NETPLAN_PUBLIC NetplanBackend
 netplan_netdef_get_backend(const NetplanNetDefinition* netdef)
 {
+    g_assert(netdef);
     return netdef->backend;
 }
 
-NETPLAN_INTERNAL NetplanDefType
+NETPLAN_PUBLIC NetplanDefType
 netplan_netdef_get_type(const NetplanNetDefinition* netdef)
 {
+    g_assert(netdef);
     return netdef->type;
 }
 
-NETPLAN_INTERNAL ssize_t
+NETPLAN_PUBLIC ssize_t
 netplan_netdef_get_id(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size)
 {
     g_assert(netdef);
     return netplan_copy_string(netdef->id, out_buffer, out_buf_size);
+}
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_vlan_link(const NetplanNetDefinition* netdef) {
+    g_assert(netdef);
+    return netdef->vlan_link;
+}
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_sriov_link(const NetplanNetDefinition* netdef) {
+    g_assert(netdef);
+    return netdef->sriov_link;
+}
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_bridge_link(const NetplanNetDefinition* netdef) {
+    g_assert(netdef);
+    return netdef->bridge_link;
+}
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_bond_link(const NetplanNetDefinition* netdef) {
+    g_assert(netdef);
+    return netdef->bond_link;
+}
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_netdef_get_peer_link(const NetplanNetDefinition* netdef) {
+    g_assert(netdef);
+    return netdef->peer_link;
 }
 
 gboolean
@@ -526,27 +560,15 @@ netplan_netdef_get_delay_virtual_functions_rebind(const NetplanNetDefinition* ne
     return netdef->sriov_delay_virtual_functions_rebind;
 }
 
-NETPLAN_INTERNAL gboolean
+NETPLAN_PUBLIC gboolean
 netplan_netdef_has_match(const NetplanNetDefinition* netdef)
 {
     return netdef->has_match;
 }
 
-NETPLAN_INTERNAL NetplanNetDefinition*
-_netplan_netdef_get_sriov_link(const NetplanNetDefinition* netdef)
-{
-    return netdef->sriov_link;
-}
-
 NETPLAN_INTERNAL gboolean
 _netplan_netdef_get_sriov_vlan_filter(const NetplanNetDefinition* netdef) {
     return netdef->sriov_vlan_filter;
-}
-
-NETPLAN_INTERNAL NetplanNetDefinition*
-_netplan_netdef_get_vlan_link(const NetplanNetDefinition* netdef)
-{
-    return netdef->vlan_link;
 }
 
 NETPLAN_INTERNAL guint

--- a/src/types.h
+++ b/src/types.h
@@ -280,3 +280,6 @@ route_clear(NetplanIPRoute** route);
 
 gboolean
 netplan_state_has_nondefault_globals(const NetplanState* np_state);
+
+void
+clear_netdef_from_list(void* def);

--- a/src/util.c
+++ b/src/util.c
@@ -781,7 +781,7 @@ netplan_netdef_match_interface(const NetplanNetDefinition* netdef, const char* n
     return TRUE;
 }
 
-NETPLAN_INTERNAL ssize_t
+NETPLAN_PUBLIC ssize_t
 netplan_netdef_get_set_name(const NetplanNetDefinition* netdef, char* out_buf, size_t out_size)
 {
     return netplan_copy_string(netdef->set_name, out_buf, out_size);

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -432,6 +432,69 @@ class TestNetDefinition(TestBase):
         self.assertTrue(state['br0'].is_trivial_compound_itf)
         self.assertFalse(state['br1'].is_trivial_compound_itf)
 
+    def test_interface_has_pointer_to_bridge(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      dhcp4: false
+  bridges:
+    br0:
+      dhcp4: false
+      interfaces:
+        - eth0
+      ''')
+
+        self.assertEqual(state['eth0'].bridge_link.id, "br0")
+
+    def test_interface_pointer_to_bridge_is_none(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      dhcp4: false
+      ''')
+
+        self.assertIsNone(state['eth0'].bridge_link)
+
+    def test_interface_has_pointer_to_bond(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      dhcp4: false
+  bonds:
+    bond0:
+      dhcp4: false
+      interfaces:
+        - eth0
+      ''')
+
+        self.assertEqual(state['eth0'].bond_link.id, "bond0")
+
+    def test_interface_pointer_to_bond_is_none(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      dhcp4: false
+      ''')
+
+        self.assertIsNone(state['eth0'].bond_link)
+
+    def test_interface_has_pointer_to_peer(self):
+        state = state_from_yaml(self.confdir, '''network:
+  openvswitch:
+    ports:
+      - [patch0-1, patch1-0]
+  bonds:
+    bond0:
+      interfaces:
+        - patch1-0
+  bridges:
+    ovs0:
+      interfaces: [patch0-1, bond0]
+      ''')
+
+        self.assertEqual(state['patch0-1'].peer_link.id, "patch1-0")
+        self.assertEqual(state['patch1-0'].peer_link.id, "patch0-1")
+
 
 class TestFreeFunctions(TestBase):
     def test_create_yaml_patch_bad_syntax(self):


### PR DESCRIPTION
 * Implement some of the new APIs described in [1] and add some functions that were intended for internal use to the public header files.
 * Implement/change unit tests related to the changes.
 * Introduce some unit tests written in C using the cmocka framework. The idea is to make it easier to catch runtime problems like memory errors. One can just build the tests with -fsanitize=address or run them with valgrind to check for problems. The new files will not be compiled by default, the new option -Dunit_testing=true must be used during the meson setup step.
 * Integrate the new tests with the meson build configuration.
 * Add a .gcovr file to exclude the new tests from the coverage test. It a future commit we might just move the new tests directory to another place.

[1] - https://discourse.ubuntu.com/t/spec-api-and-bindings-definition-for-libnetplan/29106


## Description

It's a work in progress, some APIs were not implemented yet.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

