### PR TITLE
api:util: rename netplan_error_clear (from _free) & adopt to nullify

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -34,7 +34,7 @@ NETPLAN_PUBLIC ssize_t
 netplan_netdef_get_output_filename(const NetplanNetDefinition* netdef, const char* ssid, char* out_buffer, size_t out_buf_size);
 
 NETPLAN_PUBLIC void
-netplan_error_free(NetplanError* error);
+netplan_error_clear(NetplanError** error);
 
 NETPLAN_PUBLIC ssize_t
 netplan_error_message(NetplanError* error, char* buf, size_t buf_size);

--- a/src/error.c
+++ b/src/error.c
@@ -179,9 +179,9 @@ yaml_error(const NetplanParser *npp, const yaml_node_t* node, GError** error, co
 }
 
 void
-netplan_error_free(NetplanError* error)
+netplan_error_clear(NetplanError** error)
 {
-    g_error_free(error);
+    g_clear_error(error);
 }
 
 ssize_t

--- a/tests/ctests/test_netplan_error.c
+++ b/tests/ctests/test_netplan_error.c
@@ -24,7 +24,7 @@ test_netplan_error_message(void** state)
     GError *gerror = g_error_new(1, 2, "%s: error message", message);
     netplan_error_message(gerror, error_message, sizeof(error_message) - 1);
     assert_string_equal(error_message, "it failed: error message");
-    netplan_error_free(gerror);
+    netplan_error_clear(&gerror);
 }
 
 void
@@ -37,7 +37,7 @@ test_netplan_error_code(void** state)
 
     assert_int_equal(domain, 1234);
     assert_int_equal(error, 5678);
-    netplan_error_free(gerror);
+    netplan_error_clear(&gerror);
 }
 
 int


### PR DESCRIPTION
## Description
api:util: rename netplan_error_clear (from _free) & adopt to nullify

The spec was updated accordingly.
As discussed during the last netplan sync meeting

## Checklist

- [x] Runs `make check` successfully.
- [X] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

