### PR TITLE
ATTN: parser: validate lacp-rate properly (LP: #1745648)

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2100,9 +2100,18 @@ handle_bond_primary_member(NetplanParser* npp, yaml_node_t* node, const void* da
     return TRUE;
 }
 
+static gboolean
+handle_bond_lacp_rate(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+{
+    if (!(strcmp(scalar(node), "slow") == 0 || strcmp(scalar(node), "fast") == 0))
+        return yaml_error(npp, node, error, "unknown lacp-rate value '%s' (expected 'fast' or 'slow')", scalar(node));
+
+    return handle_netdef_str(npp, node, data, error);
+}
+
 static const mapping_entry_handler bond_params_handlers[] = {
     {"mode", YAML_SCALAR_NODE, {.generic=handle_bond_mode}, netdef_offset(bond_params.mode)},
-    {"lacp-rate", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.lacp_rate)},
+    {"lacp-rate", YAML_SCALAR_NODE, {.generic=handle_bond_lacp_rate}, netdef_offset(bond_params.lacp_rate)},
     {"mii-monitor-interval", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.monitor_interval)},
     {"min-links", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(bond_params.min_links)},
     {"transmit-hash-policy", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.transmit_hash_policy)},

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -157,7 +157,7 @@ UseMTU=true
     bn0:
       parameters:
         mode: 802.3ad
-        lacp-rate: 10
+        lacp-rate: fast
         mii-monitor-interval: 10
         min-links: 10
         up-delay: 20
@@ -183,7 +183,7 @@ UseMTU=true
         self.assert_networkd({'bn0.netdev': '[NetDev]\nName=bn0\nKind=bond\n\n'
                                             '[Bond]\n'
                                             'Mode=802.3ad\n'
-                                            'LACPTransmitRate=10\n'
+                                            'LACPTransmitRate=fast\n'
                                             'MIIMonitorSec=10ms\n'
                                             'MinLinks=10\n'
                                             'TransmitHashPolicy=none\n'
@@ -230,7 +230,7 @@ UseMTU=true
     bn0:
       parameters:
         mode: 802.3ad
-        lacp-rate: 10
+        lacp-rate: fast
         mii-monitor-interval: 10
         min-links: 10
         up-delay: 20
@@ -258,7 +258,7 @@ UseMTU=true
         self.assert_networkd({'bn0.netdev': '[NetDev]\nName=bn0\nKind=bond\n\n'
                                             '[Bond]\n'
                                             'Mode=802.3ad\n'
-                                            'LACPTransmitRate=10\n'
+                                            'LACPTransmitRate=fast\n'
                                             'MIIMonitorSec=10ms\n'
                                             'MinLinks=10\n'
                                             'TransmitHashPolicy=none\n'
@@ -611,7 +611,7 @@ method=ignore
       interfaces: [eno1, switchport]
       parameters:
         mode: 802.3ad
-        lacp-rate: 10
+        lacp-rate: slow
         mii-monitor-interval: 10
         min-links: 10
         up-delay: 10
@@ -672,7 +672,7 @@ interface-name=bn0
 
 [bond]
 mode=802.3ad
-lacp_rate=10
+lacp_rate=slow
 miimon=10
 min_links=10
 xmit_hash_policy=none
@@ -715,7 +715,7 @@ method=ignore
       interfaces: [eno1, switchport]
       parameters:
         mode: 802.3ad
-        lacp-rate: 10
+        lacp-rate: slow
         mii-monitor-interval: 10
         min-links: 10
         up-delay: 10
@@ -778,7 +778,7 @@ interface-name=bn0
 
 [bond]
 mode=802.3ad
-lacp_rate=10
+lacp_rate=slow
 miimon=10
 min_links=10
 xmit_hash_policy=none
@@ -893,6 +893,21 @@ class TestConfigErrors(TestBase):
           - 2001:dead:beef::1
       dhcp4: true''', expect_fail=True)
         self.assertIn("unknown bond mode 'lacp'", err)
+
+    def test_bond_invalid_lacp_rate(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eno1:
+      match:
+        name: eth0
+  bonds:
+    bond0:
+      interfaces: [eno1]
+      parameters:
+        lacp-rate: abcd
+      dhcp4: true''', expect_fail=True)
+        self.assertIn("unknown lacp-rate value 'abcd'", err)
 
     def test_bond_invalid_arp_target(self):
         self.generate('''network:

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -901,7 +901,7 @@ interface-name=bn0
 
 [bond]
 mode=802.3ad
-lacp_rate=10
+lacp_rate=fast
 miimon=10
 min_links=10
 xmit_hash_policy=none
@@ -938,7 +938,7 @@ method=ignore
         mii-monitor-interval: "10"
         up-delay: "10"
         down-delay: "10"
-        lacp-rate: "10"
+        lacp-rate: "fast"
         transmit-hash-policy: "none"
         ad-select: "none"
         arp-validate: "all"


### PR DESCRIPTION
This field should accept only the values "fast" and "slow". It's documented in the Netplan documentation.

It addresses LP: #1745648

Note: although we have it documented that the expected values are "fast" and "slow", NetworkManager also accepts 1 and 0, respectively, besides the keywords. There is a chance that someone out there is using NetworkManager as renderer and the values as numbers and it is just working fine. Should we handle the case and also accept 1 and 0? In this case, we would simply forward the value to NM and translate it to text before generating the configuration for networkd.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1745648

