### PR TITLE
tests: mock calls to systemctl

### DIFF
--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -338,6 +338,7 @@ search search.domain  another.one
 1 inactive interfaces hidden. Use "--all" to show all.
 ''')
 
+    @patch('netplan.cli.utils.systemctl')
     @patch('netplan.cli.commands.status.NetplanStatus.query_iproute2')
     @patch('netplan.cli.commands.status.NetplanStatus.query_networkd')
     @patch('netplan.cli.commands.status.NetplanStatus.query_nm')
@@ -345,8 +346,10 @@ search search.domain  another.one
     @patch('netplan.cli.commands.status.NetplanStatus.query_resolved')
     @patch('netplan.cli.commands.status.NetplanStatus.resolvconf_json')
     @patch('netplan.cli.commands.status.NetplanStatus.query_online_state')
-    def test_call_cli(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock):
+    def test_call_cli(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock,
+                      systemctl_mock):
         status = NetplanStatus()
+        systemctl_mock.return_value = None
         iproute2_mock.return_value = [FAKE_DEV]
         networkd_mock.return_value = status.process_networkd(NETWORKD)
         nm_mock.return_value = []
@@ -360,14 +363,17 @@ Online state: offline
 
 ● 42: fakedev0 other DOWN (unmanaged)''')
 
+    @patch('netplan.cli.utils.systemctl')
     @patch('netplan.cli.commands.status.NetplanStatus.query_iproute2')
     @patch('netplan.cli.commands.status.NetplanStatus.query_networkd')
-    def test_fail_cli(self, networkd_mock, iproute2_mock):
+    def test_fail_cli(self, networkd_mock, iproute2_mock, systemctl_mock):
+        systemctl_mock.return_value = None
         iproute2_mock.return_value = [FAKE_DEV]
         networkd_mock.return_value = []
         with self.assertRaises(SystemExit):
             self._call([])
 
+    @patch('netplan.cli.utils.systemctl')
     @patch('netplan.cli.commands.status.NetplanStatus.query_iproute2')
     @patch('netplan.cli.commands.status.NetplanStatus.query_networkd')
     @patch('netplan.cli.commands.status.NetplanStatus.query_nm')
@@ -375,8 +381,10 @@ Online state: offline
     @patch('netplan.cli.commands.status.NetplanStatus.query_resolved')
     @patch('netplan.cli.commands.status.NetplanStatus.resolvconf_json')
     @patch('netplan.cli.commands.status.NetplanStatus.query_online_state')
-    def test_call_cli_ifname(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock):
+    def test_call_cli_ifname(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock,
+                             systemctl_mock):
         status = NetplanStatus()
+        systemctl_mock.return_value = None
         iproute2_mock.return_value = [FAKE_DEV, self._get_itf('wlan0')]
         networkd_mock.return_value = status.process_networkd(NETWORKD)
         nm_mock.return_value = []
@@ -392,6 +400,7 @@ Online state: offline
 
 1 inactive interfaces hidden. Use "--all" to show all.''')
 
+    @patch('netplan.cli.utils.systemctl')
     @patch('netplan.cli.commands.status.NetplanStatus.query_iproute2')
     @patch('netplan.cli.commands.status.NetplanStatus.query_networkd')
     @patch('netplan.cli.commands.status.NetplanStatus.query_nm')
@@ -399,8 +408,10 @@ Online state: offline
     @patch('netplan.cli.commands.status.NetplanStatus.query_resolved')
     @patch('netplan.cli.commands.status.NetplanStatus.resolvconf_json')
     @patch('netplan.cli.commands.status.NetplanStatus.query_online_state')
-    def test_fail_cli_ifname(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock):
+    def test_fail_cli_ifname(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock,
+                             systemctl_mock):
         status = NetplanStatus()
+        systemctl_mock.return_value = None
         iproute2_mock.return_value = [FAKE_DEV, self._get_itf('wlan0')]
         networkd_mock.return_value = status.process_networkd(NETWORKD)
         nm_mock.return_value = []
@@ -411,6 +422,7 @@ Online state: offline
         with self.assertRaises(SystemExit):
             self._call(['notaninteface0'])
 
+    @patch('netplan.cli.utils.systemctl')
     @patch('netplan.cli.commands.status.NetplanStatus.query_iproute2')
     @patch('netplan.cli.commands.status.NetplanStatus.query_networkd')
     @patch('netplan.cli.commands.status.NetplanStatus.query_nm')
@@ -418,8 +430,10 @@ Online state: offline
     @patch('netplan.cli.commands.status.NetplanStatus.query_resolved')
     @patch('netplan.cli.commands.status.NetplanStatus.resolvconf_json')
     @patch('netplan.cli.commands.status.NetplanStatus.query_online_state')
-    def test_call_cli_json(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock):
+    def test_call_cli_json(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock,
+                           systemctl_mock):
         status = NetplanStatus()
+        systemctl_mock.return_value = None
         iproute2_mock.return_value = [FAKE_DEV]
         networkd_mock.return_value = status.process_networkd(NETWORKD)
         nm_mock.return_value = []
@@ -432,6 +446,7 @@ Online state: offline
 "netplan-global-state": {"online": false, "nameservers": {"addresses": [], "search": [], "mode": null}}, \
 "fakedev0": {"index": 42, "adminstate": "DOWN", "operstate": "DOWN"}}\n''')
 
+    @patch('netplan.cli.utils.systemctl')
     @patch('netplan.cli.commands.status.NetplanStatus.query_iproute2')
     @patch('netplan.cli.commands.status.NetplanStatus.query_networkd')
     @patch('netplan.cli.commands.status.NetplanStatus.query_nm')
@@ -439,8 +454,10 @@ Online state: offline
     @patch('netplan.cli.commands.status.NetplanStatus.query_resolved')
     @patch('netplan.cli.commands.status.NetplanStatus.resolvconf_json')
     @patch('netplan.cli.commands.status.NetplanStatus.query_online_state')
-    def test_call_cli_yaml(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock):
+    def test_call_cli_yaml(self, online_mock, resolvconf_mock, rd_mock, routes_mock, nm_mock, networkd_mock, iproute2_mock,
+                           systemctl_mock):
         status = NetplanStatus()
+        systemctl_mock.return_value = None
         iproute2_mock.return_value = [FAKE_DEV]
         networkd_mock.return_value = status.process_networkd(NETWORKD)
         nm_mock.return_value = []


### PR DESCRIPTION
Some tests were failing in sbuild due to calls to systemctl. It would check if networkd was running and try to start it. In my system the same happens except these tests get stuck asking for my password if I stop networkd.


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

