### PR TITLE
Netplan api iterator

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -69,4 +69,8 @@ typedef enum {
 
 typedef GError NetplanError;
 
-typedef struct netplan_state_iterator NetplanStateIterator;
+typedef struct _NetplanStateIterator NetplanStateIterator;
+
+struct _NetplanStateIterator {
+    void* placeholder;
+};

--- a/include/types.h
+++ b/include/types.h
@@ -68,3 +68,5 @@ typedef enum {
 } NetplanBackend;
 
 typedef GError NetplanError;
+
+typedef struct netplan_state_iterator NetplanStateIterator;

--- a/include/util.h
+++ b/include/util.h
@@ -45,6 +45,15 @@ netplan_error_message(NetplanError* error, char* buf, size_t buf_size);
 NETPLAN_PUBLIC uint64_t
 netplan_error_code(NetplanError* error);
 
+NETPLAN_PUBLIC void
+netplan_state_iterator_init(const NetplanState* np_state, NetplanStateIterator* iter);
+
+NETPLAN_PUBLIC NetplanNetDefinition*
+netplan_state_iterator_next(NetplanStateIterator* iter);
+
+NETPLAN_PUBLIC gboolean
+netplan_state_iterator_has_next(const NetplanStateIterator* iter);
+
 /********** Old API below this ***********/
 
 NETPLAN_DEPRECATED NETPLAN_PUBLIC gchar*

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -242,6 +242,10 @@ struct netplan_parser {
     GHashTable* null_fields;
 };
 
+struct netplan_state_iterator {
+    GList* next;
+};
+
 #define NETPLAN_ADVERTISED_RECEIVE_WINDOW_UNSPEC 0
 #define NETPLAN_CONGESTION_WINDOW_UNSPEC 0
 #define NETPLAN_MTU_UNSPEC 0

--- a/src/util.c
+++ b/src/util.c
@@ -40,6 +40,7 @@ wifi_frequency_24;
 NETPLAN_ABI GHashTable*
 wifi_frequency_5;
 
+typedef struct netplan_state_iterator RealStateIter;
 /**
  * Create the parent directories of given file path. Exit program on failure.
  */
@@ -841,17 +842,19 @@ void
 netplan_state_iterator_init(const NetplanState* np_state, NetplanStateIterator* iter)
 {
     g_assert(iter);
-    iter->next = np_state->netdefs_ordered;
+    RealStateIter* _iter = (RealStateIter*) iter;
+    _iter->next = g_list_first(np_state->netdefs_ordered);
 }
 
 NetplanNetDefinition*
 netplan_state_iterator_next(NetplanStateIterator* iter)
 {
     NetplanNetDefinition* netdef = NULL;
+    RealStateIter* _iter = (RealStateIter*) iter;
 
-    if (iter && iter->next) {
-        netdef = iter->next->data;
-        iter->next = iter->next->next;
+    if (_iter && _iter->next) {
+        netdef = _iter->next->data;
+        _iter->next = g_list_next(_iter->next);
     }
 
     return netdef;
@@ -860,7 +863,9 @@ netplan_state_iterator_next(NetplanStateIterator* iter)
 gboolean
 netplan_state_iterator_has_next(const NetplanStateIterator* iter)
 {
-    if (!iter)
+    RealStateIter* _iter = (RealStateIter*) iter;
+
+    if (!_iter)
         return FALSE;
-    return iter->next != NULL;
+    return _iter->next != NULL;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -836,3 +836,31 @@ is_multicast_address(const char* address)
 
     return FALSE;
 }
+
+void
+netplan_state_iterator_init(const NetplanState* np_state, NetplanStateIterator* iter)
+{
+    g_assert(iter);
+    iter->next = np_state->netdefs_ordered;
+}
+
+NetplanNetDefinition*
+netplan_state_iterator_next(NetplanStateIterator* iter)
+{
+    NetplanNetDefinition* netdef = NULL;
+
+    if (iter && iter->next) {
+        netdef = iter->next->data;
+        iter->next = iter->next->next;
+    }
+
+    return netdef;
+}
+
+gboolean
+netplan_state_iterator_has_next(const NetplanStateIterator* iter)
+{
+    if (!iter)
+        return FALSE;
+    return iter->next != NULL;
+}

--- a/tests/ctests/test_netplan_state.c
+++ b/tests/ctests/test_netplan_state.c
@@ -16,6 +16,8 @@
 #include "util.c"
 #include "parse.c"
 
+#include "test_utils.h"
+
 void
 test_netplan_state_new_state(void** state)
 {
@@ -23,6 +25,56 @@ test_netplan_state_new_state(void** state)
     assert_non_null(np_state);
     netplan_state_clear(&np_state);
 }
+
+void
+test_netplan_state_iterator(void** state)
+{
+    NetplanState* np_state = load_fixture_to_netplan_state("bond.yaml");
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+    netplan_state_iterator_init(np_state, &iter);
+
+    assert_true(netplan_state_iterator_has_next(&iter));
+    netdef = netplan_state_iterator_next(&iter);
+    assert_string_equal(netdef->id, "eth0");
+
+    assert_true(netplan_state_iterator_has_next(&iter));
+    netdef = netplan_state_iterator_next(&iter);
+    assert_string_equal(netdef->id, "bond0");
+
+    assert_false(netplan_state_iterator_has_next(&iter));
+    netdef = netplan_state_iterator_next(&iter);
+    assert_null(netdef);
+
+    netplan_state_clear(&np_state);
+}
+
+void
+test_netplan_state_iterator_empty(void** state)
+{
+    NetplanStateIterator iter = { 0 };
+    NetplanNetDefinition* netdef = NULL;
+
+    netdef = netplan_state_iterator_next(&iter);
+    assert_null(netdef);
+}
+
+void
+test_netplan_state_iterator_null(void** state)
+{
+    NetplanStateIterator *iter = NULL;
+    NetplanNetDefinition* netdef = NULL;
+
+    netdef = netplan_state_iterator_next(iter);
+    assert_null(netdef);
+}
+
+void
+test_netplan_state_iterator_null_has_next(void** state)
+{
+    assert_false(netplan_state_iterator_has_next(NULL));
+}
+
 
 int
 setup(void** state)
@@ -42,6 +94,10 @@ main()
 
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_netplan_state_new_state),
+        cmocka_unit_test(test_netplan_state_iterator),
+        cmocka_unit_test(test_netplan_state_iterator_empty),
+        cmocka_unit_test(test_netplan_state_iterator_null),
+        cmocka_unit_test(test_netplan_state_iterator_null_has_next),
     };
 
     return cmocka_run_group_tests(tests, setup, tear_down);


### PR DESCRIPTION
## Description

The Netplan state iterator API is intended to enable consumers to walk through the ordered list of network definitions. It is useful, for instance, when you need to save the netdefs to files but you don't know the netdef ID to lookup for it.

The idea of having a non-opaque struct exposed to consumers was borrowed from Glib ([here](https://github.com/GNOME/glib/blob/abd76e02864163b6a627e5c5722cb4d6a8d35501/glib/ghash.h#L46) and [here](https://github.com/GNOME/glib/blob/abd76e02864163b6a627e5c5722cb4d6a8d35501/glib/ghash.c#L1143)). By doing this, the iterator can be placed at the stack, which is much more convenient.

This API was integrated and tested with the NetworkManager+Netplan integration code base.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

