### PR TITLE
meson: use meson-make-symlink.sh helper script instead of install_symlink()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,8 @@ yaml = dependency('yaml-0.1')
 uuid = dependency('uuid')
 libsystemd = dependency('libsystemd')
 
+meson_make_symlink = meson.current_source_dir() + '/tools/meson-make-symlink.sh'
+
 systemd = dependency('systemd')
 completions = dependency('bash-completion')
 systemd_generator_dir = systemd.get_variable(pkgconfig: 'systemdsystemgeneratordir')

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,10 +34,9 @@ executable(
     dependencies: [glib, gio, yaml, uuid],
     install_dir: libexec_netplan,
     install: true)
-install_symlink(
-    'netplan',
-    pointing_to: join_paths('..', '..', '..') + join_paths(get_option('prefix'), libexec_netplan, 'generate'),
-    install_dir: systemd_generator_dir)
+meson.add_install_script(meson_make_symlink,
+    join_paths(get_option('prefix'), libexec_netplan, 'generate'),
+    join_paths(systemd_generator_dir, 'netplan'))
 # Install this symlink for legacy reasons, see netplan/cli/utils.py: get_generator_path()
 install_symlink(
     'generate',

--- a/tools/meson-make-symlink.sh
+++ b/tools/meson-make-symlink.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# this is needed mostly because $DESTDIR is provided as a variable,
+# and we need to create the target directory...
+
+mkdir -vp "$(dirname "${DESTDIR:-}$2")"
+if [ "$(dirname $1)" = . ]; then
+    ln -fs -T "$1" "${DESTDIR:-}$2"
+else
+    ln -fs -T --relative "${DESTDIR:-}$1" "${DESTDIR:-}$2"
+fi


### PR DESCRIPTION
## Description
meson: use meson-make-symlink.sh helper script instead of install_symlink()

This will allow to dynamically adopt the symlinks for usrmerged and non-usrmerged installations, especially:
root@ll:~# pkgconf --variable=systemdsystemgeneratordir systemd /lib/systemd/system-generators

[root@f37 ~]# pkgconf --variable=systemdsystemgeneratordir systemd /usr/lib/systemd/system-generators

Helper script inspired by util-linux 238.1-5 (tools/meson-make-symlink.sh)

Related to #323 

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

