### PR TITLE
Check and fix non-inclusive laguange

### DIFF
--- a/.github/workflows/check-wording.yaml
+++ b/.github/workflows/check-wording.yaml
@@ -17,3 +17,4 @@ jobs:
         uses: get-woke/woke-action@v0
         with:
           fail-on-error: true
+          woke-args: -o text

--- a/.github/workflows/check-wording.yaml
+++ b/.github/workflows/check-wording.yaml
@@ -16,5 +16,4 @@ jobs:
       - name: Run Woke action
         uses: get-woke/woke-action@v0
         with:
-          # Let's not fail by default while we work to fix our existing code base
-          fail-on-error: false
+          fail-on-error: true

--- a/.github/workflows/check-wording.yaml
+++ b/.github/workflows/check-wording.yaml
@@ -1,0 +1,20 @@
+name: Check for non-inclusive language
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Woke action
+        uses: get-woke/woke-action@v0
+        with:
+          # Let's not fail by default while we work to fix our existing code base
+          fail-on-error: false

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,12 +1,5 @@
 ignore_files:
   - abi-compat/*.xml
-  - tests/generator/test_vrfs.py
-  - tests/generator/test_passthrough.py
-  - tests/parser/test_keyfile.py
-  - tests/generator/test_bridges.py
-  - tests/generator/test_bonds.py
-  - tests/generator/test_tunnels.py
-  - tests/generator/test_common.py
 rules:
   # Including some terms from https://inclusivenaming.org/ that are not in the default ruleset
   - name: abort

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,15 +1,4 @@
 rules:
-  - name: slave
-    terms:
-      - slave
-    alternatives:
-      - follower
-      - replica
-      - standby
-    options:
-      # trigger findings when they are surrounded by ASCII word boundaries
-      word_boundary: true
-
   # Including some terms from https://inclusivenaming.org/ that are not in the default ruleset
   - name: abort
     terms:
@@ -34,3 +23,160 @@ rules:
       - segment/segmentation
       - separate/separation
 
+  # From https://github.com/canonical/Inclusive-naming
+  # Overtly racist terms
+  - name: whitelist
+    terms:
+      - whitelist
+      - white-list
+      - whitelisted
+      - white-listed
+      - whitelisting
+      - white-listing
+    alternatives:
+      - allowlist
+    severity: warning
+
+  - name: blacklist
+    terms:
+      - blacklist
+      - black-list
+      - blacklisted
+      - black-listed
+      - blacklisting
+      - black-listing
+    alternatives:
+      - denylist
+      - blocklist
+    severity: warning
+
+  - name: blackhat
+    terms:
+      - blackhat
+      - black hat
+    alternatives:
+      - malicious actor
+      - attacker
+    severity: warning
+
+  - name: illegal characters
+    terms:
+      - illegal characters
+    alternatives:
+      - invalid characters
+      - unsupported characters
+    severity: warning
+
+  - name: master
+    terms:
+      - master
+    alternatives:
+      - primary
+      - main
+    severity: warning
+    options:
+      word_boundary: true
+
+  - name: slave
+    terms:
+      - slave
+    alternatives:
+      - secondary
+      - replica
+    severity: warning
+    options:
+      word_boundary: true
+
+  - name: whitehat
+    terms:
+      - whitehat
+      - white hat
+    alternatives:
+      - researcher
+      - security specialist
+    severity: warning
+  # Overtly Sexist/Transphobic/Homophobic/Default Male Gendered Terms/Pejorative about Gender Identity/Discriminative
+  - name: chairman
+    terms:
+      - chairman
+      - foreman
+    alternatives:
+      - chair
+      - foreperson
+    severity: warning
+
+  - name: dummy
+    terms:
+      - dummy
+    alternatives:
+      - placeholder
+      - sample
+    severity: warning
+
+  - name: grandfathered
+    terms:
+      - grandfathered
+    alternatives:
+      - legacied
+    severity: warning
+
+  - name: guys
+    terms:
+      - guys
+    alternatives:
+      - people
+      - folks
+    severity: warning
+
+  - name: hang
+    terms:
+      - hang
+    alternatives:
+      - stop responding
+      - stall
+    severity: warning
+    options:
+      word_boundary: true
+
+  - name: man hours
+    terms:
+      - man hours
+    alternatives:
+      - staff hours
+      - hours of effort
+    severity: warning
+
+  - name: man in the middle
+    terms:
+      - man in the middle
+      - man-in-the-middle
+    alternatives:
+      - machine-in-the-middle
+      - person-in-the-middle
+    severity: warning
+
+  - name: manned
+    terms:
+      - manned
+    alternatives:
+      - staffed
+      - monitored
+    severity: warning
+
+  - name: middleman
+    terms:
+      - middleman
+    alternatives:
+      - middleperson
+      - intermediary
+    severity: warning
+
+  - name: sanity check
+    terms:
+      - sanity
+    alternatives:
+      - confidence check
+      - coherence check
+    severity: warning
+  # Ignore rules
+  - name: he

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,0 +1,36 @@
+rules:
+  - name: slave
+    terms:
+      - slave
+    alternatives:
+      - follower
+      - replica
+      - standby
+    options:
+      # trigger findings when they are surrounded by ASCII word boundaries
+      word_boundary: true
+
+  # Including some terms from https://inclusivenaming.org/ that are not in the default ruleset
+  - name: abort
+    terms:
+      - abort
+    alternatives:
+      - force quit
+      - halt
+      - close
+
+  - name: cripple
+    terms:
+      - cripple
+    alternatives:
+      - degraded
+      - restrict
+
+  - name: segregate
+    terms:
+      - segregate
+      - segregation
+    alternatives:
+      - segment/segmentation
+      - separate/separation
+

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -74,8 +74,6 @@ rules:
       - primary
       - main
     severity: warning
-    options:
-      word_boundary: true
 
   - name: slave
     terms:
@@ -84,8 +82,6 @@ rules:
       - secondary
       - replica
     severity: warning
-    options:
-      word_boundary: true
 
   - name: whitehat
     terms:

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,5 +1,12 @@
 ignore_files:
   - abi-compat/*.xml
+  - tests/generator/test_vrfs.py
+  - tests/generator/test_passthrough.py
+  - tests/parser/test_keyfile.py
+  - tests/generator/test_bridges.py
+  - tests/generator/test_bonds.py
+  - tests/generator/test_tunnels.py
+  - tests/generator/test_common.py
 rules:
   # Including some terms from https://inclusivenaming.org/ that are not in the default ruleset
   - name: abort

--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,3 +1,5 @@
+ignore_files:
+  - abi-compat/*.xml
 rules:
   # Including some terms from https://inclusivenaming.org/ that are not in the default ruleset
   - name: abort

--- a/abi-compat/jammy_0.105.xml
+++ b/abi-compat/jammy_0.105.xml
@@ -658,7 +658,7 @@
         <var-decl name='selection_logic' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='270' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='all_members_active' type-id='type-id-40' visibility='default' filepath='../src/abi.h' line='271' column='1'/>
+        <var-decl name='all_slaves_active' type-id='type-id-40' visibility='default' filepath='../src/abi.h' line='271' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='arp_interval' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='272' column='1'/>
@@ -685,7 +685,7 @@
         <var-decl name='gratuitous_arp' type-id='type-id-42' visibility='default' filepath='../src/abi.h' line='279' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='packets_per_member' type-id='type-id-42' visibility='default' filepath='../src/abi.h' line='281' column='1'/>
+        <var-decl name='packets_per_slave' type-id='type-id-42' visibility='default' filepath='../src/abi.h' line='281' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
         <var-decl name='primary_reselect_policy' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='282' column='1'/>
@@ -697,7 +697,7 @@
         <var-decl name='learn_interval' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='284' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='primary_member' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='285' column='1'/>
+        <var-decl name='primary_slave' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='285' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='__anonymous_struct__3' size-in-bits='640' is-struct='yes' is-anonymous='yes' visibility='default' filepath='../src/abi.h' line='289' column='1' id='type-id-78'>

--- a/abi-compat/jammy_0.105.xml
+++ b/abi-compat/jammy_0.105.xml
@@ -1893,22 +1893,22 @@
     <typedef-decl name='GHashTableIter' type-id='type-id-245' filepath='/usr/include/glib-2.0/glib/ghash.h' line='43' column='1' id='type-id-14'/>
     <class-decl name='_GHashTableIter' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='45' column='1' id='type-id-245'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='placeholder1' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='48' column='1'/>
+        <var-decl name='dummy1' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='48' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='placeholder2' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='49' column='1'/>
+        <var-decl name='dummy2' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='49' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='placeholder3' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='50' column='1'/>
+        <var-decl name='dummy3' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='50' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='placeholder4' type-id='type-id-16' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='51' column='1'/>
+        <var-decl name='dummy4' type-id='type-id-16' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='51' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='placeholder5' type-id='type-id-40' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='52' column='1'/>
+        <var-decl name='dummy5' type-id='type-id-40' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='placeholder6' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='53' column='1'/>
+        <var-decl name='dummy6' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='53' column='1'/>
       </data-member>
     </class-decl>
     <typedef-decl name='GCompareFunc' type-id='type-id-246' filepath='/usr/include/glib-2.0/glib/gtypes.h' line='106' column='1' id='type-id-247'/>

--- a/abi-compat/jammy_0.105.xml
+++ b/abi-compat/jammy_0.105.xml
@@ -658,7 +658,7 @@
         <var-decl name='selection_logic' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='270' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='all_slaves_active' type-id='type-id-40' visibility='default' filepath='../src/abi.h' line='271' column='1'/>
+        <var-decl name='all_members_active' type-id='type-id-40' visibility='default' filepath='../src/abi.h' line='271' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='arp_interval' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='272' column='1'/>
@@ -685,7 +685,7 @@
         <var-decl name='gratuitous_arp' type-id='type-id-42' visibility='default' filepath='../src/abi.h' line='279' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='packets_per_slave' type-id='type-id-42' visibility='default' filepath='../src/abi.h' line='281' column='1'/>
+        <var-decl name='packets_per_member' type-id='type-id-42' visibility='default' filepath='../src/abi.h' line='281' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
         <var-decl name='primary_reselect_policy' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='282' column='1'/>
@@ -697,7 +697,7 @@
         <var-decl name='learn_interval' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='284' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='primary_slave' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='285' column='1'/>
+        <var-decl name='primary_member' type-id='type-id-41' visibility='default' filepath='../src/abi.h' line='285' column='1'/>
       </data-member>
     </class-decl>
     <class-decl name='__anonymous_struct__3' size-in-bits='640' is-struct='yes' is-anonymous='yes' visibility='default' filepath='../src/abi.h' line='289' column='1' id='type-id-78'>

--- a/abi-compat/jammy_0.105.xml
+++ b/abi-compat/jammy_0.105.xml
@@ -1893,22 +1893,22 @@
     <typedef-decl name='GHashTableIter' type-id='type-id-245' filepath='/usr/include/glib-2.0/glib/ghash.h' line='43' column='1' id='type-id-14'/>
     <class-decl name='_GHashTableIter' size-in-bits='320' is-struct='yes' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='45' column='1' id='type-id-245'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dummy1' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='48' column='1'/>
+        <var-decl name='placeholder1' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='48' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='dummy2' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='49' column='1'/>
+        <var-decl name='placeholder2' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='49' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='dummy3' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='50' column='1'/>
+        <var-decl name='placeholder3' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='50' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='dummy4' type-id='type-id-16' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='51' column='1'/>
+        <var-decl name='placeholder4' type-id='type-id-16' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='51' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='dummy5' type-id='type-id-40' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='52' column='1'/>
+        <var-decl name='placeholder5' type-id='type-id-40' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='52' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='dummy6' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='53' column='1'/>
+        <var-decl name='placeholder6' type-id='type-id-120' visibility='default' filepath='/usr/include/glib-2.0/glib/ghash.h' line='53' column='1'/>
       </data-member>
     </class-decl>
     <typedef-decl name='GCompareFunc' type-id='type-id-246' filepath='/usr/include/glib-2.0/glib/gtypes.h' line='106' column='1' id='type-id-247'/>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,7 +2,7 @@
 #
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
+# https://www.sphinx-doc.org/en/master/usage/configuration.html  wokeignore:rule=master
 
 # -- Path setup --------------------------------------------------------------
 

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1144,12 +1144,12 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
     > `bandwidth`, and `count`. This option is only used in 802.3ad
     > mode.
 
-  - **all-members-active**, **all-slaves-active** (bool)
+  - **all-members-active** (bool)
 
     > If the bond should drop duplicate frames received on inactive ports,
     > set this option to `false`. If they should be delivered, set this
     > option to `true`. The default value is false, and is the desirable
-    > behavior in most situations.
+    > behavior in most situations. Alias: **all-slaves-active**
 
   - **arp-interval** (scalar)
 
@@ -1214,13 +1214,13 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
     > For historical reasons, the misspelling `gratuitious-arp` is also
     > accepted and has the same function.
 
-  - **packets-per-member**, **packets-per-slave** (scalar)
+  - **packets-per-member** (scalar)
 
     > In `balance-rr` mode, specifies the number of packets to transmit
     > on a port before switching to the next. When this value is set to
     > `0`, ports are chosen at random. Allowable values are between
     > `0` and `65535`. The default value is `1`. This setting is
-    > only used in `balance-rr` mode.
+    > only used in `balance-rr` mode. Alias: **packets-per-slave**
 
   - **primary-reselect-policy** (scalar)
 

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1144,7 +1144,7 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
     > `bandwidth`, and `count`. This option is only used in 802.3ad
     > mode.
 
-  - **all-slaves-active** (bool)
+  - **all-members-active**, **all-slaves-active** (bool)
 
     > If the bond should drop duplicate frames received on inactive ports,
     > set this option to `false`. If they should be delivered, set this
@@ -1214,7 +1214,7 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
     > For historical reasons, the misspelling `gratuitious-arp` is also
     > accepted and has the same function.
 
-  - **packets-per-slave** (scalar)
+  - **packets-per-member**, **packets-per-slave** (scalar)
 
     > In `balance-rr` mode, specifies the number of packets to transmit
     > on a port before switching to the next. When this value is set to

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1133,7 +1133,7 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
 
   - **transmit-hash-policy** (scalar)
 
-    > Specifies the transmit hash policy for the selection of slaves. This
+    > Specifies the transmit hash policy for the selection of ports. This
     > is only useful in balance-xor, 802.3ad and balance-tlb modes.
     > Possible values are `layer2`, `layer3+4`, `layer2+3`,
     > `encap2+3`, and `encap3+4`.
@@ -1162,7 +1162,7 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
   - **arp-ip-targets** (sequence of scalars)
 
     > IPs of other hosts on the link which should be sent ARP requests in
-    > order to validate that a slave is up. This option is only used when
+    > order to validate that a port is up. This option is only used when
     > `arp-interval` is set to a value other than `0`. At least one IP
     > address must be given for ARP link monitoring to function. Only IPv4
     > addresses are supported. You can specify up to 16 IP addresses. The
@@ -1177,7 +1177,7 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
   - **arp-all-targets** (scalar)
 
     > Specify whether to use any ARP IP target being up as sufficient for
-    > a slave to be considered up; or if all the targets must be up. This
+    > a port to be considered up; or if all the targets must be up. This
     > is only used for `active-backup` mode when `arp-validate` is
     > enabled. Possible values are `any` and `all`.
 
@@ -1199,14 +1199,14 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
 
   - **fail-over-mac-policy** (scalar)
 
-    > Set whether to set all slaves to the same MAC address when adding
+    > Set whether to set all ports to the same MAC address when adding
     > them to the bond, or how else the system should handle MAC addresses.
     > The possible values are `none`, `active`, and `follow`.
 
   - **gratuitous-arp** (scalar)
 
     > Specify how many ARP packets to send after failover. Once a link is
-    > up on a new slave, a notification is sent and possibly repeated if
+    > up on a new port, a notification is sent and possibly repeated if
     > this value is set to a number greater than `1`. The default value
     > is `1` and valid values are between `1` and `255`. This only
     > affects `active-backup` mode.
@@ -1217,23 +1217,23 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
   - **packets-per-slave** (scalar)
 
     > In `balance-rr` mode, specifies the number of packets to transmit
-    > on a slave before switching to the next. When this value is set to
-    > `0`, slaves are chosen at random. Allowable values are between
+    > on a port before switching to the next. When this value is set to
+    > `0`, ports are chosen at random. Allowable values are between
     > `0` and `65535`. The default value is `1`. This setting is
     > only used in `balance-rr` mode.
 
   - **primary-reselect-policy** (scalar)
 
-    > Set the reselection policy for the primary slave. On failure of the
-    > active slave, the system will use this policy to decide how the new
-    > active slave will be chosen and how recovery will be handled. The
+    > Set the reselection policy for the primary port. On failure of the
+    > active port, the system will use this policy to decide how the new
+    > active port will be chosen and how recovery will be handled. The
     > possible values are `always`, `better`, and `failure`.
 
   - **resend-igmp** (scalar)
 
     > In modes `balance-rr`, `active-backup`, `balance-tlb` and
     > `balance-alb`, a failover can switch IGMP traffic from one
-    > slave to another.
+    > port to another.
     >
     > This parameter specifies how many IGMP membership reports
     > are issued on a failover event. Values range from 0 to 255. 0
@@ -1244,7 +1244,7 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
   - **learn-packet-interval** (scalar)
 
     > Specify the interval between sending learning packets to
-    > each slave.  The value range is between `1` and `0x7fffffff`.
+    > each port.  The value range is between `1` and `0x7fffffff`.
     > The default value is `1`. This option only affects `balance-tlb`
     > and `balance-alb` modes. Using the networkd renderer, this field
     > maps to the LearnPacketIntervalSec= property. If no time suffix is
@@ -1252,8 +1252,8 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
 
   - **primary** (scalar)
 
-    > Specify a device to be used as a primary slave, or preferred device
-    > to use as a slave for the bond (i.e. the preferred device to send
+    > Specify a device to be used as a primary port, or preferred device
+    > to use as a port for the bond (i.e. the preferred device to send
     > data through), whenever it is available. This only affects
     > `active-backup`, `balance-alb`, and `balance-tlb` modes.
 

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1149,7 +1149,9 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
     > If the bond should drop duplicate frames received on inactive ports,
     > set this option to `false`. If they should be delivered, set this
     > option to `true`. The default value is false, and is the desirable
-    > behavior in most situations. Alias: **all-slaves-active**  <!--- wokeignore:rule=slave -->
+    > behavior in most situations.
+
+    Alias: **all-slaves-active**  <!--- wokeignore:rule=slave -->
 
   - **arp-interval** (scalar)
 
@@ -1220,7 +1222,9 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
     > on a port before switching to the next. When this value is set to
     > `0`, ports are chosen at random. Allowable values are between
     > `0` and `65535`. The default value is `1`. This setting is
-    > only used in `balance-rr` mode. Alias: **packets-per-slave** <!--- wokeignore:rule=slave -->
+    > only used in `balance-rr` mode.
+
+    Alias: **packets-per-slave** <!--- wokeignore:rule=slave -->
 
   - **primary-reselect-policy** (scalar)
 

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1149,7 +1149,7 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
     > If the bond should drop duplicate frames received on inactive ports,
     > set this option to `false`. If they should be delivered, set this
     > option to `true`. The default value is false, and is the desirable
-    > behavior in most situations. Alias: **all-slaves-active**
+    > behavior in most situations. Alias: **all-slaves-active**  <!--- wokeignore:rule=slave -->
 
   - **arp-interval** (scalar)
 
@@ -1220,7 +1220,7 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
     > on a port before switching to the next. When this value is set to
     > `0`, ports are chosen at random. Allowable values are between
     > `0` and `65535`. The default value is `1`. This setting is
-    > only used in `balance-rr` mode. Alias: **packets-per-slave**
+    > only used in `balance-rr` mode. Alias: **packets-per-slave** <!--- wokeignore:rule=slave -->
 
   - **primary-reselect-policy** (scalar)
 

--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -69,7 +69,7 @@ def _string_realloc_call_no_error(function):
             return None  # pragma: nocover as it's hard to trigger for now
         else:
             return buffer.value.decode('utf-8')
-    raise LibNetplanException('Aborting due to string buffer size > 1M')  # pragma: nocover
+    raise LibNetplanException('Halting due to string buffer size > 1M')  # pragma: nocover
 
 
 def _checked_lib_call(fn, *args):

--- a/src/abi.h
+++ b/src/abi.h
@@ -269,6 +269,7 @@ struct netplan_net_definition {
         char* transmit_hash_policy;
         char* selection_logic;
         gboolean all_slaves_active;
+#define all_members_active all_slaves_active
         char* arp_interval;
         GArray* arp_ip_targets;
         char* arp_validate;
@@ -279,6 +280,7 @@ struct netplan_net_definition {
         guint gratuitous_arp;
         /* TODO: unsolicited_na */
         guint packets_per_slave;
+#define packets_per_member packets_per_slave
         char* primary_reselect_policy;
         guint resend_igmp;
         char* learn_interval;

--- a/src/abi.h
+++ b/src/abi.h
@@ -268,8 +268,7 @@ struct netplan_net_definition {
         guint min_links;
         char* transmit_hash_policy;
         char* selection_logic;
-        gboolean all_slaves_active;
-#define all_members_active all_slaves_active
+        gboolean all_members_active;
         char* arp_interval;
         GArray* arp_ip_targets;
         char* arp_validate;
@@ -279,12 +278,11 @@ struct netplan_net_definition {
         char* fail_over_mac_policy;
         guint gratuitous_arp;
         /* TODO: unsolicited_na */
-        guint packets_per_slave;
-#define packets_per_member packets_per_slave
+        guint packets_per_member;
         char* primary_reselect_policy;
         guint resend_igmp;
         char* learn_interval;
-        char* primary_slave;
+        char* primary_member;
     } bond_params;
 
     /* netplan-feature: modems */

--- a/src/abi.h
+++ b/src/abi.h
@@ -224,7 +224,7 @@ struct netplan_net_definition {
         gboolean ipv6;
     } linklocal;
 
-    /* master ID for slave devices */
+    /* primary ID for member devices */
     char* bridge; // deprecated, use bridge_link instead
     char* bond;   // deprecated, use bond_link instead
 

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -158,11 +158,11 @@ write_bond_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNet
         || def->bond_params.primary_reselect_policy
         || def->bond_params.learn_interval
         || def->bond_params.arp_interval
-        || def->bond_params.primary_slave
+        || def->bond_params.primary_member
         || def->bond_params.min_links
-        || def->bond_params.all_slaves_active
+        || def->bond_params.all_members_active
         || def->bond_params.gratuitous_arp
-        || def->bond_params.packets_per_slave
+        || def->bond_params.packets_per_member
         || def->bond_params.resend_igmp
         || def->bond_params.arp_ip_targets) {
         YAML_SCALAR_PLAIN(event, emitter, "parameters");
@@ -180,7 +180,7 @@ write_bond_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNet
         YAML_STRING(def, event, emitter, "primary-reselect-policy", def->bond_params.primary_reselect_policy);
         YAML_STRING(def, event, emitter, "learn-packet-interval", def->bond_params.learn_interval);
         YAML_STRING(def, event, emitter, "arp-interval", def->bond_params.arp_interval);
-        YAML_STRING(def, event, emitter, "primary", def->bond_params.primary_slave);
+        YAML_STRING(def, event, emitter, "primary", def->bond_params.primary_member);
         YAML_UINT_0(def, event, emitter, "min-links", def->bond_params.min_links);
         YAML_BOOL_TRUE(def, event, emitter, "all-members-active", def->bond_params.all_members_active);
         YAML_UINT_0(def, event, emitter, "gratuitous-arp", def->bond_params.gratuitous_arp);

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -182,9 +182,9 @@ write_bond_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNet
         YAML_STRING(def, event, emitter, "arp-interval", def->bond_params.arp_interval);
         YAML_STRING(def, event, emitter, "primary", def->bond_params.primary_slave);
         YAML_UINT_0(def, event, emitter, "min-links", def->bond_params.min_links);
-        YAML_BOOL_TRUE(def, event, emitter, "all-slaves-active", def->bond_params.all_slaves_active);
+        YAML_BOOL_TRUE(def, event, emitter, "all-members-active", def->bond_params.all_members_active);
         YAML_UINT_0(def, event, emitter, "gratuitous-arp", def->bond_params.gratuitous_arp);
-        YAML_UINT_0(def, event, emitter, "packets-per-slave", def->bond_params.packets_per_slave);
+        YAML_UINT_0(def, event, emitter, "packets-per-member", def->bond_params.packets_per_member);
         YAML_UINT_0(def, event, emitter, "resend-igmp", def->bond_params.resend_igmp);
         if (def->bond_params.arp_ip_targets || DIRTY(def, def->bond_params.arp_ip_targets)) {
             GArray* arr = def->bond_params.arp_ip_targets;

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -362,7 +362,7 @@ write_bond_parameters(const NetplanNetDefinition* def, GString* s)
     if (def->bond_params.selection_logic)
         g_string_append_printf(params, "\nAdSelect=%s", def->bond_params.selection_logic);
     if (def->bond_params.all_members_active)
-        g_string_append_printf(params, "\nAllSlavesActive=%d", def->bond_params.all_members_active);
+        g_string_append_printf(params, "\nAllSlavesActive=%d", def->bond_params.all_members_active); /* wokeignore:rule=slave */ 
     if (def->bond_params.arp_interval) {
         g_string_append(params, "\nARPIntervalSec=");
         if (interval_has_suffix(def->bond_params.arp_interval))
@@ -402,7 +402,7 @@ write_bond_parameters(const NetplanNetDefinition* def, GString* s)
         g_string_append_printf(params, "\nGratuitousARP=%d", def->bond_params.gratuitous_arp);
     /* TODO: add unsolicited_na, not documented as supported by NM. */
     if (def->bond_params.packets_per_member)
-        g_string_append_printf(params, "\nPacketsPerSlave=%d", def->bond_params.packets_per_member);
+        g_string_append_printf(params, "\nPacketsPerSlave=%d", def->bond_params.packets_per_member); /* wokeignore:rule=slave */ 
     if (def->bond_params.primary_reselect_policy)
         g_string_append_printf(params, "\nPrimaryReselectPolicy=%s", def->bond_params.primary_reselect_policy);
     if (def->bond_params.resend_igmp)
@@ -854,7 +854,7 @@ netplan_netdef_write_network_file(
         g_string_append_printf(network, "Bond=%s\n", def->bond);
 
         if (def->bond_params.primary_member)
-            g_string_append_printf(network, "PrimarySlave=true\n");
+            g_string_append_printf(network, "PrimarySlave=true\n"); /* wokeignore:rule=slave */
     }
 
     if (def->has_vlans && def->backend != NETPLAN_BACKEND_OVS) {

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -361,8 +361,8 @@ write_bond_parameters(const NetplanNetDefinition* def, GString* s)
         g_string_append_printf(params, "\nTransmitHashPolicy=%s", def->bond_params.transmit_hash_policy);
     if (def->bond_params.selection_logic)
         g_string_append_printf(params, "\nAdSelect=%s", def->bond_params.selection_logic);
-    if (def->bond_params.all_slaves_active)
-        g_string_append_printf(params, "\nAllSlavesActive=%d", def->bond_params.all_slaves_active);
+    if (def->bond_params.all_members_active)
+        g_string_append_printf(params, "\nAllSlavesActive=%d", def->bond_params.all_members_active);
     if (def->bond_params.arp_interval) {
         g_string_append(params, "\nARPIntervalSec=");
         if (interval_has_suffix(def->bond_params.arp_interval))
@@ -401,8 +401,8 @@ write_bond_parameters(const NetplanNetDefinition* def, GString* s)
     if (def->bond_params.gratuitous_arp)
         g_string_append_printf(params, "\nGratuitousARP=%d", def->bond_params.gratuitous_arp);
     /* TODO: add unsolicited_na, not documented as supported by NM. */
-    if (def->bond_params.packets_per_slave)
-        g_string_append_printf(params, "\nPacketsPerSlave=%d", def->bond_params.packets_per_slave);
+    if (def->bond_params.packets_per_member)
+        g_string_append_printf(params, "\nPacketsPerSlave=%d", def->bond_params.packets_per_member);
     if (def->bond_params.primary_reselect_policy)
         g_string_append_printf(params, "\nPrimaryReselectPolicy=%s", def->bond_params.primary_reselect_policy);
     if (def->bond_params.resend_igmp)
@@ -853,7 +853,7 @@ netplan_netdef_write_network_file(
     if (def->bond && def->backend != NETPLAN_BACKEND_OVS) {
         g_string_append_printf(network, "Bond=%s\n", def->bond);
 
-        if (def->bond_params.primary_slave)
+        if (def->bond_params.primary_member)
             g_string_append_printf(network, "PrimarySlave=true\n");
     }
 

--- a/src/nm.c
+++ b/src/nm.c
@@ -546,7 +546,7 @@ write_fallback_key_value(GQuark key_id, gpointer value, gpointer user_data)
     has_key = g_key_file_has_key(kf, group, k, NULL);
     old_key = g_key_file_get_string(kf, group, k, NULL);
     g_key_file_set_string(kf, group, k, val);
-    /* delete the dummy key, if this was just an empty group */
+    /* delete the placeholder key, if this was just an empty group */
     if (!g_strcmp0(k, NETPLAN_NM_EMPTY_GROUP))
         g_key_file_remove_key(kf, group, k, NULL);
     /* handle differing defaults:

--- a/src/nm.c
+++ b/src/nm.c
@@ -266,8 +266,8 @@ write_bond_parameters(const NetplanNetDefinition* def, GKeyFile *kf)
         g_key_file_set_string(kf, "bond", "xmit_hash_policy", def->bond_params.transmit_hash_policy);
     if (def->bond_params.selection_logic)
         g_key_file_set_string(kf, "bond", "ad_select", def->bond_params.selection_logic);
-    if (def->bond_params.all_slaves_active)
-        g_key_file_set_integer(kf, "bond", "all_slaves_active", def->bond_params.all_slaves_active);
+    if (def->bond_params.all_members_active)
+        g_key_file_set_integer(kf, "bond", "all_slaves_active", def->bond_params.all_members_active);
     if (def->bond_params.arp_interval)
         g_key_file_set_string(kf, "bond", "arp_interval", def->bond_params.arp_interval);
     if (def->bond_params.arp_ip_targets) {
@@ -296,16 +296,16 @@ write_bond_parameters(const NetplanNetDefinition* def, GKeyFile *kf)
          * https://github.com/NetworkManager/NetworkManager/commit/42b0bef33c77a0921590b2697f077e8ea7805166 */
         g_key_file_set_integer(kf, "bond", "num_unsol_na", def->bond_params.gratuitous_arp);
     }
-    if (def->bond_params.packets_per_slave)
-        g_key_file_set_integer(kf, "bond", "packets_per_slave", def->bond_params.packets_per_slave);
+    if (def->bond_params.packets_per_member)
+        g_key_file_set_integer(kf, "bond", "packets_per_slave", def->bond_params.packets_per_member);
     if (def->bond_params.primary_reselect_policy)
         g_key_file_set_string(kf, "bond", "primary_reselect", def->bond_params.primary_reselect_policy);
     if (def->bond_params.resend_igmp)
         g_key_file_set_integer(kf, "bond", "resend_igmp", def->bond_params.resend_igmp);
     if (def->bond_params.learn_interval)
         g_key_file_set_string(kf, "bond", "lp_interval", def->bond_params.learn_interval);
-    if (def->bond_params.primary_slave)
-        g_key_file_set_string(kf, "bond", "primary", def->bond_params.primary_slave);
+    if (def->bond_params.primary_member)
+        g_key_file_set_string(kf, "bond", "primary", def->bond_params.primary_member);
 }
 
 static void

--- a/src/nm.c
+++ b/src/nm.c
@@ -267,7 +267,7 @@ write_bond_parameters(const NetplanNetDefinition* def, GKeyFile *kf)
     if (def->bond_params.selection_logic)
         g_key_file_set_string(kf, "bond", "ad_select", def->bond_params.selection_logic);
     if (def->bond_params.all_members_active)
-        g_key_file_set_integer(kf, "bond", "all_slaves_active", def->bond_params.all_members_active);
+        g_key_file_set_integer(kf, "bond", "all_slaves_active", def->bond_params.all_members_active); /* wokeignore:rule=slave */
     if (def->bond_params.arp_interval)
         g_key_file_set_string(kf, "bond", "arp_interval", def->bond_params.arp_interval);
     if (def->bond_params.arp_ip_targets) {
@@ -297,7 +297,7 @@ write_bond_parameters(const NetplanNetDefinition* def, GKeyFile *kf)
         g_key_file_set_integer(kf, "bond", "num_unsol_na", def->bond_params.gratuitous_arp);
     }
     if (def->bond_params.packets_per_member)
-        g_key_file_set_integer(kf, "bond", "packets_per_slave", def->bond_params.packets_per_member);
+        g_key_file_set_integer(kf, "bond", "packets_per_slave", def->bond_params.packets_per_member); /* wokeignore:rule=slave */
     if (def->bond_params.primary_reselect_policy)
         g_key_file_set_string(kf, "bond", "primary_reselect", def->bond_params.primary_reselect_policy);
     if (def->bond_params.resend_igmp)
@@ -702,8 +702,8 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
             g_key_file_set_string(kf, modem_type, "sim-operator-id", def->modem_params.sim_operator_id);
     }
     if (def->bridge) {
-        g_key_file_set_string(kf, "connection", "slave-type", "bridge");
-        g_key_file_set_string(kf, "connection", "master", def->bridge);
+        g_key_file_set_string(kf, "connection", "slave-type", "bridge"); /* wokeignore:rule=slave */
+        g_key_file_set_string(kf, "connection", "master", def->bridge); /* wokeignore:rule=master */
 
         if (def->bridge_params.path_cost)
             g_key_file_set_uint64(kf, "bridge-port", "path-cost", def->bridge_params.path_cost);
@@ -711,13 +711,13 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
             g_key_file_set_uint64(kf, "bridge-port", "priority", def->bridge_params.port_priority);
     }
     if (def->bond) {
-        g_key_file_set_string(kf, "connection", "slave-type", "bond");
-        g_key_file_set_string(kf, "connection", "master", def->bond);
+        g_key_file_set_string(kf, "connection", "slave-type", "bond"); /* wokeignore:rule=slave */
+        g_key_file_set_string(kf, "connection", "master", def->bond); /* wokeignore:rule=master */
     }
 
     if (def->vrf_link) {
-        g_key_file_set_string(kf, "connection", "slave-type", "vrf");
-        g_key_file_set_string(kf, "connection", "master", def->vrf_link->id);
+        g_key_file_set_string(kf, "connection", "slave-type", "vrf"); /* wokeignore:rule=slave */
+        g_key_file_set_string(kf, "connection", "master", def->vrf_link->id); /* wokeignore:rule=master */
     }
 
     if (def->ipv6_mtubytes) {

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -171,7 +171,7 @@ write_ovs_bond_interfaces(const NetplanState* np_state, const NetplanNetDefiniti
     GString* patch_ports = g_string_new("");
 
     if (!def->bridge) {
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "Bond %s needs to be a slave of an OpenVSwitch bridge\n", def->id);
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "Bond %s needs to be a member of an OpenVSwitch bridge\n", def->id);
         return NULL;
     }
 
@@ -189,7 +189,7 @@ write_ovs_bond_interfaces(const NetplanState* np_state, const NetplanNetDefiniti
         }
     }
     if (i < 2) {
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "Bond %s needs to have at least 2 slave interfaces\n", def->id);
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "Bond %s needs to have at least 2 member interfaces\n", def->id);
         return NULL;
     }
 

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -693,13 +693,13 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
     handle_generic_str(kf, "bond", "primary", &nd->bond_params.primary_member);
     handle_generic_uint(kf, "bond", "min_links", &nd->bond_params.min_links, 0);
     handle_generic_uint(kf, "bond", "resend_igmp", &nd->bond_params.resend_igmp, 0);
-    handle_generic_uint(kf, "bond", "packets_per_slave", &nd->bond_params.packets_per_member, 0);
+    handle_generic_uint(kf, "bond", "packets_per_slave", &nd->bond_params.packets_per_member, 0); /* wokeignore:rule=slave */
     handle_generic_uint(kf, "bond", "num_grat_arp", &nd->bond_params.gratuitous_arp, 0);
     /* num_unsol_na might overwrite num_grat_arp, but we're fine if they are equal:
      * https://github.com/NetworkManager/NetworkManager/commit/42b0bef33c77a0921590b2697f077e8ea7805166 */
     if (g_key_file_get_uint64(kf, "bond", "num_unsol_na", NULL) == nd->bond_params.gratuitous_arp)
         _kf_clear_key(kf, "bond", "num_unsol_na");
-    handle_generic_bool(kf, "bond", "all_slaves_active", &nd->bond_params.all_members_active);
+    handle_generic_bool(kf, "bond", "all_slaves_active", &nd->bond_params.all_members_active); /* wokeignore:rule=slave */
     parse_bond_arp_ip_targets(kf, &nd->bond_params.arp_ip_targets);
 
     /* Special handling for WiFi "access-points:" mapping */

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -690,16 +690,16 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
     handle_generic_str(kf, "bond", "fail_over_mac", &nd->bond_params.fail_over_mac_policy);
     handle_generic_str(kf, "bond", "primary_reselect", &nd->bond_params.primary_reselect_policy);
     handle_generic_str(kf, "bond", "lp_interval", &nd->bond_params.learn_interval);
-    handle_generic_str(kf, "bond", "primary", &nd->bond_params.primary_slave);
+    handle_generic_str(kf, "bond", "primary", &nd->bond_params.primary_member);
     handle_generic_uint(kf, "bond", "min_links", &nd->bond_params.min_links, 0);
     handle_generic_uint(kf, "bond", "resend_igmp", &nd->bond_params.resend_igmp, 0);
-    handle_generic_uint(kf, "bond", "packets_per_slave", &nd->bond_params.packets_per_slave, 0);
+    handle_generic_uint(kf, "bond", "packets_per_slave", &nd->bond_params.packets_per_member, 0);
     handle_generic_uint(kf, "bond", "num_grat_arp", &nd->bond_params.gratuitous_arp, 0);
     /* num_unsol_na might overwrite num_grat_arp, but we're fine if they are equal:
      * https://github.com/NetworkManager/NetworkManager/commit/42b0bef33c77a0921590b2697f077e8ea7805166 */
     if (g_key_file_get_uint64(kf, "bond", "num_unsol_na", NULL) == nd->bond_params.gratuitous_arp)
         _kf_clear_key(kf, "bond", "num_unsol_na");
-    handle_generic_bool(kf, "bond", "all_slaves_active", &nd->bond_params.all_slaves_active);
+    handle_generic_bool(kf, "bond", "all_slaves_active", &nd->bond_params.all_members_active);
     parse_bond_arp_ip_targets(kf, &nd->bond_params.arp_ip_targets);
 
     /* Special handling for WiFi "access-points:" mapping */

--- a/src/parse.c
+++ b/src/parse.c
@@ -2077,7 +2077,7 @@ handle_arp_ip_targets(NetplanParser* npp, yaml_node_t* node, const void* _, GErr
 }
 
 static gboolean
-handle_bond_primary_slave(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_bond_primary_member(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     NetplanNetDefinition *component;
     char** ref_ptr;
@@ -2087,19 +2087,19 @@ handle_bond_primary_slave(NetplanParser* npp, yaml_node_t* node, const void* dat
         add_missing_node(npp, node);
     } else {
         /* If this is not the primary pass, the primary member might already be equally set. */
-        if (!g_strcmp0(npp->current.netdef->bond_params.primary_slave, scalar(node))) {
+        if (!g_strcmp0(npp->current.netdef->bond_params.primary_member, scalar(node))) {
             return TRUE;
-        } else if (npp->current.netdef->bond_params.primary_slave)
+        } else if (npp->current.netdef->bond_params.primary_member)
             return yaml_error(npp, node, error, "%s: bond already has a primary member: %s",
-                              npp->current.netdef->id, npp->current.netdef->bond_params.primary_slave);
+                              npp->current.netdef->id, npp->current.netdef->bond_params.primary_member);
 
         ref_ptr = ((char**) ((void*) component + GPOINTER_TO_UINT(data)));
         *ref_ptr = g_strdup(scalar(node));
-        npp->current.netdef->bond_params.primary_slave = g_strdup(scalar(node));
+        npp->current.netdef->bond_params.primary_member = g_strdup(scalar(node));
         mark_data_as_dirty(npp, ref_ptr);
     }
 
-    mark_data_as_dirty(npp, &npp->current.netdef->bond_params.primary_slave);
+    mark_data_as_dirty(npp, &npp->current.netdef->bond_params.primary_member);
     return TRUE;
 }
 
@@ -2110,7 +2110,7 @@ static const mapping_entry_handler bond_params_handlers[] = {
     {"min-links", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.min_links)},
     {"transmit-hash-policy", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.transmit_hash_policy)},
     {"ad-select", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.selection_logic)},
-    {"all-slaves-active", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(bond_params.all_slaves_active)},
+    {"all-slaves-active", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(bond_params.all_members_active)},
     {"all-members-active", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(bond_params.all_members_active)},
     {"arp-interval", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.arp_interval)},
     /* TODO: arp_ip_targets */
@@ -2124,12 +2124,12 @@ static const mapping_entry_handler bond_params_handlers[] = {
     /* Handle the old misspelling */
     {"gratuitious-arp", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.gratuitous_arp)},
     /* TODO: unsolicited_na */
-    {"packets-per-slave", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.packets_per_slave)},
+    {"packets-per-slave", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.packets_per_member)},
     {"packets-per-member", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.packets_per_member)},
     {"primary-reselect-policy", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.primary_reselect_policy)},
     {"resend-igmp", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.resend_igmp)},
     {"learn-packet-interval", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.learn_interval)},
-    {"primary", YAML_SCALAR_NODE, {.generic=handle_bond_primary_slave}, netdef_offset(bond_params.primary_slave)},
+    {"primary", YAML_SCALAR_NODE, {.generic=handle_bond_primary_member}, netdef_offset(bond_params.primary_member)},
     {NULL}
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -2111,6 +2111,7 @@ static const mapping_entry_handler bond_params_handlers[] = {
     {"transmit-hash-policy", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.transmit_hash_policy)},
     {"ad-select", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.selection_logic)},
     {"all-slaves-active", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(bond_params.all_slaves_active)},
+    {"all-members-active", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(bond_params.all_members_active)},
     {"arp-interval", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.arp_interval)},
     /* TODO: arp_ip_targets */
     {"arp-ip-targets", YAML_SEQUENCE_NODE, {.generic=handle_arp_ip_targets}},
@@ -2124,6 +2125,7 @@ static const mapping_entry_handler bond_params_handlers[] = {
     {"gratuitious-arp", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.gratuitous_arp)},
     /* TODO: unsolicited_na */
     {"packets-per-slave", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.packets_per_slave)},
+    {"packets-per-member", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.packets_per_member)},
     {"primary-reselect-policy", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.primary_reselect_policy)},
     {"resend-igmp", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.resend_igmp)},
     {"learn-packet-interval", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.learn_interval)},

--- a/src/parse.c
+++ b/src/parse.c
@@ -2110,7 +2110,7 @@ static const mapping_entry_handler bond_params_handlers[] = {
     {"min-links", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.min_links)},
     {"transmit-hash-policy", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.transmit_hash_policy)},
     {"ad-select", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.selection_logic)},
-    {"all-slaves-active", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(bond_params.all_members_active)},
+    {"all-slaves-active", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(bond_params.all_members_active)}, /* wokeignore:rule=slave */
     {"all-members-active", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(bond_params.all_members_active)},
     {"arp-interval", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.arp_interval)},
     /* TODO: arp_ip_targets */
@@ -2124,7 +2124,7 @@ static const mapping_entry_handler bond_params_handlers[] = {
     /* Handle the old misspelling */
     {"gratuitious-arp", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.gratuitous_arp)},
     /* TODO: unsolicited_na */
-    {"packets-per-slave", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.packets_per_member)},
+    {"packets-per-slave", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.packets_per_member)}, /* wokeignore:rule=slave */
     {"packets-per-member", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.packets_per_member)},
     {"primary-reselect-policy", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.primary_reselect_policy)},
     {"resend-igmp", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.resend_igmp)},

--- a/src/parse.c
+++ b/src/parse.c
@@ -2086,11 +2086,11 @@ handle_bond_primary_slave(NetplanParser* npp, yaml_node_t* node, const void* dat
     if (!component) {
         add_missing_node(npp, node);
     } else {
-        /* If this is not the primary pass, the primary slave might already be equally set. */
+        /* If this is not the primary pass, the primary member might already be equally set. */
         if (!g_strcmp0(npp->current.netdef->bond_params.primary_slave, scalar(node))) {
             return TRUE;
         } else if (npp->current.netdef->bond_params.primary_slave)
-            return yaml_error(npp, node, error, "%s: bond already has a primary slave: %s",
+            return yaml_error(npp, node, error, "%s: bond already has a primary member: %s",
                               npp->current.netdef->id, npp->current.netdef->bond_params.primary_slave);
 
         ref_ptr = ((char**) ((void*) component + GPOINTER_TO_UINT(data)));

--- a/src/parse.c
+++ b/src/parse.c
@@ -147,7 +147,7 @@ assert_type_fn(const NetplanParser* npp, yaml_node_t* node, yaml_node_type_t exp
 
     switch (expected_type) {
         case YAML_VARIABLE_NODE:
-            /* Special case, defer sanity checking to the next handlers */
+            /* Special case, defer coherence checking to the next handlers */
             return TRUE;
             break;
         case YAML_SCALAR_NODE:

--- a/src/types.c
+++ b/src/types.c
@@ -310,7 +310,7 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     FREE_AND_NULLIFY(netdef->bond_params.fail_over_mac_policy);
     FREE_AND_NULLIFY(netdef->bond_params.primary_reselect_policy);
     FREE_AND_NULLIFY(netdef->bond_params.learn_interval);
-    FREE_AND_NULLIFY(netdef->bond_params.primary_slave);
+    FREE_AND_NULLIFY(netdef->bond_params.primary_member);
     memset(&netdef->bond_params, 0, sizeof(netdef->bond_params));
 
     netdef->has_vxlans = FALSE;

--- a/src/validation.c
+++ b/src/validation.c
@@ -31,7 +31,7 @@
 #include "util-internal.h"
 #include "validation.h"
 
-/* Check sanity for address types */
+/* Check coherence for address types */
 
 gboolean
 is_ip4_address(const char* address)
@@ -79,7 +79,7 @@ is_wireguard_key(const char* key)
     return FALSE;
 }
 
-/* Check sanity of OpenVSwitch controller targets */
+/* Check coherence of OpenVSwitch controller targets */
 gboolean
 validate_ovs_target(gboolean host_first, gchar* s) {
     static guint dport = 6653; // the default port
@@ -388,7 +388,7 @@ gboolean
 validate_backend_rules(const NetplanParser* npp, NetplanNetDefinition* nd, GError** error)
 {
     gboolean valid = FALSE;
-    /* Set a dummy, NULL yaml_node_t for error reporting */
+    /* Set a placeholder, NULL yaml_node_t for error reporting */
     yaml_node_t* node = NULL;
 
     g_assert(nd->type != NETPLAN_DEF_TYPE_NONE);
@@ -414,7 +414,7 @@ validate_sriov_rules(const NetplanParser* npp, NetplanNetDefinition* nd, GError*
     NetplanNetDefinition* def;
     GHashTableIter iter;
     gboolean valid = FALSE;
-    /* Set a dummy, NULL yaml_node_t for error reporting */
+    /* Set a placeholder, NULL yaml_node_t for error reporting */
     yaml_node_t* node = NULL;
 
     g_assert(nd->type != NETPLAN_DEF_TYPE_NONE);

--- a/tests/cli/test_get_set.py
+++ b/tests/cli/test_get_set.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Blackbox tests of netplan CLI. These are run during "make check" and don't
+# Functional tests of netplan CLI. These are run during "make check" and don't
 # touch the system configuration at all.
 #
 # Copyright (C) 2020 Canonical, Ltd.

--- a/tests/cli/test_units.py
+++ b/tests/cli/test_units.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Blackbox tests of netplan CLI. These are run during "make check" and don't
+# Functional tests of netplan CLI. These are run during "make check" and don't
 # touch the system configuration at all.
 #
 # Copyright (C) 2021 Canonical, Ltd.

--- a/tests/cli_legacy.py
+++ b/tests/cli_legacy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Blackbox tests of netplan CLI. These are run during "make check" and don't
+# Functional tests of netplan CLI. These are run during "make check" and don't
 # touch the system configuration at all.
 #
 # Copyright (C) 2016 Canonical, Ltd.

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -1,5 +1,5 @@
 #
-# Blackbox tests of netplan generate that verify that the generated
+# Functional tests of netplan generate that verify that the generated
 # configuration files look as expected. These are run during "make check" and
 # don't touch the system configuration at all.
 #

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -253,7 +253,7 @@ UseMTU=true
       interfaces: [eno1, switchports]
       dhcp4: true''', skip_generated_yaml_validation=True)
         # Skipping the yaml validation above because the emitter will use
-        # all-members_active and packets-per-member by default.
+        # all-members-active and packets-per-member by default.
 
         self.assert_networkd({'bn0.netdev': '[NetDev]\nName=bn0\nKind=bond\n\n'
                                             '[Bond]\n'
@@ -736,7 +736,7 @@ method=ignore
         learn-packet-interval: 10
       dhcp4: true''', skip_generated_yaml_validation=True)
         # Skipping the yaml validation above because the emitter will use
-        # all-members_active and packets-per-member by default.
+        # all-members-active and packets-per-member by default.
 
         self.assert_nm({'eno1': '''[connection]
 id=netplan-eno1

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -235,7 +235,7 @@ UseMTU=true
         min-links: 10
         up-delay: 20
         down-delay: 30
-        all-slaves-active: true
+        all-slaves-active: true  # wokeignore:rule=slave
         transmit-hash-policy: none
         ad-select: none
         arp-interval: 15
@@ -243,7 +243,7 @@ UseMTU=true
         arp-all-targets: all
         fail-over-mac-policy: none
         gratuitious-arp: 10
-        packets-per-slave: 10
+        packets-per-slave: 10  # wokeignore:rule=slave
         primary-reselect-policy: none
         resend-igmp: 10
         learn-packet-interval: 10

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -188,7 +188,7 @@ UseMTU=true
                                             'MinLinks=10\n'
                                             'TransmitHashPolicy=none\n'
                                             'AdSelect=none\n'
-                                            'AllSlavesActive=1\n'
+                                            'AllSlavesActive=1\n'  # wokeignore:rule=slave
                                             'ARPIntervalSec=15ms\n'
                                             'ARPIPTargets=10.10.10.10 20.20.20.20\n'
                                             'ARPValidate=all\n'
@@ -197,7 +197,7 @@ UseMTU=true
                                             'DownDelaySec=30ms\n'
                                             'FailOverMACPolicy=none\n'
                                             'GratuitousARP=10\n'
-                                            'PacketsPerSlave=10\n'
+                                            'PacketsPerSlave=10\n'  # wokeignore:rule=slave
                                             'PrimaryReselectPolicy=none\n'
                                             'ResendIGMP=10\n'
                                             'LearnPacketIntervalSec=10\n',
@@ -263,7 +263,7 @@ UseMTU=true
                                             'MinLinks=10\n'
                                             'TransmitHashPolicy=none\n'
                                             'AdSelect=none\n'
-                                            'AllSlavesActive=1\n'
+                                            'AllSlavesActive=1\n'  # wokeignore:rule=slave
                                             'ARPIntervalSec=15ms\n'
                                             'ARPIPTargets=10.10.10.10 20.20.20.20\n'
                                             'ARPValidate=all\n'
@@ -272,7 +272,7 @@ UseMTU=true
                                             'DownDelaySec=30ms\n'
                                             'FailOverMACPolicy=none\n'
                                             'GratuitousARP=10\n'
-                                            'PacketsPerSlave=10\n'
+                                            'PacketsPerSlave=10\n'  # wokeignore:rule=slave
                                             'PrimaryReselectPolicy=none\n'
                                             'ResendIGMP=10\n'
                                             'LearnPacketIntervalSec=10\n',
@@ -368,7 +368,8 @@ RouteMetric=100
 UseMTU=true
 ''',
                               'eno1.network': '[Match]\nName=eno1\n\n'
-                                              '[Network]\nLinkLocalAddressing=no\nBond=bn0\nPrimarySlave=true\n',
+                                              '[Network]\nLinkLocalAddressing=no\nBond=bn0\n'
+                                              'PrimarySlave=true\n',  # wokeignore:rule=slave
                               'switchports.network': '[Match]\nDriver=yayroute\n\n'
                                                      '[Network]\nLinkLocalAddressing=no\nBond=bn0\n'})
 
@@ -401,7 +402,7 @@ Name=enp65s0
 [Network]
 LinkLocalAddressing=no
 Bond=bond0
-PrimarySlave=true
+PrimarySlave=true # wokeignore:rule=slave
 ''',
                               'faketh2.network': '[Match]\nName=faketh2\n\n[Network]\nLinkLocalAddressing=no\nBridge=vbr\n',
                               'bond0.network': '[Match]\nName=bond0\n\n'
@@ -493,8 +494,8 @@ method=ignore
 id=netplan-eno1
 type=ethernet
 interface-name=eno1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -509,8 +510,8 @@ method=ignore
 id=netplan-switchport
 type=ethernet
 interface-name=enp2s1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -554,8 +555,8 @@ method=ignore
 id=netplan-eno1
 type=ethernet
 interface-name=eno1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -570,8 +571,8 @@ method=ignore
 id=netplan-switchport
 type=ethernet
 interface-name=enp2s1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -636,8 +637,8 @@ method=ignore
 id=netplan-eno1
 type=ethernet
 interface-name=eno1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -652,8 +653,8 @@ method=ignore
 id=netplan-switchport
 type=ethernet
 interface-name=enp2s1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -676,7 +677,7 @@ miimon=10
 min_links=10
 xmit_hash_policy=none
 ad_select=none
-all_slaves_active=1
+all_slaves_active=1 # wokeignore:rule=slave
 arp_interval=10
 arp_ip_target=10.10.10.10,20.20.20.20
 arp_validate=all
@@ -686,7 +687,7 @@ downdelay=10
 fail_over_mac=none
 num_grat_arp=10
 num_unsol_na=10
-packets_per_slave=10
+packets_per_slave=10 # wokeignore:rule=slave
 primary_reselect=none
 resend_igmp=10
 lp_interval=10
@@ -719,7 +720,7 @@ method=ignore
         min-links: 10
         up-delay: 10
         down-delay: 10
-        all-slaves-active: true
+        all-slaves-active: true # wokeignore:rule=slave
         transmit-hash-policy: none
         ad-select: none
         arp-interval: 10
@@ -730,7 +731,7 @@ method=ignore
           - 20.20.20.20
         fail-over-mac-policy: none
         gratuitious-arp: 10
-        packets-per-slave: 10
+        packets-per-slave: 10 # wokeignore:rule=slave
         primary-reselect-policy: none
         resend-igmp: 10
         learn-packet-interval: 10
@@ -742,8 +743,8 @@ method=ignore
 id=netplan-eno1
 type=ethernet
 interface-name=eno1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -758,8 +759,8 @@ method=ignore
 id=netplan-switchport
 type=ethernet
 interface-name=enp2s1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -782,7 +783,7 @@ miimon=10
 min_links=10
 xmit_hash_policy=none
 ad_select=none
-all_slaves_active=1
+all_slaves_active=1 # wokeignore:rule=slave
 arp_interval=10
 arp_ip_target=10.10.10.10,20.20.20.20
 arp_validate=all
@@ -792,7 +793,7 @@ downdelay=10
 fail_over_mac=none
 num_grat_arp=10
 num_unsol_na=10
-packets_per_slave=10
+packets_per_slave=10 # wokeignore:rule=slave
 primary_reselect=none
 resend_igmp=10
 lp_interval=10
@@ -827,8 +828,8 @@ method=ignore
 id=netplan-eno1
 type=ethernet
 interface-name=eno1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -843,8 +844,8 @@ method=ignore
 id=netplan-switchport
 type=ethernet
 interface-name=enp2s1
-slave-type=bond
-master=bn0
+slave-type=bond # wokeignore:rule=slave
+master=bn0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -304,7 +304,7 @@ UseMTU=true
   ethernets:
     eno1: {}
     enp65s0: {}
-    dummy2: {}
+    faketh2: {}
   bonds:
     bond0:
       interfaces: [eno1, enp65s0]
@@ -317,7 +317,7 @@ UseMTU=true
       link: vbr
   bridges:
     vbr:
-      interfaces: [dummy2]''', expect_fail=False)
+      interfaces: [faketh2]''', expect_fail=False)
 
         self.assert_networkd({'eno1.network': '[Match]\nName=eno1\n\n[Network]\nLinkLocalAddressing=no\nBond=bond0\n',
                               'enp65s0.network': '''[Match]
@@ -328,9 +328,9 @@ LinkLocalAddressing=no
 Bond=bond0
 PrimarySlave=true
 ''',
-                              'dummy2.network': '[Match]\nName=dummy2\n\n[Network]\nLinkLocalAddressing=no\nBridge=vbr\n',
+                              'faketh2.network': '[Match]\nName=faketh2\n\n[Network]\nLinkLocalAddressing=no\nBridge=vbr\n',
                               'bond0.network': '[Match]\nName=bond0\n\n'
-                                                '[Network]\nLinkLocalAddressing=ipv6\nConfigureWithoutCarrier=yes\n',
+                                               '[Network]\nLinkLocalAddressing=ipv6\nConfigureWithoutCarrier=yes\n',
                               'bond0.netdev': '[NetDev]\nName=bond0\nKind=bond\n\n[Bond]\nMode=balance-tlb\n',
                               'vbr-v10.network': '[Match]\nName=vbr-v10\n\n'
                                                  '[Network]\nLinkLocalAddressing=ipv6\nConfigureWithoutCarrier=yes\n',

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -261,7 +261,7 @@ UseMTU=true
                               'switchports.network': '[Match]\nDriver=yayroute\n\n'
                                                      '[Network]\nLinkLocalAddressing=no\nBond=bn0\n'})
 
-    def test_bond_primary_slave(self):
+    def test_bond_primary_member(self):
         self.generate('''network:
   version: 2
   ethernets:
@@ -297,7 +297,7 @@ UseMTU=true
                               'switchports.network': '[Match]\nDriver=yayroute\n\n'
                                                      '[Network]\nLinkLocalAddressing=no\nBond=bn0\n'})
 
-    def test_bond_primary_slave_duplicate(self):
+    def test_bond_primary_member_duplicate(self):
         self.generate('''network:
   version: 2
   renderer: networkd
@@ -625,7 +625,7 @@ method=ignore
         self.assert_networkd({})
         self.assert_nm_udev(NM_MANAGED % 'eno1' + NM_MANAGED % 'enp2s1' + NM_MANAGED % 'bn0')
 
-    def test_bond_primary_slave(self):
+    def test_bond_primary_member(self):
         self.generate('''network:
   version: 2
   renderer: NetworkManager
@@ -727,7 +727,7 @@ class TestConfigErrors(TestBase):
           - 2001:dead:beef::1
       dhcp4: true''', expect_fail=True)
 
-    def test_bond_invalid_primary_slave(self):
+    def test_bond_invalid_primary_member(self):
         self.generate('''network:
   version: 2
   ethernets:
@@ -741,7 +741,7 @@ class TestConfigErrors(TestBase):
         primary: wigglewiggle
       dhcp4: true''', expect_fail=True)
 
-    def test_bond_duplicate_primary_slave(self):
+    def test_bond_duplicate_primary_member(self):
         self.generate('''network:
   version: 2
   ethernets:

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -197,7 +197,7 @@ UseMTU=true
                                                      '[Network]\nLinkLocalAddressing=no\nBridge=br0\n'})
 
     @unittest.skipIf("CODECOV_TOKEN" in os.environ, "Skip on codecov.io: GLib changed hashtable sorting")
-    def test_eth_bridge_nm_blocklist(self):  # pragma: nocover
+    def test_eth_bridge_nm_denylist(self):  # pragma: nocover
         self.generate('''network:
   renderer: networkd
   ethernets:

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -409,8 +409,8 @@ method=ignore
 id=netplan-eno1
 type=ethernet
 interface-name=eno1
-slave-type=bridge
-master=br0
+slave-type=bridge # wokeignore:rule=slave
+master=br0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -425,8 +425,8 @@ method=ignore
 id=netplan-switchport
 type=ethernet
 interface-name=enp2s1
-slave-type=bridge
-master=br0
+slave-type=bridge # wokeignore:rule=slave
+master=br0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -469,8 +469,8 @@ method=ignore
 id=netplan-eno1
 type=ethernet
 interface-name=eno1
-slave-type=bridge
-master=br0
+slave-type=bridge # wokeignore:rule=slave
+master=br0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -485,8 +485,8 @@ method=ignore
 id=netplan-switchport
 type=ethernet
 interface-name=enp2s1
-slave-type=bridge
-master=br0
+slave-type=bridge # wokeignore:rule=slave
+master=br0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0
@@ -540,8 +540,8 @@ method=ignore
 id=netplan-eno1
 type=ethernet
 interface-name=eno1
-slave-type=bridge
-master=br0
+slave-type=bridge # wokeignore:rule=slave
+master=br0 # wokeignore:rule=master
 
 [bridge-port]
 path-cost=70
@@ -560,8 +560,8 @@ method=ignore
 id=netplan-switchport
 type=ethernet
 interface-name=enp2s1
-slave-type=bridge
-master=br0
+slave-type=bridge # wokeignore:rule=slave
+master=br0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0

--- a/tests/generator/test_bridges.py
+++ b/tests/generator/test_bridges.py
@@ -197,7 +197,7 @@ UseMTU=true
                                                      '[Network]\nLinkLocalAddressing=no\nBridge=br0\n'})
 
     @unittest.skipIf("CODECOV_TOKEN" in os.environ, "Skip on codecov.io: GLib changed hashtable sorting")
-    def test_eth_bridge_nm_blacklist(self):  # pragma: nocover
+    def test_eth_bridge_nm_blocklist(self):  # pragma: nocover
         self.generate('''network:
   renderer: networkd
   ethernets:

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -878,8 +878,8 @@ method=ignore
 id=netplan-eth1
 type=ethernet
 interface-name=eth1
-slave-type=bond
-master=bond0
+slave-type=bond # wokeignore:rule=slave
+master=bond0 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -139,7 +139,7 @@ Name=lom1
 LinkLocalAddressing=ipv6
 '''})
         self.assert_networkd_udev({'def1.rules': (UDEV_NO_MAC_RULE % ('ixgbe', 'lom1'))})
-        # NM cannot match by driver, so blacklisting needs to happen via udev
+        # NM cannot match by driver, so blocklisting needs to happen via udev
         self.assert_nm(None)
         self.assert_nm_udev(NM_UNMANAGED % 'lom1' + NM_UNMANAGED_DRIVER % 'ixgbe')
 

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -139,7 +139,7 @@ Name=lom1
 LinkLocalAddressing=ipv6
 '''})
         self.assert_networkd_udev({'def1.rules': (UDEV_NO_MAC_RULE % ('ixgbe', 'lom1'))})
-        # NM cannot match by driver, so blocklisting needs to happen via udev
+        # NM cannot match by driver, so denylisting needs to happen via udev
         self.assert_nm(None)
         self.assert_nm_udev(NM_UNMANAGED % 'lom1' + NM_UNMANAGED_DRIVER % 'ixgbe')
 

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -216,7 +216,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/if
       interfaces: [eth1, eth2]
       openvswitch: {}
 ''', expect_fail=True)
-        self.assertIn("Bond bond0 needs to be a slave of an OpenVSwitch bridge", err)
+        self.assertIn("Bond bond0 needs to be a member of an OpenVSwitch bridge", err)
 
     def test_bond_not_enough_interfaces(self):
         err = self.generate('''network:
@@ -233,7 +233,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/if
       interfaces: [bond0]
       openvswitch: {}
 ''', expect_fail=True)
-        self.assertIn("Bond bond0 needs to have at least 2 slave interfaces", err)
+        self.assertIn("Bond bond0 needs to have at least 2 member interfaces", err)
 
     def test_bond_lacp(self):
         self.generate('''network:

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -129,7 +129,7 @@ id=netplan-NM-87749f1d-334f-40b2-98d4-55db58965f5f
 #Netplan: passthrough setting
 uuid=87749f1d-334f-40b2-98d4-55db58965f5f
 #Netplan: passthrough setting
-type=dummy
+type=dummy # wokeignore:rule=dummy
 
 [ipv4]
 method=link-local
@@ -137,7 +137,7 @@ method=link-local
 [ipv6]
 method=ignore
 '''}, '''[device-netplan.nm-devices.NM-87749f1d-334f-40b2-98d4-55db58965f5f]
-match-device=type:dummy
+match-device=type:dummy # wokeignore:rule=dummy
 managed=1\n\n''')
 
     def test_passthrough_dotted_group(self):

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -122,7 +122,7 @@ managed=1\n\n''')
       networkmanager:
         passthrough:
           connection.uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
-          connection.type: dummy''')
+          connection.type: dummy''')  # wokeignore:rule=dummy
 
         self.assert_nm({'NM-87749f1d-334f-40b2-98d4-55db58965f5f': '''[connection]
 id=netplan-NM-87749f1d-334f-40b2-98d4-55db58965f5f

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -122,14 +122,14 @@ managed=1\n\n''')
       networkmanager:
         passthrough:
           connection.uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
-          connection.type: dummy''')
+          connection.type: faketype''')
 
         self.assert_nm({'NM-87749f1d-334f-40b2-98d4-55db58965f5f': '''[connection]
 id=netplan-NM-87749f1d-334f-40b2-98d4-55db58965f5f
 #Netplan: passthrough setting
 uuid=87749f1d-334f-40b2-98d4-55db58965f5f
 #Netplan: passthrough setting
-type=dummy
+type=faketype
 
 [ipv4]
 method=link-local
@@ -137,7 +137,7 @@ method=link-local
 [ipv6]
 method=ignore
 '''}, '''[device-netplan.nm-devices.NM-87749f1d-334f-40b2-98d4-55db58965f5f]
-match-device=type:dummy
+match-device=type:faketype
 managed=1\n\n''')
 
     def test_passthrough_dotted_group(self):

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -122,14 +122,14 @@ managed=1\n\n''')
       networkmanager:
         passthrough:
           connection.uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
-          connection.type: faketype''')
+          connection.type: dummy''')
 
         self.assert_nm({'NM-87749f1d-334f-40b2-98d4-55db58965f5f': '''[connection]
 id=netplan-NM-87749f1d-334f-40b2-98d4-55db58965f5f
 #Netplan: passthrough setting
 uuid=87749f1d-334f-40b2-98d4-55db58965f5f
 #Netplan: passthrough setting
-type=faketype
+type=dummy
 
 [ipv4]
 method=link-local
@@ -137,7 +137,7 @@ method=link-local
 [ipv6]
 method=ignore
 '''}, '''[device-netplan.nm-devices.NM-87749f1d-334f-40b2-98d4-55db58965f5f]
-match-device=type:faketype
+match-device=type:dummy
 managed=1\n\n''')
 
     def test_passthrough_dotted_group(self):

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -464,8 +464,8 @@ Endpoint=1.2.3.4:5'''),
 id=netplan-wg0
 type=wireguard
 interface-name=wg0
-slave-type=bridge
-master=br0
+slave-type=bridge # wokeignore:rule=slave
+master=br0 # wokeignore:rule=master
 
 [wireguard]
 private-key=4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=
@@ -665,8 +665,8 @@ Kind=bridge\n'''})
 id=netplan-vxlan1005
 type=vxlan
 interface-name=vxlan1005
-slave-type=bridge
-master=br0
+slave-type=bridge # wokeignore:rule=slave
+master=br0 # wokeignore:rule=master
 
 [vxlan]
 ageing=42

--- a/tests/generator/test_vrfs.py
+++ b/tests/generator/test_vrfs.py
@@ -43,8 +43,8 @@ class NetworkManager(TestBase):
 id=netplan-eth0
 type=ethernet
 interface-name=eth0
-slave-type=vrf
-master=vrf1005
+slave-type=vrf # wokeignore:rule=slave
+master=vrf1005 # wokeignore:rule=master
 
 [ethernet]
 wake-on-lan=0

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -443,7 +443,7 @@ class IntegrationTestsWifi(IntegrationTestsBase):
         klass.dev_w_client = devs[1]
 
         # don't let NM trample over our fake AP
-        with open('/run/NetworkManager/conf.d/test-blocklist.conf', 'w') as f:
+        with open('/run/NetworkManager/conf.d/test-denylist.conf', 'w') as f:
             f.write('[main]\nplugins=keyfile\n[keyfile]\nunmanaged-devices+=nptestsrv,%s\n' % klass.dev_w_ap)
 
     @classmethod

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -78,7 +78,7 @@ unmanaged-devices+=interface-name:eth0,interface-name:en*,interface-name:veth42,
     @classmethod
     def tearDownClass(klass):
         try:
-            os.remove('/run/NetworkManager/conf.d/test-blocklist.conf')
+            os.remove('/run/NetworkManager/conf.d/test-denylist.conf')
         except FileNotFoundError:
             pass
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -78,7 +78,7 @@ unmanaged-devices+=interface-name:eth0,interface-name:en*,interface-name:veth42,
     @classmethod
     def tearDownClass(klass):
         try:
-            os.remove('/run/NetworkManager/conf.d/test-blacklist.conf')
+            os.remove('/run/NetworkManager/conf.d/test-blocklist.conf')
         except FileNotFoundError:
             pass
 
@@ -443,7 +443,7 @@ class IntegrationTestsWifi(IntegrationTestsBase):
         klass.dev_w_client = devs[1]
 
         # don't let NM trample over our fake AP
-        with open('/run/NetworkManager/conf.d/test-blacklist.conf', 'w') as f:
+        with open('/run/NetworkManager/conf.d/test-blocklist.conf', 'w') as f:
             f.write('[main]\nplugins=keyfile\n[keyfile]\nunmanaged-devices+=nptestsrv,%s\n' % klass.dev_w_ap)
 
     @classmethod

--- a/tests/integration/bonds.py
+++ b/tests/integration/bonds.py
@@ -89,7 +89,7 @@ class _CommonTests():
     mybond:
       interfaces: [ethbn]
       parameters:
-        all-slaves-active: true  # wokeignore:rule=slave
+        all-members-active: true
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
         self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
@@ -255,7 +255,7 @@ class _CommonTests():
     mybond:
       parameters:
         mode: balance-rr
-        packets-per-slave: 15  # wokeignore:rule=slave
+        packets-per-member: 15
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])

--- a/tests/integration/bonds.py
+++ b/tests/integration/bonds.py
@@ -44,9 +44,9 @@ class _CommonTests():
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
 
     def test_bond_primary_member(self):
@@ -66,10 +66,10 @@ class _CommonTests():
         primary: %(ec)s
       addresses: [ '10.10.10.1/24' ]''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'mybond'])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
-        self.assert_iface_up(self.dev_e2_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
+        self.assert_iface_up(self.dev_e2_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 10.10.10.1/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             result = f.read().strip()
             self.assertIn(self.dev_e_client, result)
             self.assertIn(self.dev_e2_client, result)
@@ -89,14 +89,14 @@ class _CommonTests():
     mybond:
       interfaces: [ethbn]
       parameters:
-        all-slaves-active: true
+        all-slaves-active: true  # wokeignore:rule=slave
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
-        with open('/sys/class/net/mybond/bonding/all_slaves_active') as f:
+        with open('/sys/class/net/mybond/bonding/all_slaves_active') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), '1')
 
     def test_bond_mode_8023ad(self):
@@ -115,9 +115,9 @@ class _CommonTests():
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
             self.assertEqual(f.read().strip(), '802.3ad 4')
@@ -139,9 +139,9 @@ class _CommonTests():
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/ad_select') as f:
             self.assertEqual(f.read().strip(), 'bandwidth 1')
@@ -163,9 +163,9 @@ class _CommonTests():
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/lacp_rate') as f:
             self.assertEqual(f.read().strip(), 'fast 1')
@@ -187,9 +187,9 @@ class _CommonTests():
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
             self.assertEqual(f.read().strip(), 'active-backup 1')
@@ -212,9 +212,9 @@ class _CommonTests():
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
             self.assertEqual(f.read().strip(), 'balance-xor 2')
@@ -235,9 +235,9 @@ class _CommonTests():
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
             self.assertEqual(f.read().strip(), 'balance-rr 0')
@@ -255,17 +255,17 @@ class _CommonTests():
     mybond:
       parameters:
         mode: balance-rr
-        packets-per-slave: 15
+        packets-per-slave: 15  # wokeignore:rule=slave
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
             self.assertEqual(f.read().strip(), 'balance-rr 0')
-        with open('/sys/class/net/mybond/bonding/packets_per_slave') as f:
+        with open('/sys/class/net/mybond/bonding/packets_per_slave') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), '15')
 
     def test_bond_resend_igmp(self):
@@ -289,10 +289,10 @@ class _CommonTests():
         resend-igmp: 100
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'mybond'])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
-        self.assert_iface_up(self.dev_e2_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
+        self.assert_iface_up(self.dev_e2_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.9.9/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             result = f.read().strip()
             self.assertIn(self.dev_e_client, result)
             self.assertIn(self.dev_e2_client, result)
@@ -322,7 +322,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       dhcp4: yes''' % {'r': self.backend,
                        'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24', '00:01:02:03:04:05'])
 
     def test_bond_down_delay(self):
@@ -343,9 +343,9 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         down-delay: 10s
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/downdelay') as f:
             self.assertEqual(f.read().strip(), '10000')
@@ -368,9 +368,9 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         up-delay: 10000
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/updelay') as f:
             self.assertEqual(f.read().strip(), '10000')
@@ -393,9 +393,9 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-interval: 50s
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_interval') as f:
             self.assertEqual(f.read().strip(), '50000')
@@ -418,9 +418,9 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-ip-targets: [ 192.168.5.1 ]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_ip_target') as f:
             self.assertEqual(f.read().strip(), '192.168.5.1')
@@ -443,9 +443,9 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-ip-targets: [ 192.168.5.1, 192.168.5.34 ]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_ip_target') as f:
             result = f.read().strip()
@@ -472,9 +472,9 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-validate: all
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_all_targets') as f:
             self.assertEqual(f.read().strip(), 'all 1')
@@ -498,9 +498,9 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         arp-validate: all
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_validate') as f:
             self.assertEqual(f.read().strip(), 'all 3')
@@ -533,9 +533,9 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         down-delay: 10000
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/downdelay') as f:
             self.assertEqual(f.read().strip(), '10000')
@@ -558,9 +558,9 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         up-delay: 10000
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/updelay') as f:
             self.assertEqual(f.read().strip(), '10000')
@@ -583,9 +583,9 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         arp-interval: 50000
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_interval') as f:
             self.assertEqual(f.read().strip(), '50000')
@@ -608,9 +608,9 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         arp-ip-targets: [ 192.168.5.1 ]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_ip_target') as f:
             self.assertEqual(f.read().strip(), '192.168.5.1')
@@ -635,9 +635,9 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         arp-validate: all
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/arp_all_targets') as f:
             self.assertEqual(f.read().strip(), 'all 1')
@@ -660,9 +660,9 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
       interfaces: [ethbn]
       dhcp4: yes''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('mybond')])
-        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master mybond'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertEqual(f.read().strip(), self.dev_e_client)
         with open('/sys/class/net/mybond/bonding/mode') as f:
             self.assertEqual(f.read().strip(), 'balance-tlb 5')

--- a/tests/integration/bonds.py
+++ b/tests/integration/bonds.py
@@ -49,7 +49,7 @@ class _CommonTests():
         with open('/sys/class/net/mybond/bonding/slaves') as f:
             self.assertEqual(f.read().strip(), self.dev_e_client)
 
-    def test_bond_primary_slave(self):
+    def test_bond_primary_member(self):
         self.setup_eth(None)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'mybond'], stderr=subprocess.DEVNULL)
         with open(self.config, 'w') as f:
@@ -76,7 +76,7 @@ class _CommonTests():
         with open('/sys/class/net/mybond/bonding/primary') as f:
             self.assertEqual(f.read().strip(), '%(ec)s' % {'ec': self.dev_e_client})
 
-    def test_bond_all_slaves_active(self):
+    def test_bond_all_members_active(self):
         self.setup_eth(None)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'mybond'], stderr=subprocess.DEVNULL)
         with open(self.config, 'w') as f:

--- a/tests/integration/bridges.py
+++ b/tests/integration/bridges.py
@@ -49,7 +49,7 @@ class _CommonTests():
                                   self.dev_e2_client,
                                   self.state_dhcp4('mybr')])
         self.assert_iface_up(self.dev_e_client, ['inet 192.168.5.[0-9]+/24'])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
@@ -80,7 +80,7 @@ class _CommonTests():
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
@@ -106,7 +106,7 @@ class _CommonTests():
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
@@ -132,7 +132,7 @@ class _CommonTests():
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
@@ -158,7 +158,7 @@ class _CommonTests():
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
@@ -184,7 +184,7 @@ class _CommonTests():
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
@@ -211,7 +211,7 @@ class _CommonTests():
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
@@ -238,7 +238,7 @@ class _CommonTests():
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
@@ -272,7 +272,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
                        'ec': self.dev_e_client,
                        'ec_mac': self.dev_e_client_mac})
         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('br0')])
-        self.assert_iface_up(self.dev_e_client, ['master br0'], ['inet '])
+        self.assert_iface_up(self.dev_e_client, ['master br0'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('br0', ['inet 192.168.5.[0-9]+/24', 'ether 00:01:02:03:04:05'])
 
     def test_bridge_anonymous(self):
@@ -288,7 +288,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
     mybr:
       interfaces: [ethbr]''' % {'r': self.backend, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e2_client, self.state_up('mybr')])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', [], ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()
@@ -335,7 +335,7 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         stp: false
       dhcp4: yes''' % {'r': self.backend, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e2_client, self.state_dhcp4('mybr')])
-        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
                                         universal_newlines=True).splitlines()

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -190,7 +190,7 @@ class _CommonTests():
         self.assertIn(b'    Bridge br-data', out)
         self.assert_iface('br-%s' % self.dev_e_client, ['mtu 9000'])
         self.assert_iface('br-data', ['inet 192.168.20.1/16'])
-        self.assert_iface(self.dev_e_client, ['mtu 9000', 'master ovs-system'])
+        self.assert_iface(self.dev_e_client, ['mtu 9000', 'master ovs-system'])  # wokeignore:rule=master
         self.assertIn(b'100', subprocess.check_output(['ovs-vsctl', '-t', '5', 'br-to-vlan',
                       'br-%s.100' % self.dev_e_client]))
         self.assertIn(b'br-%b' % self.dev_e_client.encode(), subprocess.check_output(
@@ -323,8 +323,8 @@ class _CommonTests():
         self.assertIn(b'---- mybond ----', out)
         self.assertIn(b'bond_mode: balance-slb', out)
         self.assertIn(b'lacp_status: off', out)
-        self.assertRegex(out, br'(slave|member) %b: enabled' % self.dev_e_client.encode())
-        self.assertRegex(out, br'(slave|member) %b: enabled' % self.dev_e2_client.encode())
+        self.assertRegex(out, br'(slave|member) %b: enabled' % self.dev_e_client.encode())  # wokeignore:rule=slave
+        self.assertRegex(out, br'(slave|member) %b: enabled' % self.dev_e2_client.encode())  # wokeignore:rule=slave
         self.assert_iface('ovsbr', ['inet 192.170.1.1/24'])
 
     def test_bridge_patch_ports(self):
@@ -387,9 +387,9 @@ class _CommonTests():
         self.assertIn('''        Port ovs-br
             Interface ovs-br
                 type: internal''', out)
-        self.assert_iface('non-ovs-bond', ['master ovs-system'])
-        self.assert_iface(self.dev_e_client, ['master non-ovs-bond'])
-        self.assert_iface(self.dev_e2_client, ['master non-ovs-bond'])
+        self.assert_iface('non-ovs-bond', ['master ovs-system'])  # wokeignore:rule=master
+        self.assert_iface(self.dev_e_client, ['master non-ovs-bond'])  # wokeignore:rule=master
+        self.assert_iface(self.dev_e2_client, ['master non-ovs-bond'])  # wokeignore:rule=master
 
     def test_vlan_maas(self):
         self.setup_eth(None, False)

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -74,13 +74,13 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'mybond'])
         self.assert_iface_up(self.dev_e_client,
-                             ['master mybond', '00:0a:f7:72:a7:28'],
+                             ['master mybond', '00:0a:f7:72:a7:28'],  # wokeignore:rule=master
                              ['inet '])
         self.assert_iface_up(self.dev_e2_client,
-                             ['master mybond', '00:0a:f7:72:a7:28'],
+                             ['master mybond', '00:0a:f7:72:a7:28'],  # wokeignore:rule=master
                              ['inet '])
         self.assert_iface_up('mybond', ['inet 192.168.5.[0-9]+/24'])
-        with open('/sys/class/net/mybond/bonding/slaves') as f:
+        with open('/sys/class/net/mybond/bonding/slaves') as f:  # wokeignore:rule=slave
             self.assertIn(self.dev_e_client, f.read().strip())
 
     def test_try_accept_lp1949095(self):

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -304,8 +304,8 @@ class _CommonTests():
       - from: 10.10.10.42
 ''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client])
-        self.assert_iface_up(self.dev_e_client, ['inet 10.10.10.22', 'master vrf0'])
-        self.assert_iface_up('vrf0', ['MASTER'])
+        self.assert_iface_up(self.dev_e_client, ['inet 10.10.10.22', 'master vrf0'])  # wokeignore:rule=master
+        self.assert_iface_up('vrf0', ['MASTER'])  # wokeignore:rule=master
         # verify routes didn't leak into the main routing table
         out = subprocess.check_output(['ip', 'route', 'show'], universal_newlines=True)
         self.assertNotIn('10.10.0.0/16', out)

--- a/tests/integration/scenarios.py
+++ b/tests/integration/scenarios.py
@@ -57,10 +57,10 @@ class _CommonTests():
       match: {name: %(e2c)s}
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'br0', 'bond0'])
-        self.assert_iface_up(self.dev_e2_client, ['master bond0'], ['inet '])
-        self.assert_iface_up('bond0', ['master br0'])
+        self.assert_iface_up(self.dev_e2_client, ['master bond0'], ['inet '])  # wokeignore:rule=master
+        self.assert_iface_up('bond0', ['master br0'])  # wokeignore:rule=master
         self.assert_iface('br0', ['inet 192.168.0.2/24'])
-        with open('/sys/class/net/bond0/bonding/slaves') as f:
+        with open('/sys/class/net/bond0/bonding/slaves') as f:  # wokeignore:rule=slave
             result = f.read().strip()
             self.assertIn(self.dev_e2_client, result)
 
@@ -106,9 +106,9 @@ class _CommonTests():
 ''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'br0', 'br1', 'bond0', 'vlan1', 'vlan2'])
         self.assert_iface_up('vlan1', ['vlan1@br0'])
-        self.assert_iface_up('vlan2', ['vlan2@' + self.dev_e_client, 'master br0'])
-        self.assert_iface_up(self.dev_e2_client, ['master br1'], ['inet '])
-        self.assert_iface_up('bond0', ['master br0'])
+        self.assert_iface_up('vlan2', ['vlan2@' + self.dev_e_client, 'master br0'])  # wokeignore:rule=master
+        self.assert_iface_up(self.dev_e2_client, ['master br1'], ['inet '])  # wokeignore:rule=master
+        self.assert_iface_up('bond0', ['master br0'])  # wokeignore:rule=master
 
     # https://bugs.launchpad.net/netplan/+bug/1943120
     def test_remove_virtual_interfaces(self):

--- a/tests/integration/wifi.py
+++ b/tests/integration/wifi.py
@@ -152,7 +152,7 @@ class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
 
     def test_wifi_ap_open(self):
         # we use dev_w_client and dev_w_ap in switched roles here, to keep the
-        # existing device blacklisting in NM; i. e. dev_w_client is the
+        # existing device blocklisting in NM; i. e. dev_w_client is the
         # NM-managed AP, and dev_w_ap the manually managed client
         with open(self.config, 'w') as f:
             f.write('''network:

--- a/tests/integration/wifi.py
+++ b/tests/integration/wifi.py
@@ -152,7 +152,7 @@ class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
 
     def test_wifi_ap_open(self):
         # we use dev_w_client and dev_w_ap in switched roles here, to keep the
-        # existing device blocklisting in NM; i. e. dev_w_client is the
+        # existing device denylisting in NM; i. e. dev_w_client is the
         # NM-managed AP, and dev_w_ap the manually managed client
         with open(self.config, 'w') as f:
             f.write('''network:

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -1,5 +1,5 @@
 #
-# Blackbox tests of netplan's keyfile parser that verify that the generated
+# Functional tests of netplan's keyfile parser that verify that the generated
 # YAML files look as expected. These are run during "make check" and
 # don't touch the system configuration at all.
 #

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -21,6 +21,7 @@
 from configparser import ConfigParser
 from netplan.libnetplan import _GError
 import os
+import re
 import sys
 import shutil
 import tempfile
@@ -41,6 +42,8 @@ os.environ.update({'LD_LIBRARY_PATH': '.:{}'.format(os.environ.get('LD_LIBRARY_P
 os.environ['G_DEBUG'] = 'fatal-criticals'
 
 lib = ctypes.CDLL(ctypes.util.find_library('netplan'))
+
+WOKE_REPLACE_REGEX = ' +# wokeignore:rule=[a-z]+'
 
 
 # A contextmanager to catch the output on a low level so that it catches output
@@ -78,6 +81,7 @@ class TestKeyfileBase(unittest.TestCase):
         err = ctypes.POINTER(_GError)()
         # Autodetect default 'NM-<UUID>' netdef-id
         ssid = ''
+        keyfile = re.sub(WOKE_REPLACE_REGEX, '', keyfile)
         if not netdef_id:
             found_values = 0
             uuid = 'UNKNOWN_UUID'
@@ -124,6 +128,7 @@ class TestKeyfileBase(unittest.TestCase):
 
     def assert_netplan(self, file_contents_map):
         for uuid in file_contents_map.keys():
+            file_contents_map[uuid] = re.sub(WOKE_REPLACE_REGEX, '', file_contents_map[uuid])
             path = os.path.join(self.confdir, '90-NM-{}.yaml'.format(uuid))
             self.assertTrue(os.path.isfile(path))
             st = os.stat(path)
@@ -178,6 +183,7 @@ class TestKeyfileBase(unittest.TestCase):
             self.assertEqual(set(os.listdir(con_dir)),
                              set([n for n in file_contents_map]))
             for fname, contents in file_contents_map.items():
+                contents = re.sub(WOKE_REPLACE_REGEX, '', contents)
                 with open(os.path.join(con_dir, fname)) as f:
                     generated_keyfile = self.normalize_keyfile(f.read())
                     normalized_contents = self.normalize_keyfile(contents)

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Blackbox tests of NetworkManager keyfile parser. These are run during
+# Functional tests of NetworkManager keyfile parser. These are run during
 # "make check" and don't touch the system configuration at all.
 #
 # Copyright (C) 2021 Canonical, Ltd.
@@ -388,7 +388,7 @@ route2=4:5:6:7:8:9:0:1/63,,5
         self._template_keyfile_type('nm-devices', 'wireguard', False)
 
     def test_keyfile_type_other(self):
-        self._template_keyfile_type('nm-devices', 'dummy', False)
+        self._template_keyfile_type('nm-devices', 'faketype', False)
 
     def test_keyfile_type_wifi(self):
         self.generate_from_keyfile('''[connection]

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -948,9 +948,9 @@ method=ignore
         learn-packet-interval: "10"
         arp-interval: "10"
         min-links: 10
-        all-slaves-active: true
+        all-members-active: true
         gratuitous-arp: 10
-        packets-per-slave: 10
+        packets-per-member: 10
         resend-igmp: 10
         arp-ip-targets:
         - 10.10.10.10

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -718,7 +718,7 @@ ip6-privacy=0
 [wifi]
 ssid=my-hotspot
 mode=ap
-mac-address-blacklist=
+mac-address-blacklist= # wokeignore:rule=blacklist
 
 [wifi-security]
 group=ccmp;
@@ -750,7 +750,7 @@ psk=test1234
               ipv4.dns-search: ""
               ipv6.addr-gen-mode: "1"
               ipv6.dns-search: ""
-              wifi.mac-address-blacklist: ""
+              wifi.mac-address-blacklist: "" # wokeignore:rule=blacklist
               wifi-security.group: "ccmp;"
               wifi-security.pairwise: "ccmp;"
               wifi-security.proto: "rsn;"
@@ -906,7 +906,7 @@ miimon=10
 min_links=10
 xmit_hash_policy=none
 ad_select=none
-all_slaves_active=1
+all_slaves_active=1 # wokeignore:rule=slave
 arp_interval=10
 arp_ip_target=10.10.10.10,20.20.20.20
 arp_validate=all
@@ -916,7 +916,7 @@ downdelay=10
 fail_over_mac=none
 num_grat_arp=10
 num_unsol_na=10
-packets_per_slave=10
+packets_per_slave=10 # wokeignore:rule=slave
 primary_reselect=none
 resend_igmp=10
 lp_interval=10
@@ -1063,7 +1063,7 @@ timestamp=305419896
 
 [ethernet]
 mac-address=99:88:77:66:55:44
-mac-address-blacklist=
+mac-address-blacklist= # wokeignore:rule=blacklist
 mtu=900
 
 [ipv4]
@@ -1146,7 +1146,7 @@ route4=5:6:7:8:9:0:1:2/62
           connection.autoconnect: "false"
           connection.permissions: ""
           connection.timestamp: "305419896"
-          ethernet.mac-address-blacklist: ""
+          ethernet.mac-address-blacklist: "" # wokeignore:rule=blacklist
           ipv4.address1: "192.168.0.5/24,192.168.0.1"
           ipv4.dns-search: ""
           ipv4.method: "manual"

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -388,7 +388,7 @@ route2=4:5:6:7:8:9:0:1/63,,5
         self._template_keyfile_type('nm-devices', 'wireguard', False)
 
     def test_keyfile_type_other(self):
-        self._template_keyfile_type('nm-devices', 'dummy', False)
+        self._template_keyfile_type('nm-devices', 'dummy', False)  # wokeignore:rule=dummy
 
     def test_keyfile_type_wifi(self):
         self.generate_from_keyfile('''[connection]

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -388,7 +388,7 @@ route2=4:5:6:7:8:9:0:1/63,,5
         self._template_keyfile_type('nm-devices', 'wireguard', False)
 
     def test_keyfile_type_other(self):
-        self._template_keyfile_type('nm-devices', 'faketype', False)
+        self._template_keyfile_type('nm-devices', 'dummy', False)
 
     def test_keyfile_type_wifi(self):
         self.generate_from_keyfile('''[connection]

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Blackbox tests of certain libnetplan functions. These are run during
+# Functional tests of certain libnetplan functions. These are run during
 # "make check" and don't touch the system configuration at all.
 #
 # Copyright (C) 2020-2021 Canonical, Ltd.

--- a/tests/test_sriov.py
+++ b/tests/test_sriov.py
@@ -73,7 +73,7 @@ class TestSRIOV(unittest.TestCase):
         self.configmanager = ConfigManager(prefix=self.workdir.name, extra_files={})
 
     def _prepare_sysfs_dir_structure(self, pf=('enp2', '0000:00:1f.0'),
-                                     vfs=[('enp2s16f1', '0000:00:1f.6')], pf_driver='dummy_driver'):
+                                     vfs=[('enp2s16f1', '0000:00:1f.6')], pf_driver='fake_driver'):
         """
         Setup sysfs mock for reading certain SR-IOV related files and symlinks
 
@@ -861,7 +861,7 @@ class TestParser(TestBase):
       embedded-switch-mode: switchdev
       delay-virtual-functions-rebind: true
     enblue:
-      match: {driver: dummy_driver}
+      match: {driver: fake_driver}
       set-name: enblue
       embedded-switch-mode: legacy
       delay-virtual-functions-rebind: true

--- a/tests/validate_docs.sh
+++ b/tests/validate_docs.sh
@@ -22,7 +22,7 @@ for term in $(sed -n 's/[ ]\+{"\([a-z0-9-]\+\)", YAML_[A-Z]\+_NODE.*/\1/p' src/p
     fi
 
     # 2. "[blah, ]**blah**[, **blah2**]: (scalar|bool|...)
-    if egrep "\*\*$term\*\*.*\((scalar|bool|mapping|sequence of scalars|sequence of mappings|sequence of sequence of scalars)" doc/netplan-yaml.md > /dev/null; then
+    if egrep "Alias: \*\*$term\*\*|\*\*$term\*\*.*\((scalar|bool|mapping|sequence of scalars|sequence of mappings|sequence of sequence of scalars)" doc/netplan-yaml.md > /dev/null; then
         continue
     fi
 

--- a/tests/validate_docs.sh
+++ b/tests/validate_docs.sh
@@ -3,7 +3,7 @@
 #     {"driver", YAML_SCALAR_NODE,...,
 # extract the thing in quotes.
 
-# sanity check: make sure none have disappeared, as might happen from a reformat.
+# coherence check: make sure none have disappeared, as might happen from a reformat.
 count=$(sed -n 's/[ ]\+{"\([a-z0-9-]\+\)", YAML_[A-Z]\+_NODE.*/\1/p' src/parse.c | sort | wc -l)
 # 144 is based on 0.99+da6f776 definitions, and should be updated periodically.
 if [ $count -lt 202 ]; then


### PR DESCRIPTION
## Description
This PR introduces a new github action used to check for non-inclusive wording in our code base and documentation using Woke.

While not all the occurrences of non-inclusive words were fixed, it also replaces many occurrences with proper language. Most of the remaining occurrences are due to external APIs and tools we rely on.

It provides alternative names for the options below:
    all-slaves-active -> all-members-active
    packets-per-slave -> packets-per-member

The yaml emitter will produce yaml documents using the new words.

Ideally, every single unit test containing the old words should be duplicated to also handle the new one, but at the moment only two tests were adapted.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

