### PR TITLE
vxlan: initialize mac_learning with 1

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -436,12 +436,18 @@ write_vxlan_parameters(const NetplanNetDefinition* def, GString* s)
         g_string_append_printf(params, "\nTOS=%d", def->vxlan->tos);
     if (def->tunnel_ttl)
         g_string_append_printf(params, "\nTTL=%d", def->tunnel_ttl);
-    if (def->vxlan->mac_learning)
-        g_string_append_printf(params, "\nMacLearning=%s", def->vxlan->mac_learning ? "true" : "false");
+
+    /* XXX: Convert this option to Tristate.
+     * The vxlan learning feature is enabled by default when an interface is created.
+     * Ideally, it should be a Tristate so we wouldn't emit the config unless explicitly set.
+     */
+    g_string_append_printf(params, "\nMacLearning=%s", def->vxlan->mac_learning ? "true" : "false");
+
     if (def->vxlan->ageing)
         g_string_append_printf(params, "\nFDBAgeingSec=%d", def->vxlan->ageing);
     if (def->vxlan->limit)
         g_string_append_printf(params, "\nMaximumFDBEntries=%d", def->vxlan->limit);
+    /* XXX: Convert to Tristate */
     if (def->vxlan->arp_proxy)
         g_string_append_printf(params, "\nReduceARPProxy=%s", def->vxlan->arp_proxy ? "true" : "false");
     if (def->vxlan->notifications) {
@@ -450,6 +456,7 @@ write_vxlan_parameters(const NetplanNetDefinition* def, GString* s)
         if (def->vxlan->notifications & NETPLAN_VXLAN_NOTIFICATION_L3_MISS)
             g_string_append(params, "\nL3MissNotification=true");
     }
+    /* XXX: Convert to Tristate */
     if (def->vxlan->short_circuit)
         g_string_append_printf(params, "\nRouteShortCircuit=%s", def->vxlan->short_circuit ? "true" : "false");
     if (def->vxlan->checksums) {

--- a/src/types.c
+++ b/src/types.c
@@ -198,6 +198,7 @@ reset_vxlan(NetplanVxlan* vxlan)
     vxlan->link = NULL;
     vxlan->flow_label = G_MAXUINT;
     vxlan->do_not_fragment = NETPLAN_TRISTATE_UNSET;
+    vxlan->mac_learning = TRUE;
 }
 
 /* Free a heap-allocated NetplanWifiAccessPoint object.

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -1069,12 +1069,13 @@ ConfigureWithoutCarrier=yes
     vx0:
       mode: vxlan
       id: 1005
+      mac-learning: true
       remote: 10.0.0.5
       port-range: [100, 10]''')
         self.assertIn("swapped invalid port-range order [MIN, MAX]", out)
 
         self.assert_networkd({'vx0.netdev': ND_VXLAN % ('vx0', 1005) +
-                              'Remote=10.0.0.5\nPortRange=10-100\nIndependent=true\n',
+                              'Remote=10.0.0.5\nMacLearning=true\nPortRange=10-100\nIndependent=true\n',
                               'vx0.network': ND_EMPTY % ('vx0', 'ipv6')})
 
     def test_vxlan_ip6_multicast(self):
@@ -1084,10 +1085,11 @@ ConfigureWithoutCarrier=yes
     vx0:
       mode: vxlan
       id: 1005
+      mac-learning: true
       remote: "ff42::dead:beef"''')
 
         self.assert_networkd({'vx0.netdev': ND_VXLAN % ('vx0', 1005) +
-                              'Group=ff42::dead:beef\nIndependent=true\n',
+                              'Group=ff42::dead:beef\nMacLearning=true\nIndependent=true\n',
                               'vx0.network': ND_EMPTY % ('vx0', 'ipv6')})
 
 
@@ -1420,6 +1422,7 @@ method=ignore
     vx0:
       mode: vxlan
       id: 42
+      mac-learning: true
       link: id0
   ethernets:
     id0:
@@ -1441,6 +1444,7 @@ interface-name=vx0
 
 [vxlan]
 id=42
+learning=true
 parent=%s
 
 [ipv4]


### PR DESCRIPTION
Vxlan learning is enabled by default on Linux. On Netplan it's a boolean variable that we initialize with false and only include in the generated configuration if it's true. That means we can't disable it on vxlan interfaces even if we define mac-learning: false explicitly in the yaml file.

That is not the ideal solution! The proper way to do that is defining it as a tristate variable but it requires changes in the netplan_vxlan structure. One bad side effect of this change is that the yaml configuration generated from netdefs and the NM/networkd configuration will contain the option mac-learning even if we don't have it in the original yaml.

This addresses [LP#2000712](https://bugs.launchpad.net/netplan/+bug/2000712)


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

