### PR TITLE
parser: return the correct error on failure (LP#2000324)

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3103,6 +3103,10 @@ process_document(NetplanParser* npp, GError** error)
             break;
     } while (still_missing > 0 || npp->missing_ids_found > 0);
 
+    /* If an error already occurred we should return and not assume it's a missing interface*/
+    if (error && *error)
+        return ret;
+
     if (g_hash_table_size(npp->missing_id) > 0) {
         GHashTableIter iter;
         gpointer key, value;

--- a/src/parse.c
+++ b/src/parse.c
@@ -3105,7 +3105,7 @@ process_document(NetplanParser* npp, GError** error)
 
     /* If an error already occurred we should return and not assume it's a missing interface*/
     if (error && *error)
-        return ret;
+        goto cleanup;
 
     if (g_hash_table_size(npp->missing_id) > 0) {
         GHashTableIter iter;
@@ -3120,11 +3120,12 @@ process_document(NetplanParser* npp, GError** error)
         g_hash_table_iter_next (&iter, &key, &value);
         missing = (NetplanMissingNode*) value;
 
-        return yaml_error(npp, missing->node, error, "%s: interface '%s' is not defined",
-                          missing->netdef_id,
-                          key);
+        ret = yaml_error(npp, missing->node, error, "%s: interface '%s' is not defined",
+                         missing->netdef_id, key);
+        goto cleanup;
     }
 
+cleanup:
     g_hash_table_destroy(npp->missing_id);
     npp->missing_id = NULL;
     return ret;

--- a/tests/ctests/fixtures/invalid_route.yaml
+++ b/tests/ctests/fixtures/invalid_route.yaml
@@ -1,0 +1,11 @@
+network:
+  bridges:
+    br0:
+      interfaces:
+        - ens3
+      routes:
+        - to: 0/0
+          via: 100.64.0.1
+  ethernets:
+    ens3: {}
+  version: 2

--- a/tests/ctests/fixtures/missing_interface.yaml
+++ b/tests/ctests/fixtures/missing_interface.yaml
@@ -1,0 +1,9 @@
+network:
+  bridges:
+    br0:
+      interfaces:
+        - ens3
+      routes:
+        - to: default
+          via: 100.64.0.1
+  version: 2

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -4,9 +4,11 @@
 #include <setjmp.h>
 
 #include <cmocka.h>
+#include <yaml.h>
 
 #include "netplan.h"
 #include "parse.h"
+#include "util.h"
 
 #undef __USE_MISC
 #include "error.c"
@@ -115,6 +117,70 @@ test_netplan_parser_sriov_embedded_switch(void** state)
     netplan_state_clear(&np_state);
 }
 
+/* process_document() shouldn't return a missing interface as error if a previous error happened
+ * LP#2000324
+ */
+void
+test_netplan_parser_process_document_proper_error(void** state)
+{
+
+    NetplanParser *npp = netplan_parser_new();
+    yaml_document_t *doc = &npp->doc;
+    GError *error = NULL;
+    const char* filepath = FIXTURESDIR "/invalid_route.yaml";
+
+    load_yaml(filepath, doc, NULL);
+
+    char* source = g_strdup(filepath);
+    npp->sources = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+    g_hash_table_add(npp->sources, source);
+    npp->ids_in_file = g_hash_table_new(g_str_hash, NULL);
+    npp->current.filepath = g_strdup(filepath);
+    process_document(npp, &error);
+
+    yaml_document_delete(doc);
+    g_free((void *)npp->current.filepath);
+    npp->current.filepath = NULL;
+    g_hash_table_destroy(npp->ids_in_file);
+    npp->ids_in_file = NULL;
+    netplan_parser_clear(&npp);
+
+    /* In this instance the interface IS defined and the actual problem is the malformed IP address */
+    gboolean found = strstr(error->message, "invalid IP family '-1'") != NULL;
+    netplan_error_free(error);
+    assert_true(found);
+}
+
+void
+test_netplan_parser_process_document_missing_interface_error(void** state)
+{
+
+    NetplanParser *npp = netplan_parser_new();
+    yaml_document_t *doc = &npp->doc;
+    GError *error = NULL;
+    const char* filepath = FIXTURESDIR "/missing_interface.yaml";
+
+    load_yaml(filepath, doc, NULL);
+
+    char* source = g_strdup(filepath);
+    npp->sources = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+    g_hash_table_add(npp->sources, source);
+    npp->ids_in_file = g_hash_table_new(g_str_hash, NULL);
+    npp->current.filepath = g_strdup(filepath);
+    process_document(npp, &error);
+
+    yaml_document_delete(doc);
+    g_free((void *)npp->current.filepath);
+    npp->current.filepath = NULL;
+    g_hash_table_destroy(npp->ids_in_file);
+    npp->ids_in_file = NULL;
+    netplan_parser_clear(&npp);
+
+    gboolean found = strstr(error->message, "br0: interface 'ens3' is not defined") != NULL;
+    netplan_error_free(error);
+    assert_true(found);
+}
+
 int
 setup(void** state)
 {
@@ -138,6 +204,8 @@ main()
            cmocka_unit_test(test_netplan_parser_interface_has_bond_netdef),
            cmocka_unit_test(test_netplan_parser_interface_has_peer_netdef),
            cmocka_unit_test(test_netplan_parser_sriov_embedded_switch),
+           cmocka_unit_test(test_netplan_parser_process_document_proper_error),
+           cmocka_unit_test(test_netplan_parser_process_document_missing_interface_error),
        };
 
        return cmocka_run_group_tests(tests, setup, tear_down);


### PR DESCRIPTION
If the parsing process finishes with an error, we should return this error instead of assuming it's a missing interface.

For instance, the configuration below will fail with "br0: interface 'ens3' is not defined" when the actual error is "invalid IP family '-1'" due to the invalid IP used as the default route:

```
network:
  bridges:
    br0:
      interfaces:
        - ens3
      routes:
        - to: 0/0
          via: 100.64.0.1
  ethernets:
    ens3: {}
  version: 2
```

## Description

This PR addresses [LP#2000324](https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2000324)

The configuration above was failing with:

```
$ netplan generate --root-dir /workspace/netplan-issues/fakeroot
/workspace/netplan-issues/fakeroot/etc/netplan/static.yaml:5:11: Error in network definition: br0: interface 'ens3' is not defined
        - ens3
          ^
```
With this change this is the result:

```
$ LD_LIBRARY_PATH=build/src/ PYTHONPATH=. src/netplan.script generate --root-dir /workspace/netplan-issues/fakeroot
/workspace/netplan-issues/fakeroot/etc/netplan/static.yaml:7:15: Error in network definition: invalid IP family '-1'
        - to: 0/0
              ^
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

