### PR TITLE
Fix FTBFS on Fedora and refresh RPM packaging

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', def
 pyflakes = find_program('pyflakes-3', 'pyflakes3', required: false)
 pycodestyle = find_program('pycodestyle-3', 'pycodestyle', 'pep8', required: false)
 pytest = find_program('pytest-3', 'pytest3')  # also requires the pytest-cov plugin
-pycoverage = find_program('python3-coverage')
+pycoverage = find_program('coverage-3', 'python3-coverage')
 pandoc = find_program('pandoc', required: false)
 find = find_program('find')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,7 +36,7 @@ executable(
     install: true)
 install_symlink(
     'netplan',
-    pointing_to: join_paths('..', '..', '..') + join_paths(get_option('prefix'), libexec_netplan, 'generate'),
+    pointing_to: join_paths('..', '..', '..', '..') + join_paths(get_option('prefix'), libexec_netplan, 'generate'),
     install_dir: systemd_generator_dir)
 # Install this symlink for legacy reasons, see netplan/cli/utils.py: get_generator_path()
 install_symlink(


### PR DESCRIPTION
This pull request fixes Netplan to build on Fedora Linux and updates the RPM packaging to use the Meson build.