### PR TITLE
netplan: cli: fix typo from 'unkown' to 'unknown'

### DIFF
--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -94,7 +94,7 @@ def _del_global(type, iface, key, value):
         if all(item in out for item in value.split(',')):
             subprocess.check_call(args_del)
     else:
-        raise Exception('Reset command unkown for:', key)
+        raise Exception('Reset command unknown for:', key)
 
 
 def clear_setting(type, iface, setting, value):


### PR DESCRIPTION
## Description
Fix typo from  'unkown' to 'unknown'

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

