### PR TITLE
networkd: make sure VXLAN is in the right section (LP: #2000713)

### DIFF
--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -1713,16 +1713,5 @@ VXLAN=vxlan1
 Destination=10.20.30.40/32
 Gateway=10.20.30.1
 ''',
-                              'vxlan1.netdev': '''[NetDev]
-Name=vxlan1
-Kind=vxlan
-
-[VXLAN]
-VNI=1''',
-                              'vxlan1.network': '''[Match]
-Name=vxlan1
-
-[Network]
-LinkLocalAddressing=ipv6
-ConfigureWithoutCarrier=yes
-'''})
+                              'vxlan1.netdev': (ND_VXLAN % ('vxlan1', 1)).strip(),
+                              'vxlan1.network': ND_EMPTY % ('vxlan1', 'ipv6')})


### PR DESCRIPTION
If an interface has a list of routes and is linked to a vxlan, the VXLAN keyword is added to the [Route] section in the resulting networkd configuration file.

This change makes the vxlan handling to happen before routes so VXLAN= will be added to the [Network] section.

It fixes [LP#2000713](https://bugs.launchpad.net/netplan/+bug/2000713)


## Description

Can be reproduced with:

```
network:
  renderer: networkd
  ethernets:
    eth0:
      routes:
        - to: 10.20.30.40/32
          via: 10.20.30.1
  tunnels:
    vxlan1:
      mode: vxlan
      id: 1
      link: eth0
```

This is the current output. The VXLAN= keyword was added to the [Route] section.

```
$ cat fakeroot/run/systemd/network/10-netplan-eth0.network
[Match]
Name=eth0

[Network]
LinkLocalAddressing=ipv6

[Route]
Destination=10.20.30.40/32
Gateway=10.20.30.1
VXLAN=vxlan1
```

This is the result with this patch:

```
[Match]
Name=eth0

[Network]
LinkLocalAddressing=ipv6
VXLAN=vxlan1

[Route]
Destination=10.20.30.40/32
Gateway=10.20.30.1
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

