### PR TITLE
docs: small fix on netplan-set doc

### DIFF
--- a/doc/netplan-set.md
+++ b/doc/netplan-set.md
@@ -19,7 +19,7 @@ netplan-set - write netplan YAML configuration snippets to file
 
 **netplan set [key=value]** writes a given key/value pair or YAML subtree into a YAML file in ``/etc/netplan/`` and validates its format.
 
-You can specify a single value as: ``"[network.]ethernets.eth0.dhcp4=[1.2.3.4/24, 5.6.7.8/24]"`` or a full subtree as: ``"[network.]ethernets.eth0={dhcp4: true, dhcp6: true}"``.
+You can specify a single value as: ``"[network.]ethernets.eth0.addresses=[1.2.3.4/24, 5.6.7.8/24]"`` or a full subtree as: ``"[network.]ethernets.eth0={dhcp4: true, dhcp6: true}"``.
 
 For details of the configuration file format, see **netplan**(5).
 


### PR DESCRIPTION
The key should be "addresses" not "dhcp4".


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

