### PR TITLE
apply: Fix crash when OVS is stopped (LP#1995598)

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -31,7 +31,7 @@ import time
 import netplan.cli.utils as utils
 from netplan.configmanager import ConfigManager, ConfigurationError
 from netplan.cli.sriov import apply_sriov_config
-from netplan.cli.ovs import apply_ovs_cleanup
+from netplan.cli.ovs import OvsDbServerNotRunning, apply_ovs_cleanup
 
 
 OVS_CLEANUP_SERVICE = 'netplan-ovs-cleanup.service'
@@ -401,3 +401,5 @@ class NetplanApply(utils.NetplanCommand):
             logging.error(str(e))
             if exit_on_error:
                 sys.exit(1)
+        except OvsDbServerNotRunning as e:
+            logging.warning('Cannot call openvswitch: {}.'.format(e))

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -23,7 +23,7 @@ import re
 from netplan.cli.utils import systemctl_is_active
 
 OPENVSWITCH_OVS_VSCTL = '/usr/bin/ovs-vsctl'
-OPENVSWITCH_OVSDB_SERVER_UNIT = 'ovsdb-server'
+OPENVSWITCH_OVSDB_SERVER_UNIT = 'ovsdb-server.service'
 # Defaults for non-optional settings, as defined here:
 # http://www.openvswitch.org/ovs-vswitchd.conf.db.5.pdf
 DEFAULTS = {

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -20,7 +20,10 @@ import os
 import subprocess
 import re
 
+from netplan.cli.utils import systemctl_is_active
+
 OPENVSWITCH_OVS_VSCTL = '/usr/bin/ovs-vsctl'
+OPENVSWITCH_OVSDB_SERVER_UNIT = 'ovsdb-server'
 # Defaults for non-optional settings, as defined here:
 # http://www.openvswitch.org/ovs-vswitchd.conf.db.5.pdf
 DEFAULTS = {
@@ -34,6 +37,10 @@ GLOBALS = {
     'set-fail-mode': ('del-fail-mode', 'get-fail-mode'),
     'set-controller': ('del-controller', 'get-controller'),
 }
+
+
+class OvsDbServerNotRunning(Exception):
+    pass
 
 
 def _del_col(type, iface, column, value):
@@ -118,6 +125,9 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
     Also filter for individual settings tagged netplan/<column>[/<key]=value
     in external-ids and clear them if they have been set by netplan.
     """
+    if not systemctl_is_active(OPENVSWITCH_OVSDB_SERVER_UNIT):
+        raise OvsDbServerNotRunning('{} is not running'.format(OPENVSWITCH_OVSDB_SERVER_UNIT))
+
     config_manager.parse()
     ovs_ifaces = set()
     for i in config_manager.all_defs.keys():

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -471,7 +471,7 @@ class _CommonTests():
         p = subprocess.Popen(['netplan', 'apply'], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, universal_newlines=True)
         (_, err) = p.communicate()
-        self.assertIn('Cannot call openvswitch: ovsdb-server is not running.', err)
+        self.assertIn('Cannot call openvswitch: ovsdb-server.service is not running.', err)
         self.assertEqual(p.returncode, 0)
 
     def test_settings_tag_cleanup(self):

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -459,9 +459,9 @@ class _CommonTests():
     # Netplan shouldn't crash if openvswitch is installed but not running: LP#1995598
     def test_ovsdb_server_is_not_running(self):
         self.setup_eth(None, False)
-        self.addCleanup(subprocess.call, ['systemctl', 'start', 'ovsdb-server'])
-        self.addCleanup(subprocess.call, ['systemctl', 'start', 'ovs-vswitchd'])
-        subprocess.check_call(['systemctl', 'stop', 'ovsdb-server'])
+        self.addCleanup(subprocess.call, ['systemctl', 'start', 'ovsdb-server.service'])
+        self.addCleanup(subprocess.call, ['systemctl', 'start', 'ovs-vswitchd.service'])
+        subprocess.check_call(['systemctl', 'stop', 'ovsdb-server.service'])
         with open(self.config, 'w') as f:
             f.write('''network:
     version: 2
@@ -470,7 +470,7 @@ class _CommonTests():
         dhcp4: false''')
         p = subprocess.Popen(['netplan', 'apply'], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, universal_newlines=True)
-        (out, err) = p.communicate()
+        (_, err) = p.communicate()
         self.assertIn('Cannot call openvswitch: ovsdb-server is not running.', err)
         self.assertEqual(p.returncode, 0)
 


### PR DESCRIPTION
If openvswitch is installed but not running, netplan apply will try to call the service anyway and will crash. In this case we probably should ignore the error and log a warning message to the user.

Add an integration test that will be executed by autopkgtest.


## Description

It addresses https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/1995598

The problem can be reproduced with:
```
lxc launch ubuntu:22.04 jammy --vm
lxc exec jammy bash
apt install openvswitch-switch
systemctl stop ovsdb-server
netplan apply
```
## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

