### PR TITLE
cli:set: update only specific origin-hint if given (LP: #1997467)

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -44,6 +44,15 @@ netplan_parser_load_nullable_fields(NetplanParser* npp, int input_fd, NetplanErr
 NETPLAN_PUBLIC gboolean
 netplan_state_import_parser_results(NetplanState* np_state, NetplanParser* npp, NetplanError** error);
 
+/* Load the overrides, i.e. all global values (like "renderer") or Netdef-IDs
+ * that are part of the given YAML patch (<input_fd>), and are supposed to be
+ * overridden inside the yaml hierarchy by the resulting origin_hint file.
+ * They are supposed to be parsed from the origin-hint file given in
+ * <constraint> only. */
+NETPLAN_PUBLIC gboolean
+netplan_parser_load_nullable_overrides(
+    NetplanParser* npp, int input_fd, const char* constraint, GError** error);
+
 /********** Old API below this ***********/
 
 NETPLAN_PUBLIC gboolean

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -99,6 +99,10 @@ class Parser:
         lib.netplan_parser_load_nullable_fields.argtypes = [_NetplanParserP, c_int, _GErrorPP]
         lib.netplan_parser_load_nullable_fields.restype = c_int
 
+        lib.netplan_parser_load_nullable_overrides.argtypes =\
+            [_NetplanParserP, c_int, c_char_p, _GErrorPP]
+        lib.netplan_parser_load_nullable_overrides.restype = c_int
+
         cls._abi_loaded = True
 
     def __init__(self):
@@ -119,6 +123,10 @@ class Parser:
 
     def load_nullable_fields(self, input_file: IO):
         _checked_lib_call(lib.netplan_parser_load_nullable_fields, self._ptr, input_file.fileno())
+
+    def load_nullable_overrides(self, input_file: IO, constraint: str):
+        _checked_lib_call(lib.netplan_parser_load_nullable_overrides,
+                          self._ptr, input_file.fileno(), constraint.encode('utf-8'))
 
 
 class State:

--- a/src/generate.c
+++ b/src/generate.c
@@ -324,8 +324,10 @@ int main(int argc, char** argv)
             start_unit_jit("systemd-networkd-wait-online.service");
             start_unit_jit("systemd-networkd.service");
         }
-        g_autofree char* glob_run = g_strjoin(NULL, rootdir ?: "", G_DIR_SEPARATOR_S,
-                                              "run/systemd/system/netplan-*.service", NULL);
+        g_autofree char* glob_run = g_build_path(G_DIR_SEPARATOR_S,
+                                                 rootdir ?: G_DIR_SEPARATOR_S,
+                                                 "run/systemd/system/netplan-*.service",
+                                                 NULL);
         if (!glob(glob_run, 0, NULL, &gl)) {
             for (size_t i = 0; i < gl.gl_pathc; ++i) {
                 gchar *unit_name = g_path_get_basename(gl.gl_pathv[i]);

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Canonical, Ltd.
+ * Copyright (C) 2021-2023 Canonical, Ltd.
  * Author: Lukas Märdian <slyon@ubuntu.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -994,7 +994,7 @@ contains_netdef_type(gconstpointer value, gconstpointer user_data)
 }
 
 static gboolean
-netplan_netdef_list_write_yaml(const NetplanState* np_state, GList* netdefs, int out_fd, GError** error)
+netplan_netdef_list_write_yaml(const NetplanState* np_state, GList* netdefs, int out_fd, const char* out_fname, gboolean is_fallback, GError** error)
 {
     GHashTable *ovs_ports = NULL;
 
@@ -1018,11 +1018,27 @@ netplan_netdef_list_write_yaml(const NetplanState* np_state, GList* netdefs, int
     /* We support version 2 only, currently */
     YAML_NONNULL_STRING_PLAIN(event, emitter, "version", "2");
 
-    if (netplan_state_get_backend(np_state) == NETPLAN_BACKEND_NM) {
-        YAML_NONNULL_STRING_PLAIN(event, emitter, "renderer", "NetworkManager");
-    } else if (netplan_state_get_backend(np_state) == NETPLAN_BACKEND_NETWORKD) {
-        YAML_NONNULL_STRING_PLAIN(event, emitter, "renderer", "networkd");
+    /* fallback to default global handling, if renderer was not set for this file */
+    NetplanBackend renderer = netplan_state_get_backend(np_state);
+    /* Try to find a file specific (global) renderer.
+     * If this is the fallback file (70-netplan-set.yaml or <origin-hint>.yaml),
+     * a renderer parsed from a YAML patch takes precedence. */
+    if (out_fname && np_state->global_renderer) {
+        gpointer value;
+        renderer = GPOINTER_TO_INT(g_hash_table_lookup(np_state->global_renderer, out_fname));
+        /* A renderer parsed from an (anonymous) YAML patch takes precendence
+         * (e.g. "netplan set ..."). Such data does not have any filename
+         * associated to it in the global_renderer map (i.e. empty string). */
+        if (is_fallback && g_hash_table_lookup_extended(np_state->global_renderer, "", NULL, &value))
+            renderer = GPOINTER_TO_INT(value);
     }
+    if (renderer == NETPLAN_BACKEND_NM || renderer == NETPLAN_BACKEND_NETWORKD)
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "renderer", netplan_backend_name(renderer));
+
+    /* Do not write any netdefs, if we're just setting/updating some globals,
+     * e.g.: netplan set "network.renderer=NetworkManager" */
+    if (!netdefs)
+        goto skip_netdefs;
 
     /* Go through the netdefs type-by-type */
     for (unsigned i = 0; i < NETPLAN_DEF_TYPE_MAX_; ++i) {
@@ -1056,6 +1072,7 @@ netplan_netdef_list_write_yaml(const NetplanState* np_state, GList* netdefs, int
         }
     }
 
+skip_netdefs:
     write_openvswitch(event, emitter, &np_state->ovs_settings, NETPLAN_BACKEND_NONE, ovs_ports);
 
     /* Close remaining mappings */
@@ -1085,7 +1102,7 @@ file_error:
  * relevant.
  *
  * @np_state: the state for which to generate the config
- * @filename: Relevant file basename
+ * @filename: Relevant file basename (e.g. origin-hint.yaml)
  * @rootdir: If not %NULL, generate configuration in this root directory
  *           (useful for testing).
  */
@@ -1109,7 +1126,8 @@ netplan_state_write_yaml_file(const NetplanState* np_state, const char* filename
     }
 
     /* Remove any existing file if there is no data to write */
-    if (to_write == NULL) {
+    gboolean write_globals = !!np_state->global_renderer;
+    if (to_write == NULL && !write_globals) {
         if (unlink(path) && errno != ENOENT) {
             g_set_error(error, G_FILE_ERROR, errno, "%s", strerror(errno));
             return FALSE;
@@ -1124,7 +1142,7 @@ netplan_state_write_yaml_file(const NetplanState* np_state, const char* filename
         return FALSE;
     }
 
-    gboolean ret = netplan_netdef_list_write_yaml(np_state, to_write, out_fd, error);
+    gboolean ret = netplan_netdef_list_write_yaml(np_state, to_write, out_fd, path, TRUE, error);
     g_list_free(to_write);
     close(out_fd);
     if (ret) {
@@ -1149,7 +1167,7 @@ netplan_state_dump_yaml(const NetplanState* np_state, int out_fd, GError** error
     if (!np_state->netdefs_ordered && !netplan_state_has_nondefault_globals(np_state))
         return TRUE;
 
-    return netplan_netdef_list_write_yaml(np_state, np_state->netdefs_ordered, out_fd, error);
+    return netplan_netdef_list_write_yaml(np_state, np_state->netdefs_ordered, out_fd, NULL, TRUE, error);
 }
 
 /**
@@ -1198,11 +1216,12 @@ netplan_state_update_yaml_hierarchy(const NetplanState* np_state, const char* de
     g_hash_table_iter_init(&hash_iter, perfile_netdefs);
     while (g_hash_table_iter_next (&hash_iter, &key, &value)) {
         const char *filename = key;
+        gboolean is_fallback = (g_strcmp0(filename, default_path) == 0);
         GList* netdefs = value;
         out_fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0600);
         if (out_fd < 0)
             goto file_error;
-        if (!netplan_netdef_list_write_yaml(np_state, netdefs, out_fd, error))
+        if (!netplan_netdef_list_write_yaml(np_state, netdefs, out_fd, filename, is_fallback, error))
             goto cleanup; // LCOV_EXCL_LINE
         close(out_fd);
     }

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -182,6 +182,7 @@ struct netplan_state {
     /* Hashset of the source files used to create this state. Owns its data (glib-allocated
      * char*) and is initialized with g_hash_table_new_full to avoid leaks. */
     GHashTable* sources;
+    GHashTable* global_renderer;
 };
 
 struct netplan_parser {
@@ -241,6 +242,7 @@ struct netplan_parser {
     /* Which fields have been nullified by a subsequent patch? */
     GHashTable* null_fields;
     GHashTable* null_overrides;
+    GHashTable* global_renderer;
 };
 
 struct netplan_state_iterator {

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -240,6 +240,7 @@ struct netplan_parser {
 
     /* Which fields have been nullified by a subsequent patch? */
     GHashTable* null_fields;
+    GHashTable* null_overrides;
 };
 
 struct netplan_state_iterator {

--- a/src/types.c
+++ b/src/types.c
@@ -435,6 +435,11 @@ netplan_state_reset(NetplanState* np_state)
         g_hash_table_destroy(np_state->sources);
         np_state->sources = NULL;
     }
+
+    if (np_state->global_renderer) {
+        g_hash_table_destroy(np_state->global_renderer);
+        np_state->global_renderer = NULL;
+    }
 }
 
 NetplanBackend

--- a/src/util.c
+++ b/src/util.c
@@ -113,7 +113,9 @@ unlink_glob(const char* rootdir, const char* _glob)
 int find_yaml_glob(const char* rootdir, glob_t* out_glob)
 {
     int rc;
-    g_autofree char* rglob = g_strjoin(NULL, rootdir ?: "", G_DIR_SEPARATOR_S, "{lib,etc,run}/netplan/*.yaml", NULL);
+    g_autofree char* rglob = g_build_path(G_DIR_SEPARATOR_S,
+                                          rootdir ?: G_DIR_SEPARATOR_S,
+                                          "{lib,etc,run}/netplan/*.yaml", NULL);
     rc = glob(rglob, GLOB_BRACE, NULL, out_glob);
     if (rc != 0 && rc != GLOB_NOMATCH) {
         // LCOV_EXCL_START

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -43,6 +43,22 @@ test_netplan_parser_load_yaml(void** state)
 }
 
 void
+test_netplan_parser_load_nullable_overrides(void** state)
+{
+    const char* filename = FIXTURESDIR "/optional.yaml";
+    FILE* f = fopen(filename, "r");
+    GError *error = NULL;
+    NetplanParser* npp = netplan_parser_new();
+    assert_null(npp->null_overrides);
+    gboolean res = netplan_parser_load_nullable_overrides(npp, fileno(f), "hint.yaml", &error);
+    assert_true(res);
+    assert_non_null(npp->null_overrides);
+    assert_string_equal(g_hash_table_lookup(npp->null_overrides, "\tnetwork\trenderer"), "hint.yaml");
+    assert_string_equal(g_hash_table_lookup(npp->null_overrides, "\tnetwork\tethernets\teth0"), "hint.yaml");
+    netplan_parser_clear(&npp);
+}
+
+void
 test_netplan_parser_interface_has_bridge_netdef(void** state)
 {
 
@@ -200,6 +216,7 @@ main()
        const struct CMUnitTest tests[] = {
            cmocka_unit_test(test_netplan_parser_new_parser),
            cmocka_unit_test(test_netplan_parser_load_yaml),
+           cmocka_unit_test(test_netplan_parser_load_nullable_overrides),
            cmocka_unit_test(test_netplan_parser_interface_has_bridge_netdef),
            cmocka_unit_test(test_netplan_parser_interface_has_bond_netdef),
            cmocka_unit_test(test_netplan_parser_interface_has_peer_netdef),


### PR DESCRIPTION
## Description
This PR solves multiple issues in `netplan set`. First, deletion of origin-hint files on update (i.e. if the netdef is already contained inside the origin-hint file). This happens when repeatedly calling netplan set on the same origin-hint and netdef, e.g.:
```
    Starting with an empty Netplan config in /etc/netplan:
    $ netplan set --origin-hint test "bridges.br54.dhcp4=false"
    => will create test.yaml, containing the br54 definition
    $ netplan set --origin-hint test "bridges.br54.dhcp4=true"
    => updating the same br54 netdef (re-using 'netplan set') will delete test.yaml
```

This is fixed by the first commit:
* 8931bf367b4c5185c67113da05668c34eb190562 generate:util: fix double-slash root filepath

Next, when parsing the full YAML hierarchy, stanza updates might be siphoned away, as the same interface might have been defined in another file (e.g. 0-snapd-defaults.yaml) and therefore any updates are redirected to that previous file, or ignored if an origin-hint is passed, which does not match the previous filename (e.g. origin-hint: 90-snapd-config.yaml). Still we always need to parse the full YAML hierarchy in order to validate our data. For example, somebody might call `netplan set --origin-hint=test "ethernets.br54.interfaces=[eth0]"`, which will end up having the new `br54` data in `hint.yaml` but still relies on a definition of `eth0` in some other YAML file. If somebody calls `netplan set --origin-hint=test "ethernets.eth0.dhcp4=true"` OTOH, we want to ignore any previous definition of `eth0` and write our update into `hint.yaml` (assuming it will be a higher order file, compared to the existing YAML hierarchy).
We implemented a `load_nullable_overrides()` function, to ignore global values or netdefs that are supposed to be written into an origin-hint file.

Last, we want global values (like "renderer") to be conserved per file, instead of written to any new file. When writing a new file (e.g. origin-hint.yaml) we want any `renderer` value inside the YAML hierarchy to stay unchanged. Also, we only want to add a `renderer` stanza to the new file if that was given via a "netplan set ..." YAML patch (or an already existing origin-hint file already contains this stanza). So we need to track the global values on a per YAML file base and confirm the filename/path before writing those.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1997467

