### PR TITLE
doc/examples: remove unnecessary route for IPv6 on-link gateways

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -378,7 +378,7 @@ network:
                on-link: true
 ```
 
-For IPv6 the config would be very similar, with the notable difference being an additional scope: link host route to the router's address required:
+For IPv6 the config would be very similar:
 
 ```yaml
 network:
@@ -388,8 +388,6 @@ network:
         ens3:
             addresses: [ "2001:cafe:face:beef::dead:dead/64" ]
             routes:
-             - to: "2001:cafe:face::1/128"
-               scope: link
              - to: default # or "::/0"
                via: "2001:cafe:face::1"
                on-link: true

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -667,7 +667,7 @@ eth1:
   - **scope** (scalar)
 
     > The route scope, how wide-ranging it is to the network. Possible
-    > values are "global", "link", or "host".
+    > values are "global", "link", or "host". Applies to IPv4 only.
 
   - **table** (scalar)
 

--- a/examples/direct_connect_gateway_ipv6.yaml
+++ b/examples/direct_connect_gateway_ipv6.yaml
@@ -4,8 +4,6 @@ network:
   ethernets:
     addresses: [ "2001:cafe:face:beef::dead:dead/64" ]
     routes:
-      - to: "2001:cafe:face::1/128"
-        scope: link
       - to: "::/0"
         via: "2001:cafe:face::1"
         on-link: true


### PR DESCRIPTION


## Description
Hi,
When the on-link flag is enabled, the additional route has no effect. This extra route is only required when the on-link flag is *not* set.

Indeed, for netorkd, when "on-link" is true, the resulting systemd-networkd config file contains "GatewayOnLink=true", which translates to "flags: onlink" in its logs. The resulting route appears with this "onlink" flag in the output of "ip route".

Similarly, for NetworkManager, "route1_options=onlink=true" gets added by
https://github.com/canonical/netplan/blob/e5ff9f6dbeb20a8a3e6abc712efcf1b0008afa75/src/nm.c#L228-L230


## Checklist

- [x] Runs `make check` successfully → except for `test_with_empty_config` which also fails on the `main` branch on my Ubuntu 22.10 test server, so I'm assuming this is entirely unrelated.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

