### PR TITLE
src:parse: plug memory leaks in nullable handling

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3490,6 +3490,7 @@ netplan_parser_load_nullable_fields(NetplanParser* npp, int input_fd, GError** e
         npp->null_fields = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
     extract_null_fields(&doc, yaml_document_get_root_node(&doc), npp->null_fields, g_strdup(""), NULL);
+    yaml_document_delete(&doc);
     return TRUE;
 }
 
@@ -3520,5 +3521,6 @@ netplan_parser_load_nullable_overrides(
      * yaml patch: "network.renderer=NetworkManager"
      * => network.renderer: hint.yaml */
     extract_null_fields(&doc, yaml_document_get_root_node(&doc), npp->null_overrides, g_strdup(""), constraint);
+    yaml_document_delete(&doc);
     return TRUE;
 }

--- a/tests/ctests/fixtures/nullable.yaml
+++ b/tests/ctests/fixtures/nullable.yaml
@@ -1,0 +1,4 @@
+network:
+  ethernets:
+    eth0:
+      dhcp4: NULL


### PR DESCRIPTION
## Description
src:parse: plug memory leaks in nullable handling

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

