### PR TITLE
parse:ovs: Ignore deprecated OpenFlow1.6 protocol (LP: #1963735)

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -161,7 +161,7 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
     > Valid for bridge interfaces or the network section. List of protocols to
     > be used when negotiating a connection with the controller. Accepts
     > `OpenFlow10`, `OpenFlow11`, `OpenFlow12`, `OpenFlow13`, `OpenFlow14`,
-    > `OpenFlow15` and `OpenFlow16`.
+    > and `OpenFlow15`.
 
   - **rstp** (bool) – since **0.100**
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -2446,8 +2446,9 @@ handle_ovs_bridge_fail_mode(NetplanParser* npp, yaml_node_t* node, const void* d
 static gboolean
 handle_ovs_protocol(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
+    const char* deprecated[] = { "OpenFlow16" };
     const char* supported[] = {
-        "OpenFlow10", "OpenFlow11", "OpenFlow12", "OpenFlow13", "OpenFlow14", "OpenFlow15", "OpenFlow16", NULL
+        "OpenFlow10", "OpenFlow11", "OpenFlow12", "OpenFlow13", "OpenFlow14", "OpenFlow15", NULL
     };
     unsigned i = 0;
     guint offset = GPOINTER_TO_UINT(data);
@@ -2456,6 +2457,11 @@ handle_ovs_protocol(NetplanParser* npp, yaml_node_t* node, void* entryptr, const
     for (yaml_node_item_t *iter = node->data.sequence.items.start; iter < node->data.sequence.items.top; iter++) {
         yaml_node_t *entry = yaml_document_get_node(&npp->doc, *iter);
         assert_type(npp, entry, YAML_SCALAR_NODE);
+
+        if (!g_strcmp0(scalar(entry), deprecated[0])) {
+            g_warning("openvswitch: Ignoring deprecated protocol: %s", scalar(entry));
+            continue;
+        }
 
         for (i = 0; supported[i] != NULL; ++i)
             if (!g_strcmp0(scalar(entry), supported[i]))

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -122,13 +122,14 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/other-confi
         self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0'})
 
     def test_global_set_protocols(self):
-        self.generate('''network:
+        out = self.generate('''network:
   version: 2
   openvswitch:
-    protocols: [OpenFlow10, OpenFlow11, OpenFlow12]
+    protocols: [OpenFlow10, OpenFlow11, OpenFlow12, OpenFlow16]
   bridges:
     ovs0:
-      openvswitch: {}''')
+      openvswitch: {}''', skip_generated_yaml_validation=True)  # OpenFlow16 won't be re-generated
+        self.assertIn('openvswitch: Ignoring deprecated protocol: OpenFlow16', out)
         self.assert_ovs({'ovs0.service': OVS_VIRTUAL % {'iface': 'ovs0', 'extra': '''
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Description
parse:ovs: Ignore deprecated OpenFlow1.6 protocol (LP: #1963735)

The OpenFlow 1.6 draft got abandoned by the ONF as of OVS v2.12:
    https://www.openvswitch.org/releases/NEWS-2.12.0.txt

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1963735

