### PR TITLE
Fix 'netplan ip leases' crash (LP: #1996941)

### DIFF
--- a/netplan/cli/commands/ip.py
+++ b/netplan/cli/commands/ip.py
@@ -147,6 +147,9 @@ class NetplanIpLeases(utils.NetplanCommand):
             out = subprocess.check_output(argv, universal_newlines=True)
         except CalledProcessError:  # pragma: nocover (better be covered in autopkgtest)
             sys.exit(1)
+        if not out:
+            print("Interface '%s' is not managed by Netplan" % self.interface, file=sys.stderr)
+            sys.exit(1)
         mapping = {}
         mapping_s = out.split(',')
         for keyvalue in mapping_s:

--- a/netplan/cli/commands/ip.py
+++ b/netplan/cli/commands/ip.py
@@ -147,9 +147,6 @@ class NetplanIpLeases(utils.NetplanCommand):
             out = subprocess.check_output(argv, universal_newlines=True)
         except CalledProcessError:  # pragma: nocover (better be covered in autopkgtest)
             sys.exit(1)
-        if not out:
-            print("Interface '%s' is not managed by Netplan" % self.interface, file=sys.stderr)
-            sys.exit(1)
         mapping = {}
         mapping_s = out.split(',')
         for keyvalue in mapping_s:

--- a/netplan/cli/commands/ip.py
+++ b/netplan/cli/commands/ip.py
@@ -146,6 +146,7 @@ class NetplanIpLeases(utils.NetplanCommand):
         try:
             out = subprocess.check_output(argv, universal_newlines=True)
         except CalledProcessError:  # pragma: nocover (better be covered in autopkgtest)
+            print("No lease found for interface '%s' (not managed by Netplan)" % self.interface, file=sys.stderr)
             sys.exit(1)
         mapping = {}
         mapping_s = out.split(',')

--- a/src/generate.c
+++ b/src/generate.c
@@ -250,16 +250,20 @@ int main(int argc, char** argv)
     np_state = netplan_state_new();
     CHECK_CALL(netplan_state_import_parser_results(np_state, npp, &error));
 
+    if (mapping_iface) {
+        if (np_state->netdefs)
+            error_code = find_interface(mapping_iface, np_state->netdefs);
+        else
+            error_code = 1;
+
+        goto cleanup;
+    }
+
     /* Clean up generated config from previous runs */
     netplan_networkd_cleanup(rootdir);
     netplan_nm_cleanup(rootdir);
     netplan_ovs_cleanup(rootdir);
     netplan_sriov_cleanup(rootdir);
-
-    if (mapping_iface && np_state->netdefs) {
-        error_code = find_interface(mapping_iface, np_state->netdefs);
-        goto cleanup;
-    }
 
     /* Generate backend specific configuration files from merged data. */
     CHECK_CALL(netplan_state_finish_ovs_write(np_state, rootdir, &error)); // OVS cleanup unit is always written

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -785,27 +785,5 @@ class TestIp(unittest.TestCase):
         self.assertIn(b'No lease found', err)
         self.assertNotEqual(p.returncode, 0)
 
-    def test_ip_leases_generate_mapping_is_empty(self):
-        mock_generate = MockCmd('generate')
-        # When the interface in not defined in any netplan yaml file
-        # the command 'generate --mapping <interface>' will return nothing
-        mock_generate.set_output('')
-        os.environ.setdefault('NETPLAN_GENERATE_PATH', mock_generate.path)
-
-        c = os.path.join(self.workdir.name, 'etc', 'netplan')
-        os.makedirs(c)
-        with open(os.path.join(c, 'a.yaml'), 'w') as f:
-            f.write('''network:
-  version: 2
-  renderer: NetworkManager
-''')
-        p = subprocess.Popen(exe_cli +
-                             ['ip', 'leases', '--root-dir', self.workdir.name, 'enlol'],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        (out, err) = p.communicate()
-        self.assertEqual(out, b'')
-        self.assertIn(b"Interface 'enlol' is not managed by Netplan", err)
-        self.assertNotEqual(p.returncode, 0)
-
 
 unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -785,5 +785,24 @@ class TestIp(unittest.TestCase):
         self.assertIn(b'No lease found', err)
         self.assertNotEqual(p.returncode, 0)
 
+    def test_ip_leases_no_netdefs(self):
+        os.environ.setdefault('NETPLAN_GENERATE_PATH', os.path.join(rootdir, 'generate'))
+
+        c = os.path.join(self.workdir.name, 'etc', 'netplan')
+        os.makedirs(c)
+        with open(os.path.join(c, 'a.yaml'), 'w') as f:
+            f.write('''network:
+  version: 2
+  renderer: NetworkManager
+''')
+        # we didn't create a (mock) lease file, therefore expect stderr output
+        p = subprocess.Popen(exe_cli +
+                             ['ip', 'leases', '--root-dir', self.workdir.name, 'enlol'],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (out, err) = p.communicate()
+        self.assertEqual(out, b'')
+        self.assertIn(b"No lease found for interface 'enlol' (not managed by Netplan)", err)
+        self.assertNotEqual(p.returncode, 0)
+
 
 unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
When the interface is not defined in the Netplan configuration, the command 'generate --mapping' will return nothing.


## Description

Fix for [LP#1996941](https://bugs.launchpad.net/netplan/+bug/1996941)

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

