### PR TITLE
Fix some memory leaks

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -332,6 +332,7 @@ int main(int argc, char** argv)
     }
 
 cleanup:
+    g_option_context_free(opt_context);
     if (npp)
         netplan_parser_clear(&npp);
     if (np_state)

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -319,7 +319,7 @@ cleanup:
 gboolean
 netplan_netdef_write_ovs(const NetplanState* np_state, const NetplanNetDefinition* def, const char* rootdir, gboolean* has_been_written, GError** error)
 {
-    GString* cmds = g_string_new(NULL);
+    g_autoptr(GString) cmds = g_string_new(NULL);
     gchar* dependency = NULL;
     const char* type = netplan_type_to_table_name(def->type);
     g_autofree char* base_config_path = NULL;
@@ -371,7 +371,7 @@ netplan_netdef_write_ovs(const NetplanState* np_state, const NetplanNetDefinitio
                 /* Set controller target addresses */
                 if (def->ovs_settings.controller.addresses && def->ovs_settings.controller.addresses->len > 0) {
                     if (!write_ovs_bridge_controller_targets(settings, &(def->ovs_settings.controller), def->id, cmds, error))
-                            return FALSE;
+                        return FALSE;
 
                     /* Set controller connection mode, only applicable if at least one controller target address was set */
                     if (def->ovs_settings.controller.connection_mode) {
@@ -449,7 +449,6 @@ netplan_netdef_write_ovs(const NetplanState* np_state, const NetplanNetDefinitio
     gboolean ret = TRUE;
     if (cmds->len > 0)
         ret = write_ovs_systemd_unit(def->id, cmds, rootdir, netplan_type_is_physical(def->type), FALSE, dependency, error);
-    g_string_free(cmds, TRUE);
     SET_OPT_OUT_PTR(has_been_written, TRUE);
     return ret;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -2570,16 +2570,17 @@ handle_ovs_backend(NetplanParser* npp, yaml_node_t* node, const char* key_prefix
         GList *external_ids = g_list_find_custom(values, "external-ids", (GCompareFunc) strcmp);
         /* Non-bond/non-bridge interfaces might still be handled by the networkd backend */
         if (len == 1 && (other_config || external_ids))
-            return ret;
+            goto cleanup;
         else if (len == 2 && other_config && external_ids)
-            return ret;
+            goto cleanup;
     }
-    g_list_free_full(values, g_free);
 
     /* Set the renderer for this device to NETPLAN_BACKEND_OVS, implicitly.
      * But only if empty "openvswitch: {}" or "openvswitch:" with more than
      * "other-config" or "external-ids" keys is given. */
     npp->current.netdef->backend = NETPLAN_BACKEND_OVS;
+cleanup:
+    g_list_free_full(values, g_free);
     return ret;
 }
 
@@ -3234,7 +3235,6 @@ netplan_state_import_parser_results(NetplanState* np_state, NetplanParser* npp, 
     /* We need to reset those fields manually as we transfered ownership of the underlying
        data to out. If we don't do this, netplan_clear_parser will deallocate data
        that we don't own anymore. */
-    npp->parsed_defs = NULL;
     npp->ordered = NULL;
     memset(&npp->global_ovs_settings, 0, sizeof(NetplanOVSSettings));
 

--- a/src/types.c
+++ b/src/types.c
@@ -50,8 +50,10 @@ free_hashtable_with_destructor(GHashTable** hash, void (destructor)(void *)) {
         GHashTableIter iter;
         gpointer key, value;
         g_hash_table_iter_init(&iter, *hash);
-        while (g_hash_table_iter_next(&iter, &key, &value))
+        while (g_hash_table_iter_next(&iter, &key, &value)) {
+            destructor(key);
             destructor(value);
+        }
         g_hash_table_destroy(*hash);
         *hash = NULL;
     }

--- a/src/util.c
+++ b/src/util.c
@@ -606,8 +606,11 @@ netplan_parser_load_yaml_hierarchy(NetplanParser* npp, const char* rootdir, GErr
     config_keys = g_list_sort(g_hash_table_get_keys(configs), (GCompareFunc) strcmp);
 
     for (GList* i = config_keys; i != NULL; i = i->next)
-        if (!netplan_parser_load_yaml(npp, g_hash_table_lookup(configs, i->data), error))
+        if (!netplan_parser_load_yaml(npp, g_hash_table_lookup(configs, i->data), error)) {
+            globfree(&gl);
             return FALSE;
+        }
+    globfree(&gl);
     return TRUE;
 }
 


### PR DESCRIPTION
    * generate.c: free the options context allocated at the start of the main
      function.

    * openvswitch.c: make sure the GString "cmds" is free'd before the
      function returns.

    * parse.c: free the temporary list "values" before the function
      returns.

    * parse.c: parsed_defs is set to NULL preventing
      netplan_parser_reset() to free the memory allocated for the
      hash table. Not setting it to NULL is safe because all the data is moved to
      another hash table, leaving parsed_defs with no elements. Not
      nullifying parsed_defs here allows netplan_parser_reset() to free
      it.

    * types.c: in this particular case we g_strdup both key and value
      strings when inserting them in the hash table in
      parse.c:handle_generic_map(). Calling the destructor for both of
      them will make sure all the memory is free'd. When using
      free_hashtable_with_destructor in the future we'll need to make
      sure both key and value are not poiting to the same place to avoid
      a double free.

    * util.c: release the glob_t allocated in find_yaml_glob().


## Description
The before and after can be seen by running the generate program with valgrind

assuming you have an etc/netplan in /tmp/fakeroot:
`valgrind --leak-check=full ./generate -r /tmp/fakeroot/`

It can also be checked by compiling netplan with ASAN:

`CFLAGS=-fsanitize=address meson setup build --prefix=/usr`
`meson compile -C build --verbose`
and then
`./generate -r /tmp/fakeroot/`

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

