### PR TITLE
Migrate from (deprecated) nose to pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+concurrency = multiprocessing

--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -48,4 +48,4 @@ jobs:
           dch -v $(git describe --tags) "Autopkgtest CI testing (Jammy)"
       - name: Run autopkgtest (incl. build)
         run: |
-          sudo autopkgtest . -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/jammy/amd64
+          sudo autopkgtest . --setup-commands='apt -y install python3-pytest python3-pytest-cov' -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/jammy/amd64

--- a/.github/workflows/build-abi.yml
+++ b/.github/workflows/build-abi.yml
@@ -28,7 +28,7 @@ jobs:
           sudo sed -i '/deb-src/s/^# //' /etc/apt/sources.list
           sudo apt update
           #sudo apt install lcov python3-coverage curl
-          sudo apt install abigail-tools meson
+          sudo apt install abigail-tools meson python3-coverage python3-pytest python3-pytest-cov
           sudo apt build-dep netplan.io
 
       # Runs the build

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -28,7 +28,7 @@ jobs:
           echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
           sudo sed -i '/deb-src/s/^# //' /etc/apt/sources.list
           sudo apt update
-          sudo apt install python3-coverage curl meson gcovr expect
+          sudo apt install python3-coverage python3-pytest python3-pytest-cov curl meson gcovr expect
           sudo apt build-dep netplan.io
 
       # Runs the unit tests with coverage

--- a/TODO
+++ b/TODO
@@ -36,8 +36,6 @@
 
 - integrate 'netplan try' in tmux/screen
 
-- replace nose for python tests with something else, preserving coverage reports
-
 - add automated integration tests for WPA Enterprise / 802.1x that can run self-contained
 
 # After soname bump (ABI break)

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,8 @@ bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', def
 # Order: Fedora/Mageia/openSUSE || Debian/Ubuntu
 pyflakes = find_program('pyflakes-3', 'pyflakes3', required: false)
 pycodestyle = find_program('pycodestyle-3', 'pycodestyle', 'pep8', required: false)
-nose = find_program('nosetests-3', 'nosetests3')
+pytest = find_program('pytest-3', 'pytest3')  # also requires the pytest-cov plugin
+pycoverage = find_program('python3-coverage')
 pandoc = find_program('pandoc', required: false)
 find = find_program('find')
 
@@ -61,6 +62,7 @@ test_env = [
     'LD_LIBRARY_PATH=' + join_paths(meson.current_build_dir(), 'src'),
     'NETPLAN_GENERATE_PATH=' + join_paths(meson.current_build_dir(), 'src', 'generate'),
     'NETPLAN_DBUS_CMD=' + join_paths(meson.current_build_dir(), 'dbus', 'netplan-dbus'),
+    'COVERAGE_PROCESS_START=' + join_paths(meson.current_source_dir(), '.coveragerc'),
 ]
 #FIXME: exclude doc/env/
 test('linting',
@@ -78,8 +80,8 @@ test('legacy-tests',
      env: test_env)
 #TODO: split out dbus tests into own test() instance, to run in parallel
 test('unit-tests',
-     nose,
-     args: ['-v', '--with-coverage', meson.current_source_dir()],
+     pycoverage,
+     args: ['run', '-a', '-m', 'pytest', '-s', '-v', '--cov-append', meson.current_source_dir()],
      timeout: 600,
      env: test_env)
 
@@ -94,7 +96,6 @@ if get_option('b_coverage')
     gcovr = find_program('gcovr')
     ninja = find_program('ninja')
     grep  = find_program('grep')
-    pycoverage = find_program('python3-coverage')
     test('coverage-c-output',
          find_program('ninja'),
          args: ['-C', meson.current_build_dir(), 'coverage'],
@@ -103,6 +104,11 @@ if get_option('b_coverage')
     test('coverage-c',
          grep,
          args: ['^TOTAL.*100%$', join_paths(meson.current_build_dir(), 'meson-logs', 'coverage.txt')],
+         priority: -99, # run last
+         is_parallel: false)
+    test('coverage-py-combine',
+         pycoverage,
+         args: ['combine', '-a', meson.current_build_dir()],
          priority: -99, # run last
          is_parallel: false)
     test('coverage-py-output',

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,2 @@
+import coverage
+coverage.process_startup()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,8 @@ parts:
       - python3-coverage
       - python3-yaml
       - python3-netifaces
-      - python3-nose
+      - python3-pytest
+      - python3-pytest-cov
       - pyflakes3
       - pep8
       - systemd

--- a/tests/dbus/test_dbus.py
+++ b/tests/dbus/test_dbus.py
@@ -120,7 +120,7 @@ class TestNetplanDBus(unittest.TestCase):
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         self.assertEqual(p.stdout.read(), b"")
         self.assertEqual(p.stderr.read(), b"")
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
+        self.assertEqual(self.mock_netplan_cmd.calls(), [
             ["netplan", "apply"],
         ])
 
@@ -135,7 +135,7 @@ class TestNetplanDBus(unittest.TestCase):
         p.wait(10)
         self.assertEqual(p.stdout.read(), b"")
         self.assertEqual(p.stderr.read(), b"")
-        self.assertEquals(self.mock_busctl_cmd.calls(), [
+        self.assertEqual(self.mock_busctl_cmd.calls(), [
             ["busctl", "call", "--quiet", "--system",
              "io.netplan.Netplan",  # the service
              "/io/netplan/Netplan",  # the object
@@ -181,7 +181,7 @@ class TestNetplanDBus(unittest.TestCase):
         p.wait(10)
         self.assertEqual(p.stdout.read(), b"")
         self.assertEqual(p.stderr.read(), b"")
-        self.assertEquals(self.mock_busctl_cmd.calls(), [
+        self.assertEqual(self.mock_busctl_cmd.calls(), [
             ["busctl", "call", "--quiet", "--system",
              "io.netplan.Netplan",  # the service
              "/io/netplan/Netplan",  # the object
@@ -217,7 +217,7 @@ class TestNetplanDBus(unittest.TestCase):
     def test_netplan_dbus_noroot(self):
         # Process should fail instantly, if not: kill it after 5 sec
         r = subprocess.run(NETPLAN_DBUS_CMD, timeout=5, capture_output=True)
-        self.assertEquals(r.returncode, 1)
+        self.assertEqual(r.returncode, 1)
         self.assertIn(b'Failed to acquire service name', r.stderr)
 
     def test_netplan_dbus_happy(self):
@@ -231,7 +231,7 @@ class TestNetplanDBus(unittest.TestCase):
         output = subprocess.check_output(BUSCTL_NETPLAN_APPLY)
         self.assertEqual(output.decode("utf-8"), "b true\n")
         # one call to netplan apply in total
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
+        self.assertEqual(self.mock_netplan_cmd.calls(), [
                 ["netplan", "apply"],
         ])
 
@@ -239,7 +239,7 @@ class TestNetplanDBus(unittest.TestCase):
         output = subprocess.check_output(BUSCTL_NETPLAN_APPLY)
         self.assertEqual(output.decode("utf-8"), "b true\n")
         # and another call to netplan apply
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
+        self.assertEqual(self.mock_netplan_cmd.calls(), [
                 ["netplan", "apply"],
                 ["netplan", "apply"],
         ])
@@ -255,7 +255,7 @@ class TestNetplanDBus(unittest.TestCase):
         output = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(output.decode("utf-8"), "b true\n")
         # one call to netplan apply in total
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
+        self.assertEqual(self.mock_netplan_cmd.calls(), [
                 ["netplan", "generate"],
         ])
 
@@ -297,7 +297,7 @@ class TestNetplanDBus(unittest.TestCase):
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD, universal_newlines=True)
         self.assertIn(r's ""', out)  # No output as 'netplan get' is actually mocked
-        self.assertEquals(self.mock_netplan_cmd.calls(), [[
+        self.assertEqual(self.mock_netplan_cmd.calls(), [[
             "netplan", "get", "all", "--root-dir={}".format(tmpdir)
         ]])
 
@@ -332,7 +332,7 @@ class TestNetplanDBus(unittest.TestCase):
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
-        self.assertEquals(self.mock_netplan_cmd.calls(), [[
+        self.assertEqual(self.mock_netplan_cmd.calls(), [[
             "netplan", "set", "ethernets.eth42.dhcp6=true",
             "--root-dir={}".format(tmpdir)
         ]])
@@ -353,7 +353,7 @@ class TestNetplanDBus(unittest.TestCase):
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD, universal_newlines=True)
         self.assertIn(r's "network:\n  eth42:\n    dhcp6: true\n"', out)
-        self.assertEquals(self.mock_netplan_cmd.calls(), [[
+        self.assertEqual(self.mock_netplan_cmd.calls(), [[
             "netplan", "get", "all", "--root-dir={}".format(tmpdir)
         ]])
 
@@ -405,8 +405,8 @@ class TestNetplanDBus(unittest.TestCase):
         ]
         out = subprocess.check_output(BUSCTL_NETPLAN_CMD)
         self.assertEqual(b'b true\n', out)
-        self.assertEquals(self.mock_netplan_cmd.calls(),
-                          [["netplan", "apply", "--state=%s/run/netplan/config-BACKUP" % self.tmp]])
+        self.assertEqual(self.mock_netplan_cmd.calls(),
+                         [["netplan", "apply", "--state=%s/run/netplan/config-BACKUP" % self.tmp]])
         time.sleep(1)  # Give some time for 'Apply' to clean up
         self.assertFalse(os.path.isdir(tmpdir))
 
@@ -491,8 +491,8 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertIn('Unknown object \'/io/netplan/Netplan/config/{}\''.format(cid), err)
 
         # Verify 'netplan try' has been called
-        self.assertEquals(self.mock_netplan_cmd.calls(),
-                          [["netplan", "try", "--timeout=3", "--state=%s/run/netplan/config-BACKUP" % self.tmp]])
+        self.assertEqual(self.mock_netplan_cmd.calls(),
+                         [["netplan", "try", "--timeout=3", "--state=%s/run/netplan/config-BACKUP" % self.tmp]])
 
     def test_netplan_dbus_config_try_cb(self):
         self.mock_netplan_cmd.touch(self._netplan_try_stamp)
@@ -533,8 +533,8 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertIn('Unknown object \'/io/netplan/Netplan/config/{}\''.format(cid), err)
 
         # Verify 'netplan try' has been called
-        self.assertEquals(self.mock_netplan_cmd.calls(),
-                          [["netplan", "try", "--timeout=1", "--state=%s/run/netplan/config-BACKUP" % self.tmp]])
+        self.assertEqual(self.mock_netplan_cmd.calls(),
+                         [["netplan", "try", "--timeout=1", "--state=%s/run/netplan/config-BACKUP" % self.tmp]])
 
     def test_netplan_dbus_config_try_apply(self):
         self.mock_netplan_cmd.touch(self._netplan_try_stamp)
@@ -668,7 +668,7 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEqual(b'b true\n', out)
 
         # Verify that Set()/Apply() was only called by one config object
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
+        self.assertEqual(self.mock_netplan_cmd.calls(), [
             ["netplan", "set", "ethernets.eth0.dhcp4=true", "--origin-hint=70-snapd",
              "--root-dir={}/run/netplan/config-{}".format(self.tmp, cid)],
             ["netplan", "set", "ethernets.eth0.dhcp4=yes", "--origin-hint=70-snapd",
@@ -738,7 +738,7 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEqual(b'b true\n', out)
 
         # Verify the call stack
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
+        self.assertEqual(self.mock_netplan_cmd.calls(), [
             ["netplan", "set", "ethernets.eth0.dhcp4=true", "--origin-hint=70-snapd",
              "--root-dir={}/run/netplan/config-{}".format(self.tmp, cid)],
             ["netplan", "set", "ethernets.eth0.dhcp4=false", "--origin-hint=70-snapd",
@@ -788,7 +788,7 @@ class TestNetplanDBus(unittest.TestCase):
         self.assertEqual(b'b true\n', out)
 
         # Verify the call stack
-        self.assertEquals(self.mock_netplan_cmd.calls(), [
+        self.assertEqual(self.mock_netplan_cmd.calls(), [
             ["netplan", "set", "ethernets.eth0.dhcp4=true", "--origin-hint=70-snapd",
              "--root-dir={}/run/netplan/config-{}".format(self.tmp, cid)],
             ["netplan", "try", "--timeout=1", "--state=%s/run/netplan/config-BACKUP" % self.tmp],

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -1432,7 +1432,7 @@ method=ignore
             m = re.search('uuid=([0-9a-fA-F-]{36})\n', f.read())
             self.assertTrue(m)
             uuid = m.group(1)
-            self.assertNotEquals(uuid, "00000000-0000-0000-0000-000000000000")
+            self.assertNotEqual(uuid, "00000000-0000-0000-0000-000000000000")
 
         self.assert_nm({'vx0': '''[connection]
 id=netplan-vx0

--- a/tests/generator/test_vlans.py
+++ b/tests/generator/test_vlans.py
@@ -220,7 +220,7 @@ ip6-privacy=0
             m = re.search('uuid=([0-9a-fA-F-]{36})\n', f.read())
             self.assertTrue(m)
             uuid = m.group(1)
-            self.assertNotEquals(uuid, "00000000-0000-0000-0000-000000000000")
+            self.assertNotEqual(uuid, "00000000-0000-0000-0000-000000000000")
 
         self.assert_nm({'en-v': '''[connection]
 id=netplan-en-v

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -74,7 +74,7 @@ class TestNetworkd(TestBase):
             freqs = freqs[1].split('\n')[0]
             self.assertEqual(len(freqs.split(' ')), len(freqs_5GHz))
             for freq in freqs_5GHz:
-                self.assertRegexpMatches(new_config, '{}[ 0-9]*{}[ 0-9]*\n'.format(network, freq))
+                self.assertRegex(new_config, '{}[ 0-9]*{}[ 0-9]*\n'.format(network, freq))
 
             network = 'ssid="{}"\n  freq_list='.format('band-no-channel')
             freqs_24GHz = [2412, 2417, 2422, 2427, 2432, 2442, 2447, 2437, 2452, 2457, 2462, 2467, 2472, 2484]
@@ -82,7 +82,7 @@ class TestNetworkd(TestBase):
             freqs = freqs[1].split('\n')[0]
             self.assertEqual(len(freqs.split(' ')), len(freqs_24GHz))
             for freq in freqs_24GHz:
-                self.assertRegexpMatches(new_config, '{}[ 0-9]*{}[ 0-9]*\n'.format(network, freq))
+                self.assertRegex(new_config, '{}[ 0-9]*{}[ 0-9]*\n'.format(network, freq))
 
             self.assertIn('''
 network={

--- a/tests/test_cli_units.py
+++ b/tests/test_cli_units.py
@@ -82,14 +82,14 @@ class TestCLI(unittest.TestCase):
                                                ['br0', 'vlan2'],
                                                devices=['br0', 'vlan2', 'eth0'])
         mock.assert_not_called()
-        self.assertEquals(res, [])
+        self.assertEqual(res, [])
 
     @patch('subprocess.check_call')
     def test_clear_virtual_links_no_devices(self, mock):
         with self.assertLogs('', level='INFO') as ctx:
             res = NetplanApply.clear_virtual_links(['br0', 'br1'],
                                                    ['br0'])
-            self.assertEquals(res, [])
+            self.assertEqual(res, [])
             self.assertEqual(ctx.output, ['WARNING:root:Cannot clear virtual links: no network interfaces provided.'])
         mock.assert_not_called()
 

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -45,21 +45,21 @@ class TestTerminal(unittest.TestCase):
         self.terminal.enable_nonblocking_io()
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
         self.assertTrue(flags & os.O_NONBLOCK)
-        self.assertNotEquals(flags, orig_flags)
+        self.assertNotEqual(flags, orig_flags)
         self.terminal.disable_nonblocking_io()
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
         self.assertFalse(flags & os.O_NONBLOCK)
-        self.assertEquals(flags, orig_flags)
+        self.assertEqual(flags, orig_flags)
 
     def test_save(self):
         self.terminal.enable_nonblocking_io()
         flags = self.terminal.orig_flags
         self.terminal.save()
         self.terminal.disable_nonblocking_io()
-        self.assertNotEquals(flags, self.terminal.orig_flags)
+        self.assertNotEqual(flags, self.terminal.orig_flags)
         self.terminal.reset()
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
-        self.assertEquals(flags, self.terminal.orig_flags)
+        self.assertEqual(flags, self.terminal.orig_flags)
         self.terminal.disable_nonblocking_io()
         self.terminal.save()
 
@@ -69,10 +69,10 @@ class TestTerminal(unittest.TestCase):
         self.terminal.save(orig_settings)
         self.terminal.disable_nonblocking_io()
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
-        self.assertNotEquals(flags, orig_settings.get('flags'))
+        self.assertNotEqual(flags, orig_settings.get('flags'))
         self.terminal.reset(orig_settings)
         flags = fcntl.fcntl(self.terminal.fd, fcntl.F_GETFL)
-        self.assertEquals(flags, orig_settings.get('flags'))
+        self.assertEqual(flags, orig_settings.get('flags'))
         self.terminal.disable_nonblocking_io()
 
     def test_reset(self):

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import fcntl
-import sys
 import os
 import termios
 import unittest
@@ -25,11 +24,10 @@ import unittest
 import netplan.terminal
 
 
-@unittest.skipUnless(sys.__stdin__.isatty(), "not supported when run from a script")
 class TestTerminal(unittest.TestCase):
 
     def setUp(self):
-        self.terminal = netplan.terminal.Terminal(sys.stdin.fileno())
+        self.terminal = netplan.terminal.Terminal(0)
 
     def test_echo(self):
         self.terminal.disable_echo()

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import fcntl
+import sys
 import os
 import termios
 import unittest
@@ -24,10 +25,11 @@ import unittest
 import netplan.terminal
 
 
+@unittest.skipUnless(sys.__stdin__.isatty(), "not supported when run from a script")
 class TestTerminal(unittest.TestCase):
 
     def setUp(self):
-        self.terminal = netplan.terminal.Terminal(0)
+        self.terminal = netplan.terminal.Terminal(sys.stdin.fileno())
 
     def test_echo(self):
         self.terminal.disable_echo()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -248,7 +248,7 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_systemctl.path) + os.pathsep + path_env
         utils.systemctl('start', ['service1', 'service2'])
-        self.assertEquals(self.mock_systemctl.calls(), [['systemctl', 'start', '--no-block', 'service1', 'service2']])
+        self.assertEqual(self.mock_systemctl.calls(), [['systemctl', 'start', '--no-block', 'service1', 'service2']])
 
     def test_networkd_interfaces(self):
         self.mock_networkctl = MockCmd('networkctl')
@@ -260,7 +260,7 @@ class TestUtils(unittest.TestCase):
   3 wlan0           wlan     routable   configuring
 174 wwan0           wwan     off        linger''')
         res = utils.networkd_interfaces()
-        self.assertEquals(self.mock_networkctl.calls(), [['networkctl', '--no-pager', '--no-legend']])
+        self.assertEqual(self.mock_networkctl.calls(), [['networkctl', '--no-pager', '--no-legend']])
         self.assertIn('2', res)
         self.assertIn('3', res)
 
@@ -269,7 +269,7 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_networkctl.path) + os.pathsep + path_env
         utils.networkctl_reload()
-        self.assertEquals(self.mock_networkctl.calls(), [
+        self.assertEqual(self.mock_networkctl.calls(), [
             ['networkctl', 'reload']
         ])
 
@@ -278,7 +278,7 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_networkctl.path) + os.pathsep + path_env
         utils.networkctl_reconfigure(['3', '5'])
-        self.assertEquals(self.mock_networkctl.calls(), [
+        self.assertEqual(self.mock_networkctl.calls(), [
             ['networkctl', 'reconfigure', '3', '5']
         ])
 
@@ -287,7 +287,7 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         self.assertTrue(utils.is_nm_snap_enabled())
-        self.assertEquals(self.mock_cmd.calls(), [
+        self.assertEqual(self.mock_cmd.calls(), [
             ['systemctl', '--quiet', 'is-enabled', 'snap.network-manager.networkmanager.service']
         ])
 
@@ -297,7 +297,7 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         self.assertFalse(utils.is_nm_snap_enabled())
-        self.assertEquals(self.mock_cmd.calls(), [
+        self.assertEqual(self.mock_cmd.calls(), [
             ['systemctl', '--quiet', 'is-enabled', 'snap.network-manager.networkmanager.service']
         ])
 
@@ -306,7 +306,7 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         utils.systemctl_network_manager('start')
-        self.assertEquals(self.mock_cmd.calls(), [
+        self.assertEqual(self.mock_cmd.calls(), [
             ['systemctl', '--quiet', 'is-enabled', 'snap.network-manager.networkmanager.service'],
             ['systemctl', 'start', '--no-block', 'snap.network-manager.networkmanager.service']
         ])
@@ -316,7 +316,7 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         self.assertTrue(utils.systemctl_is_active('some.service'))
-        self.assertEquals(self.mock_cmd.calls(), [
+        self.assertEqual(self.mock_cmd.calls(), [
             ['systemctl', '--quiet', 'is-active', 'some.service']
         ])
 
@@ -326,7 +326,7 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         self.assertFalse(utils.systemctl_is_active('some.service'))
-        self.assertEquals(self.mock_cmd.calls(), [
+        self.assertEqual(self.mock_cmd.calls(), [
             ['systemctl', '--quiet', 'is-active', 'some.service']
         ])
 
@@ -335,7 +335,7 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         utils.systemctl_daemon_reload()
-        self.assertEquals(self.mock_cmd.calls(), [
+        self.assertEqual(self.mock_cmd.calls(), [
             ['systemctl', 'daemon-reload']
         ])
 
@@ -344,6 +344,6 @@ class TestUtils(unittest.TestCase):
         path_env = os.environ['PATH']
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         utils.ip_addr_flush('eth42')
-        self.assertEquals(self.mock_cmd.calls(), [
+        self.assertEqual(self.mock_cmd.calls(), [
             ['ip', 'addr', 'flush', 'eth42']
         ])


### PR DESCRIPTION
Pytest and pycoverage require some extra configuration to track test coverage in tests that spawn subprocesses. The new files .coveragerc and sitecustomize.py are intended to enable support for subprocesses.

The test set test_terminal.py is completely skipped when testing on my system and, because of that, coverage test was reporting a low coverage. I still need to see it running in our automation to validate if we still need to skip them. Another workaround would be add a nocover to the Terminal class.

Also:
  - Fix some deprecation warnings in some tests.
  - Remove this task from the TODO list :)


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

