### PR TITLE
Add all the commands to the bash completion file (LP: #1749869)

### DIFF
--- a/netplan.completions
+++ b/netplan.completions
@@ -37,7 +37,7 @@ _netplan_completions() {
       ;;
 
     'status'*)
-      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug -a --all -f --format")" -- "$cur" )
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug -a --all -f --format $(ls /sys/class/net 2> /dev/null)")" -- "$cur" )
       ;;
 
     'apply'*)

--- a/netplan.completions
+++ b/netplan.completions
@@ -1,45 +1,79 @@
-# netplan(1) completion                                       -*- shell-script -*-
+# netplan(5) completion                                       -*- shell-script -*-
 
-_compgen_help()
-{
-    local options=$1
-    shift
+_netplan_completions_filter() {
+  local words="$1"
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local result=()
 
-    compgen -W '${options} help' $@
+  if [[ "${cur:0:1}" == "-" ]]; then
+    echo "$words"
+
+  else
+    for word in $words; do
+      [[ "${word:0:1}" != "-" ]] && result+=("$word")
+    done
+
+    echo "${result[*]}"
+
+  fi
 }
 
-_netplan()
-{
-    local cur prev words cword
-    _init_completion || return
+_netplan_completions() {
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local compwords=("${COMP_WORDS[@]:1:$COMP_CWORD-1}")
+  local compline="${compwords[*]}"
 
-    case $prev in
-        netplan)
-            COMPREPLY=( $( _compgen_help 'apply generate ifupdown-migrate ip' "$cur" ) )
-            return
-            ;;
-        apply|generate)
-            return
-            ;;
-        ifupdown-migrate)
-            return
-            ;;
-        ip)
-            COMPREPLY=( $( _compgen_help 'leases' -- "$cur" ) )
-            return
-            ;;
-        leases)
-            if [ "${COMP_WORDS[COMP_CWORD-2]}" = "ip" ]; then
-                _available_interfaces -a
-            fi
-            return
-            ;;
-    esac
+  case "$compline" in
+    'ip leases'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug --root-dir")" -- "$cur" )
+      ;;
 
-    if [[ $cur == -* ]]; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
-    fi
+    'generate'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug --root-dir --mapping")" -- "$cur" )
+      ;;
+
+    'rebind'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug")" -- "$cur" )
+      ;;
+
+    'status'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug -a --all -f --format")" -- "$cur" )
+      ;;
+
+    'apply'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug --sriov-only --only-ovs-cleanup --state")" -- "$cur" )
+      ;;
+
+    'help'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help")" -- "$cur" )
+      ;;
+
+    'info'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug --json --yaml")" -- "$cur" )
+      ;;
+
+    'get'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug --root-dir")" -- "$cur" )
+      ;;
+
+    'set'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug --origin-hint")" -- "$cur" )
+      ;;
+
+    'try'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug --config-file --timeout --state")" -- "$cur" )
+      ;;
+
+    'ip'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug help leases")" -- "$cur" )
+      ;;
+
+    *)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_netplan_completions_filter "-h --help --debug help apply generate get info ip set rebind status try")" -- "$cur" )
+      ;;
+
+  esac
 } &&
-complete -F _netplan netplan
+complete -F _netplan_completions netplan
 
-# ex: ts=4 sw=4 et filetype=sh
+# ex: filetype=sh

--- a/tools/completely.yaml
+++ b/tools/completely.yaml
@@ -80,6 +80,7 @@ netplan status:
 - --all
 - -f
 - --format
+- $(ls /sys/class/net 2> /dev/null)
 
 netplan try:
 - -h

--- a/tools/completely.yaml
+++ b/tools/completely.yaml
@@ -1,0 +1,90 @@
+# Used to regenerate the bash auto completion script
+# with https://github.com/DannyBen/completely
+
+netplan:
+- -h
+- --help
+- --debug
+- help
+- apply
+- generate
+- get
+- info
+- ip
+- set
+- rebind
+- status
+- try
+
+netplan help:
+- -h
+- --help
+
+netplan apply:
+- -h
+- --help
+- --debug
+- --sriov-only
+- --only-ovs-cleanup
+- --state
+
+netplan generate:
+- -h
+- --help
+- --debug
+- --root-dir
+- --mapping
+
+netplan get:
+- -h
+- --help
+- --debug
+- --root-dir
+
+netplan info:
+- -h
+- --help
+- --debug
+- --json
+- --yaml
+
+netplan ip:
+- -h
+- --help
+- --debug
+- help
+- leases
+
+netplan ip leases:
+- -h
+- --help
+- --debug
+- --root-dir
+
+netplan set:
+- -h
+- --help
+- --debug
+- --origin-hint
+
+netplan rebind:
+- -h
+- --help
+- --debug
+
+netplan status:
+- -h
+- --help
+- --debug
+- -a
+- --all
+- -f
+- --format
+
+netplan try:
+- -h
+- --help
+- --debug
+- --config-file
+- --timeout
+- --state


### PR DESCRIPTION
The file was (lazily) regenerated using the completely tool [0].

In the future we could do that in netplan itself using what we add to the argparse instance.

[0] - https://github.com/DannyBen/completely


## Description

In the future we could try to add a builtin command similar to what `kubectl completion` does and generate the script using argparse as source of information. Something like `netplan completion [bash|zsh]`.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1749869

