### PR TITLE
NetworkManager 1.40 compat & file permission fixes (LP: #1862600, LP: #1997348)

### DIFF
--- a/src/abi_compat.c
+++ b/src/abi_compat.c
@@ -129,7 +129,7 @@ write_netplan_conf_full(const char* file_hint, const char* rootdir)
         !netplan_state_get_netdefs_size(&global_state))
         return;
     path = g_build_path(G_DIR_SEPARATOR_S, rootdir ?: G_DIR_SEPARATOR_S, "etc", "netplan", file_hint, NULL);
-    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0640);
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
     netplan_state_dump_yaml(&global_state, fd, NULL);
     close(fd);
 }

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -614,7 +614,9 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
     if (g_key_file_has_group(kf, "ethernet")) {
         /* wake-on-lan, do not clear passthrough as we do not fully support this setting */
         if (!g_key_file_has_key(kf, "ethernet", "wake-on-lan", NULL)) {
-            nd->wake_on_lan = TRUE; //NM's default is "1"
+            /* apply the default only to actual ethernet devices */
+            if (nd_type == NETPLAN_DEF_TYPE_ETHERNET)
+                nd->wake_on_lan = TRUE; //NM's default is "1"
         } else {
             guint value = g_key_file_get_uint64(kf, "ethernet", "wake-on-lan", NULL);
             //XXX: fix delta between options in NM (0x1, 0x2, 0x4, ...) and netplan (bool)

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -88,12 +88,16 @@ class TestGenerate(unittest.TestCase):
     def test_with_empty_config(self):
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
-        open(os.path.join(c, 'a.yaml'), 'w').close()
-        with open(os.path.join(c, 'b.yaml'), 'w') as f:
+        path_a = os.path.join(c, 'a.yaml')
+        path_b = os.path.join(c, 'b.yaml')
+        open(path_a, 'w').close()
+        with open(path_b, 'w') as f:
             f.write('''network:
   version: 2
   ethernets:
     enlol: {dhcp4: yes}''')
+        os.chmod(path_a, mode=0o600)
+        os.chmod(path_b, mode=0o600)
         out = subprocess.check_output(exe_cli + ['generate', '--root-dir', self.workdir.name], stderr=subprocess.STDOUT)
         self.assertEqual(out, b'')
         self.assertEqual(os.listdir(os.path.join(self.workdir.name, 'run', 'systemd', 'network')),

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -323,6 +323,7 @@ class TestBase(unittest.TestCase):
         if yaml is not None:
             with open(conf, 'w') as f:
                 f.write(yaml)
+            os.chmod(conf, mode=0o600)
             yaml_input.append(conf)
         if confs:
             for f, contents in confs.items():

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -74,7 +74,7 @@ class TestConfigArgs(TestBase):
   ethernets:
     eth0:
       dhcp4: true''', expect_fail=True, extra_args=['/non/existing/config'])
-        self.assertEqual(err, 'Cannot open /non/existing/config: No such file or directory\n')
+        self.assertEqual(err, 'Cannot stat /non/existing/config: No such file or directory\n')
         self.assertEqual(os.listdir(self.workdir.name), ['etc'])
 
     def test_help(self):

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -21,6 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import sys
 import signal
 import subprocess
@@ -87,6 +88,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
             f.write('''network:
   renderer: %(r)s
   version: 2''' % {'r': self.backend})
+            os.chmod(self.config, mode=0o600)
         p = subprocess.Popen(['netplan', 'try'], bufsize=1, universal_newlines=True,
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(2)
@@ -105,6 +107,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
             f.write('''network:
   renderer: %(r)s
   version: 2''' % {'r': self.backend})
+            os.chmod(self.config, mode=0o600)
         p = subprocess.Popen(['netplan', 'try'], bufsize=1, universal_newlines=True,
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(2)

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -124,7 +124,11 @@ class TestKeyfileBase(unittest.TestCase):
 
     def assert_netplan(self, file_contents_map):
         for uuid in file_contents_map.keys():
-            self.assertTrue(os.path.isfile(os.path.join(self.confdir, '90-NM-{}.yaml'.format(uuid))))
+            path = os.path.join(self.confdir, '90-NM-{}.yaml'.format(uuid))
+            self.assertTrue(os.path.isfile(path))
+            st = os.stat(path)
+            permission = oct(st.st_mode & 0o777)
+            self.assertEqual(permission, '0o600')
             with open(os.path.join(self.confdir, '90-NM-{}.yaml'.format(uuid)), 'r') as f:
                 self.assertEqual(f.read(), file_contents_map[uuid])
 

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1351,3 +1351,45 @@ dns-search=wallaceandgromit.com;
           ipv6.ip6-privacy: "-1"
           proxy._: ""
 '''.format(UUID, UUID)})
+
+    def test_keyfile_nm_140_default_ethernet_group(self):
+        self.generate_from_keyfile('''[connection]
+id=Test Write Bridge Main
+uuid={}
+type=bridge
+interface-name=br0
+
+[ethernet]
+
+[bridge]
+
+[ipv4]
+address1=1.2.3.4/24,1.1.1.1
+method=manual
+
+[ipv6]
+addr-gen-mode=default
+method=auto
+
+[proxy]\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  bridges:
+    NM-{}:
+      renderer: NetworkManager
+      addresses:
+      - "1.2.3.4/24"
+      dhcp6: true
+      networkmanager:
+        uuid: "{}"
+        name: "Test Write Bridge Main"
+        passthrough:
+          connection.interface-name: "br0"
+          ethernet._: ""
+          bridge._: ""
+          ipv4.address1: "1.2.3.4/24,1.1.1.1"
+          ipv4.method: "manual"
+          ipv6.addr-gen-mode: "default"
+          ipv6.ip6-privacy: "-1"
+          proxy._: ""
+'''.format(UUID, UUID)})


### PR DESCRIPTION
## Description
* add default "wakeonlan" settings for ethernet devices only (NetworkManager 1.40 compat)
* Write YAML files using 0o600 permission
* YAML files written by the user or a (external) tool (e.g. "netplan set", NetworkManager, subiquity, ...) can contain sensitive information (e.g. WiFi passwords), so should stay secret (root/owner read-only).

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1997348, LP#1862600

