### PR TITLE
generator: Don't reload udev in the generator

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -42,6 +42,9 @@ jobs:
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
+          cp data/netplan-generator.service debian/
+          sed -i '/system-generator/d' debian/netplan-generator.install
+          sed -i '/rm debian\/tmp\/lib\/netplan\/generate/d' debian/rules
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"

--- a/.github/workflows/debci.yml
+++ b/.github/workflows/debci.yml
@@ -46,6 +46,9 @@ jobs:
           dget -u "https://deb.debian.org/debian/pool/main/n/netplan.io/netplan.io_$V.dsc"
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
+          cp data/netplan-generator.service debian/
+          sed -i '/system-generator/d' debian/netplan-generator.install
+          sed -i '/rm debian\/tmp\/lib\/netplan\/generate/d' debian/rules
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"

--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -37,6 +37,9 @@ jobs:
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
+          cp data/netplan-generator.service debian/
+          sed -i '/system-generator/d' debian/netplan-generator.install
+          sed -i '/rm debian\/tmp\/lib\/netplan\/generate/d' debian/rules
           echo "3.0 (native)" > debian/source/format  # force native build
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision

--- a/data/netplan-generator.service
+++ b/data/netplan-generator.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Netplan generator
+Documentation=man:netplan(5)
+Before=systemd-networkd.service cloud-init-local.service NetworkManager.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/netplan/generate
+ExecReload=/usr/libexec/netplan/generate
+
+[Install]
+WantedBy=systemd-networkd.service cloud-init-local.service NetworkManager.service

--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -119,14 +119,8 @@ class NetplanApply(utils.NetplanCommand):
         nm_ifaces = utils.nm_interfaces(old_nm_glob, netifaces.interfaces())
         old_files_nm = bool(old_nm_glob)
 
-        generator_call = []
-        generate_out = None
-        if 'NETPLAN_PROFILE' in os.environ:
-            generator_call.extend(['valgrind', '--leak-check=full'])
-            generate_out = subprocess.STDOUT
-
-        generator_call.append(utils.get_generator_path())
-        if run_generate and subprocess.call(generator_call, stderr=generate_out) != 0:
+        generator_call = ['/usr/sbin/netplan', 'generate']
+        if run_generate and subprocess.call(generator_call) != 0:
             if exit_on_error:
                 sys.exit(os.EX_CONFIG)
             else:

--- a/netplan_cli/cli/commands/generate.py
+++ b/netplan_cli/cli/commands/generate.py
@@ -75,14 +75,20 @@ class NetplanGenerate(utils.NetplanCommand):
             else:
                 return
 
-        argv = [utils.get_generator_path()]
+        argv = []
+        generate_out = None
+        if 'NETPLAN_PROFILE' in os.environ:
+            argv.extend(['valgrind', '--leak-check=full'])
+            generate_out = subprocess.STDOUT
+
+        argv.append(utils.get_generator_path())
         if self.root_dir:
             argv += ['--root-dir', self.root_dir]
         if self.mapping:
             argv += ['--mapping', self.mapping]
         logging.debug('command generate: running %s', argv)
         # FIXME: os.execv(argv[0], argv) would be better but fails coverage
-        res = subprocess.call(argv)
+        res = subprocess.call(argv, stderr=generate_out)
 
         if res != 0:
             logging.warning("netplan generator failed to run: error %s", res)

--- a/netplan_cli/cli/commands/generate.py
+++ b/netplan_cli/cli/commands/generate.py
@@ -77,7 +77,7 @@ class NetplanGenerate(utils.NetplanCommand):
 
         argv = []
         generate_out = None
-        if 'NETPLAN_PROFILE' in os.environ:
+        if 'NETPLAN_PROFILE' in os.environ:  # pragma: nocover (only used for profiling)
             argv.extend(['valgrind', '--leak-check=full'])
             generate_out = subprocess.STDOUT
 

--- a/src/generate.c
+++ b/src/generate.c
@@ -49,13 +49,6 @@ static GOptionEntry options[] = {
     {NULL}
 };
 
-static void
-reload_udevd(void)
-{
-    const gchar *argv[] = { "/bin/udevadm", "control", "--reload", NULL };
-    g_spawn_sync(NULL, (gchar**)argv, NULL, G_SPAWN_STDERR_TO_DEV_NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-};
-
 /**
  * Create enablement symlink for systemd-networkd.service.
  */
@@ -283,13 +276,6 @@ int main(int argc, char** argv)
 
         CHECK_CALL(netplan_state_finish_nm_write(np_state, rootdir, &error));
         CHECK_CALL(netplan_state_finish_sriov_write(np_state, rootdir, &error));
-        /* We may have written .rules & .link files, thus we must
-         * invalidate udevd cache of its config as by default it only
-         * invalidates cache at most every 3 seconds. Not sure if this
-         * should live in `generate' or `apply', but it is confusing
-         * when udevd ignores just-in-time created rules files.
-         */
-        reload_udevd();
     }
 
     /* Disable /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,11 +34,3 @@ executable(
     dependencies: [glib, gio, yaml, uuid],
     install_dir: libexec_netplan,
     install: true)
-meson.add_install_script(meson_make_symlink,
-    join_paths(get_option('prefix'), libexec_netplan, 'generate'),
-    join_paths(systemd_generator_dir, 'netplan'))
-# FIXME: Drop legacy symlink after 0.107 is released:
-# It's only around for legacy reasons, see netplan/cli/utils.py: get_generator_path()
-meson.add_install_script(meson_make_symlink,
-    join_paths(get_option('prefix'), libexec_netplan, 'generate'),
-    join_paths('/', 'lib', 'netplan', 'generate'))

--- a/tests/cli_legacy.py
+++ b/tests/cli_legacy.py
@@ -86,6 +86,12 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(os.listdir(self.workdir.name), ['run'])
 
     def test_with_empty_config(self):
+        mock_udevadm = MockCmd('udevadm')
+        mock_udevadm.set_returncode(0)
+        mock_udevadm.set_output(b'')
+        path_env = os.environ['PATH']
+        os.environ['PATH'] = os.path.dirname(mock_udevadm.path) + os.pathsep + path_env
+
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         path_a = os.path.join(c, 'a.yaml')
@@ -104,6 +110,12 @@ class TestGenerate(unittest.TestCase):
                          ['10-netplan-enlol.network'])
 
     def test_with_config(self):
+        mock_udevadm = MockCmd('udevadm')
+        mock_udevadm.set_returncode(0)
+        mock_udevadm.set_output(b'')
+        path_env = os.environ['PATH']
+        os.environ['PATH'] = os.path.dirname(mock_udevadm.path) + os.pathsep + path_env
+
         c = os.path.join(self.workdir.name, 'etc', 'netplan')
         os.makedirs(c)
         with open(os.path.join(c, 'a.yaml'), 'w') as f:


### PR DESCRIPTION
The systemd documentation states that any kind of process communication shouldn't happen inside generators. It can cause problems like the one reported in LP#1999178:

`Generators are run very early at boot and cannot rely on any external services. They may not talk to any other process. That includes simple things such as logging to syslog(3), or systemd itself (this means: no systemctl(1))!`

Ubuntu IS also affected by the same issue! We are observing long pauses during upgrades from Lunar to Mantic due to a package (usbmuxd) installing a udev rules file referring to a user that will be created late in the upgrade process. Every daemon-reload will stuck for 2 minutes, and it's happening many times. While the workaround for this specific case is easy (create the user earlier), users might run in to situations that's out of our control.

This change moves the call to the udevadm command from the generator to the Python code. To keep the behavior as close to the previous one as possible, the call is made as part of the generate command.

We could simply check if the generator is being called as a systemd generator and don't call udevadm, but in the end the binary still is a generator so we shouldn't even have that logic there.

The same is true for the calls we make to systemd using systemctl. Even though they are not executed when the binary is called as a generator, they probably shouldn't be there.

**UPDATE**:

I'm also proposing that we stop using generators to generate configuration. There are 2 main reasons for that:

1. According to systemd.generator(7), it's just wrong: `Generators should only be used to generate unit files, .d/*.conf drop-ins for them and symlinks to them, not any other kind of non-unit related configuration.`
2. Every daemon-reload will run the generator and regenerate all the configuration. It's a lightweight operation if one doesn't have a lot of YAMLs, but that's totally unnecessary.

This PR also includes an experimental systemd service that will call the generate binary before running systemd-networkd, Network Manager and cloud-init. While I'm not completely sure it's correct, it appears to work fine.

I have a PPA for Mantic containing these changes here https://launchpad.net/~danilogondolfo/+archive/ubuntu/netplan.io/+packages

## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

