### PR TITLE
Check if the interface name is too long (LP: #1988749)

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -36,6 +36,7 @@ from netplan.cli.ovs import OvsDbServerNotRunning, apply_ovs_cleanup
 
 OVS_CLEANUP_SERVICE = 'netplan-ovs-cleanup.service'
 
+IF_NAMESIZE = 16
 
 class NetplanApply(utils.NetplanCommand):
 
@@ -234,6 +235,9 @@ class NetplanApply(utils.NetplanCommand):
             # rename non-critical network interfaces
             new_name = settings.get('name')
             if new_name:
+                if len(new_name) >= IF_NAMESIZE:
+                    logging.warning('Interface name {} is too long. {} will not be renamed'.format(new_name, iface))
+                    continue
                 if iface in devices and new_name in devices_after_udev:
                     logging.debug('Interface rename {} -> {} already happened.'.format(iface, new_name))
                     continue  # re-name already happened via 'udevadm test'

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -38,6 +38,7 @@ OVS_CLEANUP_SERVICE = 'netplan-ovs-cleanup.service'
 
 IF_NAMESIZE = 16
 
+
 class NetplanApply(utils.NetplanCommand):
 
     def __init__(self):

--- a/src/nm.c
+++ b/src/nm.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <arpa/inet.h>
+#include <net/if.h>
 
 #include <glib.h>
 #include <glib/gprintf.h>
@@ -657,8 +658,8 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
         /* else matches on something other than the name, do not restrict interface-name */
     } else {
         /* virtual (created) devices set a name */
-        if (strlen(def->id) > 15)
-            g_debug("interface-name longer than 15 characters is not supported");
+        if (strnlen(def->id, IF_NAMESIZE) == IF_NAMESIZE)
+            g_debug("interface-name %s is too long. Ignoring.", def->id);
         else
             g_key_file_set_string(kf, "connection", "interface-name", def->id);
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -19,6 +19,7 @@
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <arpa/inet.h>
+#include <net/if.h>
 #include <regex.h>
 
 #include <yaml.h>
@@ -149,6 +150,30 @@ validate_ovs_target(gboolean host_first, gchar* s) {
             return TRUE;
     }
     return FALSE;
+}
+
+static gboolean
+validate_interface_name_length(const NetplanNetDefinition* netdef)
+{
+    gboolean validation = TRUE;
+    char* iface = NULL;
+
+    if (netdef->type >= NETPLAN_DEF_TYPE_VIRTUAL && netdef->type < NETPLAN_DEF_TYPE_NM) {
+        if (strnlen(netdef->id, IF_NAMESIZE) == IF_NAMESIZE) {
+            iface = netdef->id;
+            validation = FALSE;
+        }
+    } else if (netdef->set_name) {
+        if (strnlen(netdef->set_name, IF_NAMESIZE) == IF_NAMESIZE) {
+            iface = netdef->set_name;
+            validation = FALSE;
+        }
+    }
+
+    if (iface)
+        g_warning("Interface name '%s' is too long. It will be ignored by the backend.", iface);
+
+    return validation;
 }
 
 /************************************************
@@ -377,6 +402,8 @@ validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
 
     if (nd->type == NETPLAN_DEF_TYPE_NM && (!nd->backend_settings.nm.passthrough || !g_datalist_get_data(&nd->backend_settings.nm.passthrough, "connection.type")))
         return yaml_error(npp, node, error, "%s: network type 'nm-devices:' needs to provide a 'connection.type' via passthrough", nd->id);
+
+    validate_interface_name_length(npp->current.netdef);
 
     valid = TRUE;
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -403,7 +403,8 @@ validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
     if (nd->type == NETPLAN_DEF_TYPE_NM && (!nd->backend_settings.nm.passthrough || !g_datalist_get_data(&nd->backend_settings.nm.passthrough, "connection.type")))
         return yaml_error(npp, node, error, "%s: network type 'nm-devices:' needs to provide a 'connection.type' via passthrough", nd->id);
 
-    validate_interface_name_length(npp->current.netdef);
+    if (npp->current.netdef)
+        validate_interface_name_length(npp->current.netdef);
 
     valid = TRUE;
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -170,6 +170,8 @@ validate_interface_name_length(const NetplanNetDefinition* netdef)
         }
     }
 
+    /* TODO: make this a hard failure in the future, but keep it as a warning
+     *       for now, to not break netplan generate at boot. */
     if (iface)
         g_warning("Interface name '%s' is too long. It will be ignored by the backend.", iface);
 

--- a/tests/ctests/meson.build
+++ b/tests/ctests/meson.build
@@ -4,6 +4,7 @@ tests = {
   'test_netplan_error': false,
   'test_netplan_misc': false,
   'test_netplan_deprecated': false,
+  'test_netplan_validation': false,
 }
 
 cmocka = dependency('cmocka', required: true)

--- a/tests/ctests/test_netplan_validation.c
+++ b/tests/ctests/test_netplan_validation.c
@@ -1,0 +1,138 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "netplan.h"
+#include "parse.h"
+
+#undef __USE_MISC
+#include "error.c"
+#include "names.c"
+#include "validation.c"
+#include "types.c"
+#include "util.c"
+#include "parse.c"
+
+#include "test_utils.h"
+
+void
+test_validate_interface_name_length(void** state)
+{
+    const char* yaml =
+        "network:\n"
+        "  version: 2\n"
+        "  bridges:\n"
+        "    ashortname:\n"
+        "      dhcp4: no\n";
+
+    NetplanState* np_state = load_string_to_netplan_state(yaml);
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+    netplan_state_iterator_init(np_state, &iter);
+
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_true(validate_interface_name_length(netdef));
+
+    netplan_state_clear(&np_state);
+}
+
+void
+test_validate_interface_name_length_set_name(void** state)
+{
+    const char* yaml =
+        "network:\n"
+        "  version: 2\n"
+        "  ethernets:\n"
+        "    eth0:\n"
+        "      match:\n"
+        "        macaddress: aa:bb:cc:dd:ee:ff\n"
+        "      set-name: ashortname\n";
+
+    NetplanState* np_state = load_string_to_netplan_state(yaml);
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+    netplan_state_iterator_init(np_state, &iter);
+
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_true(validate_interface_name_length(netdef));
+
+    netplan_state_clear(&np_state);
+}
+
+void
+test_validate_interface_name_length_too_long(void** state)
+{
+    const char* yaml =
+        "network:\n"
+        "  version: 2\n"
+        "  bridges:\n"
+        "    averylongnameforaninterface:\n"
+        "      dhcp4: no\n";
+
+    NetplanState* np_state = load_string_to_netplan_state(yaml);
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+    netplan_state_iterator_init(np_state, &iter);
+
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_false(validate_interface_name_length(netdef));
+
+    netplan_state_clear(&np_state);
+}
+
+void
+test_validate_interface_name_length_set_name_too_long(void** state)
+{
+    const char* yaml =
+        "network:\n"
+        "  version: 2\n"
+        "  ethernets:\n"
+        "    eth0:\n"
+        "      match:\n"
+        "        macaddress: aa:bb:cc:dd:ee:ff\n"
+        "      set-name: averylongnameforaninterface\n";
+
+    NetplanState* np_state = load_string_to_netplan_state(yaml);
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+    netplan_state_iterator_init(np_state, &iter);
+
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_false(validate_interface_name_length(netdef));
+
+    netplan_state_clear(&np_state);
+}
+
+int
+setup(void** state)
+{
+    return 0;
+}
+
+int
+tear_down(void** state)
+{
+    return 0;
+}
+
+int
+main()
+{
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_validate_interface_name_length),
+        cmocka_unit_test(test_validate_interface_name_length_too_long),
+        cmocka_unit_test(test_validate_interface_name_length_set_name),
+        cmocka_unit_test(test_validate_interface_name_length_set_name_too_long),
+    };
+
+    return cmocka_run_group_tests(tests, setup, tear_down);
+
+}

--- a/tests/ctests/test_utils.h
+++ b/tests/ctests/test_utils.h
@@ -48,7 +48,7 @@ load_string_to_netplan_state(const char* yaml)
     process_document(npp, error);
 
     if (error && *error) {
-        netplan_error_free(*error);
+        netplan_error_clear(error);
     } else {
         np_state = netplan_state_new();
         netplan_state_import_parser_results(np_state, npp, error);

--- a/tests/ctests/test_utils.h
+++ b/tests/ctests/test_utils.h
@@ -5,7 +5,10 @@
 #include "types.h"
 #include "netplan.h"
 #include "parse.h"
+#include "util.h"
+#include "types-internal.h"
 
+// LCOV_EXCL_START
 NetplanState *
 load_fixture_to_netplan_state(const char* filename)
 {
@@ -25,3 +28,41 @@ load_fixture_to_netplan_state(const char* filename)
 
     return np_state;
 }
+
+NetplanState*
+load_string_to_netplan_state(const char* yaml)
+{
+    yaml_parser_t parser;
+    yaml_document_t* doc;
+    NetplanError** error = NULL;
+    NetplanState* np_state = NULL;
+
+    NetplanParser* npp = netplan_parser_new();
+
+    doc = &npp->doc;
+
+    yaml_parser_initialize(&parser);
+    yaml_parser_set_input_string(&parser, (const unsigned char*) yaml, strlen(yaml));
+    yaml_parser_load(&parser, doc);
+
+    process_document(npp, error);
+
+    if (error && *error) {
+        netplan_error_free(*error);
+    } else {
+        np_state = netplan_state_new();
+        netplan_state_import_parser_results(np_state, npp, error);
+    }
+
+    yaml_parser_delete(&parser);
+    yaml_document_delete(doc);
+    netplan_parser_clear(&npp);
+
+    if (error && *error) {
+        netplan_state_clear(&np_state);
+    }
+
+    return np_state;
+}
+
+// LCOV_EXCL_STOP

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1371,11 +1371,11 @@ method=manual
 addr-gen-mode=default
 method=auto
 
-[proxy]\n'''.format(UUID))
+[proxy]\n'''.format(UUID), netdef_id='br0')
         self.assert_netplan({UUID: '''network:
   version: 2
   bridges:
-    NM-{}:
+    br0:
       renderer: NetworkManager
       addresses:
       - "1.2.3.4/24"
@@ -1384,7 +1384,6 @@ method=auto
         uuid: "{}"
         name: "Test Write Bridge Main"
         passthrough:
-          connection.interface-name: "br0"
           ethernet._: ""
           bridge._: ""
           ipv4.address1: "1.2.3.4/24,1.1.1.1"
@@ -1392,4 +1391,4 @@ method=auto
           ipv6.addr-gen-mode: "default"
           ipv6.ip6-privacy: "-1"
           proxy._: ""
-'''.format(UUID, UUID)})
+'''.format(UUID)})


### PR DESCRIPTION
## Description

Netplan will allow the user to enter an interface name that's too long without issues any warning message. The backends will fail to process such an interface with errors like:

```
Jan 17 08:37:31 ubuntu2204 systemd-udevd[176]: eth0: Invalid network interface name, ignoring: anotherverylongname0
```

```
Jan 17 14:17:53 ubuntu2204 systemd-networkd[1019]: /run/systemd/network/10-netplan-notagoodnameforabridge0.netdev:2: Interface name is not valid or too long, ignoring assignment: notagoodnameforabridge0
Jan 17 14:17:53 ubuntu2204 systemd-networkd[1019]: NetDev without Name= configured in /run/systemd/network/10-netplan-notagoodnameforabridge0.netdev. Ignoring
```

Also, netplan apply will crash when trying to rename the interface:

```
oot@ubuntu2204:~# netplan apply
Traceback (most recent call last):
  File "/usr/sbin/netplan", line 23, in <module>
    netplan.main()
  File "/usr/share/netplan/netplan/cli/core.py", line 50, in main
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 231, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/apply.py", line 61, in run
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 231, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/apply.py", line 245, in command_apply
    subprocess.check_call(['ip', 'link', 'set',
  File "/usr/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['ip', 'link', 'set', 'dev', 'eth0', 'name', 'anotherverylongname0']' returned non-zero exit status 255
```

Ideally we should fail on such cases, but at this point some users might have invalid names in their configuration so it would cause problems.

It addresses LP#1988749

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

