### PR TITLE
API: update netplan_delete_connection() to avoid spawning another process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILDFLAGS = \
 	-g \
 	-fPIC \
 	-std=c99 \
-	-D_XOPEN_SOURCE=700 \
+	-D_GNU_SOURCE \
 	-DSBINDIR=\"$(SBINDIR)\" \
 	-I${CURDIR}/include \
 	-Wall \

--- a/abi-compat/suppressions.abignore
+++ b/abi-compat/suppressions.abignore
@@ -7,3 +7,8 @@
 [suppress_variable]
   name = global_state
   type_name = NetplanState
+
+# TODO: drop after 0.106
+[suppress_function]
+  name = find_yaml_glob
+  parameter = '1 glob_t*

--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ find = find_program('find')
 
 add_project_arguments(
     '-DSBINDIR="' + join_paths(get_option('prefix'), get_option('sbindir')) + '"',
-    '-D_XOPEN_SOURCE=700',
+    '-D_GNU_SOURCE',
     language: 'c')
 
 inc = include_directories('include')

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#define __USE_MISC
 #include <glob.h>
 #include <glib.h>
 #include "types-internal.h"

--- a/tests/ctests/meson.build
+++ b/tests/ctests/meson.build
@@ -15,7 +15,11 @@ foreach name, should_fail: tests
     '@0@.c'.format(name),
     include_directories: [inc, inc_tests],
     dependencies: [cmocka, glib, gio, yaml, uuid],
-    c_args: ['-Wno-deprecated-declarations', '-DFIXTURESDIR="' + meson.project_source_root() + '/tests/ctests/fixtures"'],
+    c_args: [
+      '-DFIXTURESDIR="' + meson.project_source_root() + '/tests/ctests/fixtures"',
+      '-Wno-deprecated-declarations',
+      '-D_GNU_SOURCE',
+      ],
     )
   test(name, exe, should_fail: should_fail)
 endforeach

--- a/tests/ctests/test_netplan_deprecated.c
+++ b/tests/ctests/test_netplan_deprecated.c
@@ -10,7 +10,6 @@
 #include "types-internal.h"
 #include "types.h"
 
-#undef __USE_MISC
 #include "error.c"
 #include "names.c"
 #include "validation.c"

--- a/tests/ctests/test_netplan_error.c
+++ b/tests/ctests/test_netplan_error.c
@@ -10,6 +10,7 @@
 
 #include "error.c"
 #include "names.c"
+#include "netplan.c"
 #include "validation.c"
 #include "types.c"
 #include "util.c"

--- a/tests/ctests/test_netplan_error.c
+++ b/tests/ctests/test_netplan_error.c
@@ -8,7 +8,6 @@
 #include "netplan.h"
 #include "parse.h"
 
-#undef __USE_MISC
 #include "error.c"
 #include "names.c"
 #include "validation.c"

--- a/tests/ctests/test_netplan_misc.c
+++ b/tests/ctests/test_netplan_misc.c
@@ -10,7 +10,6 @@
 #include "types-internal.h"
 #include "types.h"
 
-#undef __USE_MISC
 #include "error.c"
 #include "names.c"
 #include "validation.c"

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -10,7 +10,6 @@
 #include "parse.h"
 #include "util.h"
 
-#undef __USE_MISC
 #include "error.c"
 #include "names.c"
 #include "validation.c"

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -12,6 +12,7 @@
 
 #include "error.c"
 #include "names.c"
+#include "netplan.c"
 #include "validation.c"
 #include "types.c"
 #include "util.c"

--- a/tests/ctests/test_netplan_state.c
+++ b/tests/ctests/test_netplan_state.c
@@ -10,6 +10,7 @@
 
 #include "error.c"
 #include "names.c"
+#include "netplan.c"
 #include "validation.c"
 #include "types.c"
 #include "util.c"

--- a/tests/ctests/test_netplan_state.c
+++ b/tests/ctests/test_netplan_state.c
@@ -8,7 +8,6 @@
 #include "netplan.h"
 #include "parse.h"
 
-#undef __USE_MISC
 #include "error.c"
 #include "names.c"
 #include "validation.c"

--- a/tests/ctests/test_netplan_validation.c
+++ b/tests/ctests/test_netplan_validation.c
@@ -10,6 +10,7 @@
 
 #include "error.c"
 #include "names.c"
+#include "netplan.c"
 #include "validation.c"
 #include "types.c"
 #include "util.c"

--- a/tests/ctests/test_netplan_validation.c
+++ b/tests/ctests/test_netplan_validation.c
@@ -8,7 +8,6 @@
 #include "netplan.h"
 #include "parse.h"
 
-#undef __USE_MISC
 #include "error.c"
 #include "names.c"
 #include "validation.c"


### PR DESCRIPTION
## Description
This function has been calling into the python 'netplan set' command for historical reasons. We can now stay internal to libnetplan and execute the corresponding libnetplan functions directly.

Basically, we're now implementing inside this function in `util.c` what has previously been executed via `netplan/cli/commands/set.py`

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

