### PR TITLE
tests: add new spread based snapd integration test

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -1,0 +1,21 @@
+name: Run spread
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  spread:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: canonical/setup-lxd@ea57509243d3cf39f8ab926e021bb353947b01b5
+      - uses: actions/checkout@v2
+      - name: Install spread
+        run: |
+          go install github.com/snapcore/spread/cmd/spread@latest
+      - name: Run the spread test inside LXD
+        run: |
+          ~/go/bin/spread -v lxd:
+

--- a/spread.yaml
+++ b/spread.yaml
@@ -33,7 +33,7 @@ prepare: |
   #        https://paste.ubuntu.com/p/qRnJvjyddN/
   #meson test -C build --verbose
   meson install -C build --destdir=/
-  # set some defaults for the tests
+  # set some defaults
   cat > /etc/netplan/0-snapd-defaults.yaml <<'EOF'
   network:
     version: 2
@@ -44,3 +44,10 @@ prepare: |
   chmod 0600 /etc/netplan/0-snapd-defaults.yaml
   echo "Precondition check, the basics work"
   netplan get bridges.br54.dhcp4 | MATCH true
+  # keep original config around
+  tar cvf "$SPREAD_PATH"/etc-netplan.tar.gz /etc/netplan/
+
+restore-each: |
+  # restore original netplan dir
+  rm -rf /etc/netplan/*
+  (cd / && tar xvf "$SPREAD_PATH"/etc-netplan.tar.gz)

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,46 @@
+project: netplan
+
+backends:
+  lxd:
+    systems: [ubuntu-22.04]
+  qemu:
+    systems:
+      - ubuntu-22.04-64:
+          username: ubuntu
+          password: ubuntu
+
+suites:
+  tests/spread/:
+    summary: integration tests
+
+path: /home/tests
+
+prepare: |
+  # FIXME: remove after legacy symlink in 107 gets dropped (see meson.build)
+  # This is needed as the git netplan puts a symlink to /lib/netplan/generate
+  # but the package has the real generate there
+  rm -f /lib/netplan/generate
+  # FIXME: having the debian packging available would allow "apt
+  # build-dep -y ./" would make this easier :)
+  apt update -qq
+  apt install -y build-essential meson pkg-config libyaml-dev \
+    libglib2.0-dev uuid-dev python3 libsystemd-dev pandoc python3-pytest \
+    python3-coverage libcmocka-dev python3-rich
+  # install, a bit ugly but this is a container (did I mention the packaging?)
+  meson setup build --prefix=/usr
+  meson compile -C build
+  # FIXME: enable, this crashes right now with:
+  #        https://paste.ubuntu.com/p/qRnJvjyddN/
+  #meson test -C build --verbose
+  meson install -C build --destdir=/
+  # set some defaults for the tests
+  cat > /etc/netplan/0-snapd-defaults.yaml <<'EOF'
+  network:
+    version: 2
+    bridges:
+      br54:
+        dhcp4: true
+  EOF
+  chmod 0600 /etc/netplan/0-snapd-defaults.yaml
+  echo "Precondition check, the basics work"
+  netplan get bridges.br54.dhcp4 | MATCH true

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,8 +39,6 @@ meson.add_install_script(meson_make_symlink,
     join_paths(systemd_generator_dir, 'netplan'))
 # FIXME: Drop legacy symlink after 0.107 is released:
 # It's only around for legacy reasons, see netplan/cli/utils.py: get_generator_path()
-install_symlink(
-    'generate',
-    pointing_to: join_paths('..', '..') + join_paths(get_option('prefix'), libexec_netplan, 'generate'),
-    install_dir: join_paths('/', 'lib', 'netplan'))
-
+meson.add_install_script(meson_make_symlink,
+    join_paths(get_option('prefix'), libexec_netplan, 'generate'),
+    join_paths('/', 'lib', 'netplan', 'generate'))

--- a/tests/spread/dbus/task.yaml
+++ b/tests/spread/dbus/task.yaml
@@ -1,0 +1,31 @@
+summary: Check that the dbus integration works
+
+debug: |
+  netplan get
+
+execute: |
+  # see the basics work
+  netplan get bridges.br54.dhcp4 | MATCH true
+  # TODO: actually use busctl
+  obj_path=$(dbus-send --system --print-reply --type=method_call \
+     --dest=io.netplan.Netplan /io/netplan/Netplan \
+     io.netplan.Netplan.Config|tail -1 | sed 's/.*"\(.*\)".*/\1/' )
+  dbus-send --print-reply  --system --type=method_call \
+     --dest=io.netplan.Netplan "$obj_path" \
+     io.netplan.Netplan.Config.Get | MATCH "version: 2"
+  # and updating via dbus netplan works
+  dbus-send --print-reply  --system --type=method_call \
+      --dest=io.netplan.Netplan "$obj_path"   \
+      io.netplan.Netplan.Config.Set \
+      string:bridges.br54.dhcp4=false string:90-test
+  # not applied yet
+  test ! -e /etc/netplan/90-test.yaml
+  netplan get bridges.br54.dhcp4 | MATCH true
+  # apply
+  dbus-send --print-reply  --system --type=method_call \
+      --dest=io.netplan.Netplan "$obj_path"   \
+      io.netplan.Netplan.Config.Apply
+  # and now it's active
+  test -e /etc/netplan/90-test.yaml
+  netplan get bridges.br54.dhcp4 | MATCH false
+

--- a/tests/spread/dbus/task.yaml
+++ b/tests/spread/dbus/task.yaml
@@ -13,7 +13,8 @@ execute: |
   dbus-send --print-reply  --system --type=method_call \
      --dest=io.netplan.Netplan "$obj_path" \
      io.netplan.Netplan.Config.Get | MATCH "version: 2"
-  # and updating via dbus netplan works
+  # and updating via dbus netplan works (use 90-test origin hint for
+  # easier test cleanup)
   dbus-send --print-reply  --system --type=method_call \
       --dest=io.netplan.Netplan "$obj_path"   \
       io.netplan.Netplan.Config.Set \

--- a/tests/spread/snapd-integration/task.yaml
+++ b/tests/spread/snapd-integration/task.yaml
@@ -1,0 +1,47 @@
+summary: Check that the snapd/netplan integration works
+
+prepare: |
+    # put snapd in debug mode for good logs
+    mkdir -p /etc/systemd/system/snapd.service.d
+    cat <<EOF > /etc/systemd/system/snapd.service.d/local.conf
+    [Service]
+    Environment=SNAPD_DEBUG=1
+    EOF
+    systemctl daemon-reload
+    # install snapd if needed (should be installed on most lxd images)
+    if ! dpkg -l snapd >/dev/null; then
+        apt install -y snapd
+        echo "apt autoremove -y snapd" >> defered.cleanup
+    fi
+    # fake running on core (netplan only enabled on ubuntu core)
+    # FIXME: find a more offical way, this if fugly
+    cp /etc/os-release /etc/os-release.save
+    sed -i s/ID=ubuntu/ID=ubuntu-core/ /etc/os-release
+    M=/var/lib/snapd/assertions/asserts-v0/model/16/generic/generic-classic/active
+    cp "$M" model.save
+    sed -i 's/classic: true/architecture: amd64\ngadget: pc\nkernel: pc-kernel/g' "$M"
+    # restart snapd
+    systemctl restart snapd
+
+restore: |
+    mv /etc/os-release.save /etc/os-release
+    mv model.save /var/lib/snapd/assertions/asserts-v0/model/16/generic/generic-classic/active
+    sudo systemctl restart snapd
+    if [ -e defered.cleanup ]; then
+        sh -ex defered.cleanup
+    fi
+    rm -f model.*
+
+debug: |
+    journalctl -u snapd
+    snap get system -d
+    snap version
+
+execute: |
+  # see the basics work
+  netplan get bridges.br54.dhcp4 | MATCH true
+  snap get system system.network.netplan.network.bridges.br54.dhcp4 | MATCH true
+  # and updating netplan works
+  snap set system system.network.netplan.network.bridges.br54.dhcp4=false
+  netplan get bridges.br54.dhcp4 | MATCH false
+  snap get system system.network.netplan.network.bridges.br54.dhcp4 | MATCH false


### PR DESCRIPTION
## Description

This is a first draft of adding integration tests for netplan with snapd and dbus. It uses spread and the LXD backend to run inside the github runners. A first test is designed to do basic interactions between netplan and snapd.

I put this into "draft" mode because I ran into the following issues:
1. following the instruction to make crashes meson inside a 22.04 container (https://paste.ubuntu.com/p/qRnJvjyddN/)
2. when commenting out the testing the install step fails with: 
```
meson install -C build --destdir=/
...
Installing /home/tests/netplan.completions to //usr/share/bash-completion/completions

ERROR: Tried to install symlink to missing file //lib/netplan/../../usr/libexec/netplan/generate

```
I suspect (2) is a result in the most recent https://github.com/canonical/netplan/pull/323 ?

I also wonder if the build/install/build-dep step could be simplified by getting the debian packaging from somewhere but I could not figure out where it comes from (sorry for that and hints/ideas welcome).

## Testing locally via spread

```
$ GOBIN=~/go/bin go install github.com/snapcore/spread/cmd/spread@latest
$ ~/go/bin/spread -v -debug lxd:
```

