### PR TITLE
netplan: Handle command exceptions

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -74,3 +74,65 @@ typedef struct _NetplanStateIterator NetplanStateIterator;
 struct _NetplanStateIterator {
     void* placeholder;
 };
+
+/*
+ * Errors and error domains
+ *
+ * NOTE: if new errors or domains are added,
+ * netplan/libnetplan.py must be updated with the new entries.
+ */
+
+enum NETPLAN_ERROR_DOMAINS {
+    NETPLAN_PARSER_ERROR = 1,
+    NETPLAN_VALIDATION_ERROR,
+    NETPLAN_FILE_ERROR,
+    NETPLAN_BACKEND_ERROR,
+    NETPLAN_EMITTER_ERROR,
+    NETPLAN_FORMAT_ERROR,
+};
+
+/*
+ * Errors for domain NETPLAN_PARSER_ERROR
+ *
+ * PARSER_ERRORS are expected to contain the file name, line and column numbers
+ */
+enum NETPLAN_PARSER_ERRORS {
+    NETPLAN_ERROR_INVALID_YAML,
+    NETPLAN_ERROR_INVALID_CONFIG
+};
+
+/*
+ * Errors for domain NETPLAN_VALIDATION_ERROR
+ *
+ * VALIDATION_ERRORS are expected to contain only the YAML file name
+ * where the error was found.
+ */
+enum NETPLAN_VALIDATION_ERRORS {
+    NETPLAN_ERROR_CONFIG_GENERIC,
+    NETPLAN_ERROR_CONFIG_VALIDATION,
+};
+
+/*
+ * Errors for domain NETPLAN_BACKEND_ERROR
+ */
+enum NETPLAN_BACKEND_ERRORS {
+    NETPLAN_ERROR_UNSUPPORTED,
+    NETPLAN_ERROR_VALIDATION,
+};
+
+/*
+ * Errors for domain NETPLAN_EMITTER_ERROR
+ */
+enum NETPLAN_EMITTER_ERRORS {
+    NETPLAN_ERROR_YAML_EMITTER,
+};
+
+/*
+ * Errors for domain NETPLAN_FORMAT_ERROR
+ *
+ * FORMAT_ERRORS are generic errors emitted from contexts where information
+ * like the file name is not known.
+ */
+enum NETPLAN_FORMAT_ERRORS {
+    NETPLAN_ERROR_FORMAT_INVALID_YAML,
+};

--- a/netplan/cli/commands/generate.py
+++ b/netplan/cli/commands/generate.py
@@ -68,10 +68,10 @@ class NetplanGenerate(utils.NetplanCommand):
             if res != 0:
                 if res == 130:
                     raise PermissionError(
-                        "failed to communicate with dbus service")
+                        "PermissionError: failed to communicate with dbus service")
                 else:
                     raise RuntimeError(
-                        "failed to communicate with dbus service: error %s" % res)
+                        "RuntimeError: failed to communicate with dbus service: error %s" % res)
             else:
                 return
 

--- a/netplan/cli/core.py
+++ b/netplan/cli/core.py
@@ -22,6 +22,7 @@ import logging
 import os
 
 import netplan.cli.utils as utils
+from netplan.libnetplan import NetplanException, NetplanValidationException, NetplanParserException
 
 
 FALLBACK_PATH = '/usr/bin:/snap/bin'
@@ -53,4 +54,12 @@ class Netplan(utils.NetplanCommand):
         else:
             logging.basicConfig(level=logging.INFO, format='%(message)s')
 
-        self.run_command()
+        try:
+            self.run_command()
+        except NetplanParserException as e:
+            message = f'{e.filename}:{e.line}:{e.column}: {e}'
+            logging.warning(f'Command failed: {message}')
+        except NetplanValidationException as e:
+            logging.warning(f'Command failed: {e.filename}: {e}')
+        except NetplanException as e:
+            logging.warning(f'Command failed: {e}')

--- a/netplan/cli/sriov.py
+++ b/netplan/cli/sriov.py
@@ -245,8 +245,8 @@ def get_vf_count_and_functions(interfaces, np_state,
 
         try:
             count = netdef.vf_count
-        except libnetplan.LibNetplanException as e:
-            raise ConfigurationError(*e.args)
+        except libnetplan.NetplanException as e:
+            raise ConfigurationError(str(e))
         if count == 0:
             continue
 

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -26,13 +26,13 @@ import re
 
 import netplan.libnetplan as np
 from netplan.configmanager import ConfigurationError
-from netplan.libnetplan import LibNetplanException
+from netplan.libnetplan import NetplanException
 
 
 NM_SERVICE_NAME = 'NetworkManager.service'
 NM_SNAP_SERVICE_NAME = 'snap.network-manager.networkmanager.service'
 
-config_errors = (ConfigurationError, LibNetplanException, RuntimeError)
+config_errors = (ConfigurationError, NetplanException, RuntimeError)
 
 
 def get_generator_path():

--- a/netplan/configmanager.py
+++ b/netplan/configmanager.py
@@ -82,8 +82,8 @@ class ConfigManager(object):
 
             self.np_state = libnetplan.State()
             self.np_state.import_parser_results(parser)
-        except libnetplan.LibNetplanException as e:
-            raise ConfigurationError(*e.args)
+        except libnetplan.NetplanException as e:
+            raise ConfigurationError(str(e))
 
         self.np_state.dump_to_logs()
         return self.np_state

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -978,7 +978,7 @@ netplan_netdef_write_yaml(
 
     // LCOV_EXCL_START
 err_path:
-    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "Error generating YAML: %s", emitter->problem);
+    g_set_error(error, NETPLAN_EMITTER_ERROR, NETPLAN_ERROR_YAML_EMITTER, "Error generating YAML: %s", emitter->problem);
     yaml_emitter_delete(emitter);
     fclose(output);
     return FALSE;
@@ -1085,14 +1085,14 @@ skip_netdefs:
 
     // LCOV_EXCL_START
 err_path:
-    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "Error generating YAML: %s", emitter->problem);
+    g_set_error(error, NETPLAN_EMITTER_ERROR, NETPLAN_ERROR_YAML_EMITTER, "Error generating YAML: %s", emitter->problem);
     yaml_emitter_delete(emitter);
     fclose(out_stream);
     return FALSE;
     // LCOV_EXCL_STOP
 
 file_error:
-    g_set_error(error, G_FILE_ERROR, errno, "%s", strerror(errno));
+    g_set_error(error, NETPLAN_FILE_ERROR, errno, "%m");
     return FALSE;
 }
 
@@ -1129,7 +1129,7 @@ netplan_state_write_yaml_file(const NetplanState* np_state, const char* filename
     gboolean write_globals = !!np_state->global_renderer;
     if (to_write == NULL && !write_globals) {
         if (unlink(path) && errno != ENOENT) {
-            g_set_error(error, G_FILE_ERROR, errno, "%s", strerror(errno));
+            g_set_error(error, NETPLAN_FILE_ERROR, errno, "%m");
             return FALSE;
         }
         return TRUE;
@@ -1138,7 +1138,7 @@ netplan_state_write_yaml_file(const NetplanState* np_state, const char* filename
     tmp_path = g_strdup_printf("%s.XXXXXX", path);
     out_fd = mkstemp(tmp_path); // permissions 0600 by default
     if (out_fd < 0) {
-        g_set_error(error, G_FILE_ERROR, errno, "%s", strerror(errno));
+        g_set_error(error, NETPLAN_FILE_ERROR, errno, "%m");
         return FALSE;
     }
 
@@ -1148,7 +1148,7 @@ netplan_state_write_yaml_file(const NetplanState* np_state, const char* filename
     if (ret) {
         if (rename(tmp_path, path) == 0)
             return TRUE;
-        g_set_error(error, G_FILE_ERROR, errno, "%s", strerror(errno));
+        g_set_error(error, NETPLAN_FILE_ERROR, errno, "%m");
     }
     /* Something went wrong, clean up the tempfile! */
     unlink(tmp_path);
@@ -1242,7 +1242,7 @@ netplan_state_update_yaml_hierarchy(const NetplanState* np_state, const char* de
     goto cleanup;
 
 file_error:
-    g_set_error(error, G_FILE_ERROR, errno, "%s", strerror(errno));
+    g_set_error(error, NETPLAN_FILE_ERROR, errno, "%m");
     ret = FALSE;
 cleanup:
     if (out_fd >= 0)

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -49,7 +49,7 @@ wifi_append_freq(gpointer key, gpointer value, gpointer user_data)
 static gboolean
 append_wifi_wowlan_flags(NetplanWifiWowlanFlag flag, GString* str, GError** error) {
     if (flag & NETPLAN_WIFI_WOWLAN_TYPES[0].flag || flag >= NETPLAN_WIFI_WOWLAN_TCP) {
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: unsupported wowlan_triggers mask: 0x%x\n", flag);
+        g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: unsupported wowlan_triggers mask: 0x%x\n", flag);
         return FALSE;
     }
     for (unsigned i = 0; NETPLAN_WIFI_WOWLAN_TYPES[i].name != NULL; ++i) {
@@ -307,7 +307,7 @@ write_regdom(const NetplanNetDefinition* def, const char* rootdir, GError** erro
     safe_mkdir_p_dir(link);
     if (symlink(path, link) < 0 && errno != EEXIST) {
         // LCOV_EXCL_START
-        g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_FAILED, "failed to create enablement symlink: %m\n");
+        g_set_error(error, NETPLAN_FILE_ERROR, errno, "failed to create enablement symlink: %m\n");
         return FALSE;
         // LCOV_EXCL_STOP
     }
@@ -652,39 +652,39 @@ combine_dhcp_overrides(const NetplanNetDefinition* def, NetplanDHCPOverrides* co
          * we enforce that they are the same.
          */
         if (def->dhcp4_overrides.use_dns != def->dhcp6_overrides.use_dns) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, DHCP_OVERRIDES_ERROR, def->id, "use-dns");
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, DHCP_OVERRIDES_ERROR, def->id, "use-dns");
             return FALSE;
         }
         if (g_strcmp0(def->dhcp4_overrides.use_domains, def->dhcp6_overrides.use_domains) != 0){
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, DHCP_OVERRIDES_ERROR, def->id, "use-domains");
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, DHCP_OVERRIDES_ERROR, def->id, "use-domains");
             return FALSE;
         }
         if (def->dhcp4_overrides.use_ntp != def->dhcp6_overrides.use_ntp) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, DHCP_OVERRIDES_ERROR, def->id, "use-ntp");
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, DHCP_OVERRIDES_ERROR, def->id, "use-ntp");
             return FALSE;
         }
         if (def->dhcp4_overrides.send_hostname != def->dhcp6_overrides.send_hostname) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, DHCP_OVERRIDES_ERROR, def->id, "send-hostname");
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, DHCP_OVERRIDES_ERROR, def->id, "send-hostname");
             return FALSE;
         }
         if (def->dhcp4_overrides.use_hostname != def->dhcp6_overrides.use_hostname) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, DHCP_OVERRIDES_ERROR, def->id, "use-hostname");
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, DHCP_OVERRIDES_ERROR, def->id, "use-hostname");
             return FALSE;
         }
         if (def->dhcp4_overrides.use_mtu != def->dhcp6_overrides.use_mtu) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, DHCP_OVERRIDES_ERROR, def->id, "use-mtu");
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, DHCP_OVERRIDES_ERROR, def->id, "use-mtu");
             return FALSE;
         }
         if (g_strcmp0(def->dhcp4_overrides.hostname, def->dhcp6_overrides.hostname) != 0) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, DHCP_OVERRIDES_ERROR, def->id, "hostname");
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, DHCP_OVERRIDES_ERROR, def->id, "hostname");
             return FALSE;
         }
         if (def->dhcp4_overrides.metric != def->dhcp6_overrides.metric) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, DHCP_OVERRIDES_ERROR, def->id, "route-metric");
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, DHCP_OVERRIDES_ERROR, def->id, "route-metric");
             return FALSE;
         }
         if (def->dhcp4_overrides.use_routes != def->dhcp6_overrides.use_routes) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, DHCP_OVERRIDES_ERROR, def->id, "use-routes");
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, DHCP_OVERRIDES_ERROR, def->id, "use-routes");
             return FALSE;
         }
         /* Just use dhcp4_overrides now, since we know they are the same. */
@@ -791,7 +791,7 @@ netplan_netdef_write_network_file(
         /* EUI-64 mode is enabled by default, if no IPv6Token= is specified */
         /* TODO: Enable stable-privacy mode for networkd, once PR#16618 has been released:
          *       https://github.com/systemd/systemd/pull/16618 */
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: ipv6-address-generation mode is not supported by networkd\n", def->id);
+        g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: ipv6-address-generation mode is not supported by networkd\n", def->id);
         return FALSE;
     }
     if (def->accept_ra == NETPLAN_RA_MODE_ENABLED)
@@ -1072,7 +1072,7 @@ append_wpa_auth_conf(GString* s, const NetplanAuthenticationSettings* auth, cons
                 /* must be a hex-digit key representation */
                 for (unsigned i = 0; i < 64; ++i)
                     if (!isxdigit(auth->password[i])) {
-                        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: PSK length of 64 is only supported for hex-digit representation\n", id);
+                        g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: PSK length of 64 is only supported for hex-digit representation\n", id);
                         return FALSE;
                     }
                 /* this is required to be unquoted */
@@ -1080,7 +1080,7 @@ append_wpa_auth_conf(GString* s, const NetplanAuthenticationSettings* auth, cons
             } else if (len < 8 || len > 63) {
                 /* per wpa_supplicant spec, passphrase needs to be between 8
                    and 63 characters */
-                g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: ASCII passphrase must be between 8 and 63 characters (inclusive)\n", id);
+                g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, "ERROR: %s: ASCII passphrase must be between 8 and 63 characters (inclusive)\n", id);
                 return FALSE;
             } else {
                 g_string_append_printf(s, "  psk=\"%s\"\n", auth->password);
@@ -1204,7 +1204,7 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir, GError** er
                     g_string_append(s, "  mode=1\n");
                     break;
                 default:
-                    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: %s: networkd does not support this wifi mode\n", def->id, ap->ssid);
+                    g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: %s: networkd does not support this wifi mode\n", def->id, ap->ssid);
                     g_string_free(s, TRUE);
                     return FALSE;
             }
@@ -1273,7 +1273,7 @@ netplan_netdef_write_networkd(
     }
 
     if (def->type == NETPLAN_DEF_TYPE_MODEM) {
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: networkd backend does not support GSM/CDMA modem configuration\n", def->id);
+        g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: networkd backend does not support GSM/CDMA modem configuration\n", def->id);
         return FALSE;
     }
 
@@ -1281,7 +1281,7 @@ netplan_netdef_write_networkd(
         g_autofree char* link = g_strjoin(NULL, rootdir ?: "", "/run/systemd/system/systemd-networkd.service.wants/netplan-wpa-", def->id, ".service", NULL);
         g_autofree char* slink = g_strjoin(NULL, "/run/systemd/system/netplan-wpa-", def->id, ".service", NULL);
         if (def->type == NETPLAN_DEF_TYPE_WIFI && def->has_match) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: networkd backend does not support wifi with match:, only by interface name\n", def->id);
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: networkd backend does not support wifi with match:, only by interface name\n", def->id);
             return FALSE;
         }
 
@@ -1297,7 +1297,7 @@ netplan_netdef_write_networkd(
 
         if (symlink(slink, link) < 0 && errno != EEXIST) {
             // LCOV_EXCL_START
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "failed to create enablement symlink: %m\n");
+            g_set_error(error, NETPLAN_FILE_ERROR, errno, "failed to create enablement symlink: %m\n");
             return FALSE;
             // LCOV_EXCL_STOP
         }

--- a/src/nm.c
+++ b/src/nm.c
@@ -198,7 +198,7 @@ write_routes(const NetplanNetDefinition* def, GKeyFile *kf, int family, GError**
                 destination = cur_route->to;
 
             if (cur_route->type && g_ascii_strcasecmp(cur_route->type, "unicast") != 0) {
-                g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: NetworkManager only supports unicast routes\n", def->id);
+                g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: NetworkManager only supports unicast routes\n", def->id);
                 return FALSE;
             }
 
@@ -336,7 +336,7 @@ write_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError** e
      * as well to check for more specific characteristics (if needed). */
     if (def->tunnel.private_key) {
         if (def->tunnel.private_key[0] == '/' && !is_wireguard_key(def->tunnel.private_key)) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "%s: private key needs to be base64 encoded when using the NM backend\n", def->id);
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, "%s: private key needs to be base64 encoded when using the NM backend\n", def->id);
             return FALSE;
         } else
             g_key_file_set_string(kf, "wireguard", "private-key", def->tunnel.private_key);
@@ -364,7 +364,7 @@ write_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError** e
              * as well to check for more specific characteristics (if needed). */
             if (peer->preshared_key) {
                 if (peer->preshared_key[0] == '/' && !is_wireguard_key(peer->preshared_key)) {
-                    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "%s: shared key needs to be base64 encoded when using the NM backend\n", def->id);
+                    g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, "%s: shared key needs to be base64 encoded when using the NM backend\n", def->id);
                     return FALSE;
                 } else {
                     g_key_file_set_value(kf, tmp_group, "preshared-key", peer->preshared_key);
@@ -634,7 +634,7 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
         /* XXX: For now NetworkManager only supports the "manual" activation
          * mode */
         if (!!g_strcmp0(def->activation_mode, "manual")) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: NetworkManager definitions do not support activation-mode %s\n", def->id, def->activation_mode);
+            g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: NetworkManager definitions do not support activation-mode %s\n", def->id, def->activation_mode);
             return FALSE;
         }
         /* "manual" */
@@ -722,7 +722,7 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
     }
 
     if (def->ipv6_mtubytes) {
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: NetworkManager definitions do not support ipv6-mtu\n", def->id);
+        g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: NetworkManager definitions do not support ipv6-mtu\n", def->id);
         return FALSE;
     }
 
@@ -959,12 +959,12 @@ netplan_netdef_write_nm(
     }
 
     if (netdef->match.driver && !netdef->set_name) {
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: NetworkManager definitions do not support matching by driver\n", netdef->id);
+        g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: NetworkManager definitions do not support matching by driver\n", netdef->id);
         return FALSE;
     }
 
     if (netdef->address_options) {
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: %s: NetworkManager does not support address options\n", netdef->id);
+        g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: NetworkManager does not support address options\n", netdef->id);
         return FALSE;
     }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -95,7 +95,7 @@ load_yaml_from_fd(int input_fd, yaml_document_t* doc, GError** error)
 
     // LCOV_EXCL_START
 file_error:
-    g_set_error(error, G_FILE_ERROR, errno, "Error when opening FD %d: %s", input_fd, g_strerror(errno));
+    g_set_error(error, NETPLAN_FILE_ERROR, errno, "Error when opening FD %d: %m", input_fd);
     if (in_dup >= 0)
         close(in_dup);
     return FALSE;
@@ -119,7 +119,7 @@ load_yaml(const char* yaml, yaml_document_t* doc, GError** error)
 
     fyaml = g_fopen(yaml, "r");
     if (!fyaml) { // LCOV_EXCL_START
-        g_set_error(error, G_FILE_ERROR, errno, "Cannot open %s: %s", yaml, g_strerror(errno));
+        g_set_error(error, NETPLAN_FILE_ERROR, errno, "Cannot open %s: %m", yaml);
         return FALSE;
     } // LCOV_EXCL_STOP
 
@@ -3298,8 +3298,7 @@ netplan_parser_load_yaml(NetplanParser* npp, const char* filename, GError** erro
     mode_t mask = S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
     struct stat info;
     if (stat(filename, &info) < 0) {
-        g_set_error(error, G_FILE_ERROR, errno, "Cannot stat %s: %s",
-                    filename, strerror(errno));
+        g_set_error(error, NETPLAN_FILE_ERROR, errno, "Cannot stat %s: %m", filename);
         return FALSE;
     } else if (info.st_mode & mask)
         g_warning("Permissions for %s are too open. Netplan configuration "

--- a/src/sriov.c
+++ b/src/sriov.c
@@ -53,7 +53,7 @@ write_sriov_rebind_systemd_unit(const GString* pfs, const char* rootdir, GError*
     safe_mkdir_p_dir(link);
     if (symlink(path, link) < 0 && errno != EEXIST) {
         // LCOV_EXCL_START
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
+        g_set_error(error, NETPLAN_FILE_ERROR, errno,
                     "failed to create enablement symlink: %m\n");
         return FALSE;
         // LCOV_EXCL_STOP
@@ -138,7 +138,7 @@ _netplan_state_get_vf_count_for_def(const NetplanState* np_state, const NetplanN
     }
 
     if (netdef->sriov_explicit_vf_count != G_MAXUINT && count > netdef->sriov_explicit_vf_count) {
-        g_set_error(error, 0, 0, "more VFs allocated than the explicit size declared: %d > %d", count, netdef->sriov_explicit_vf_count);
+        g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, "more VFs allocated than the explicit size declared: %d > %d", count, netdef->sriov_explicit_vf_count);
         return -1;
     }
     return netdef->sriov_explicit_vf_count != G_MAXUINT ? netdef->sriov_explicit_vf_count : count;

--- a/src/validation.c
+++ b/src/validation.c
@@ -500,7 +500,7 @@ adopt_and_validate_vrf_routes(const NetplanParser *npp, GHashTable *netdefs, GEr
                     g_debug("%s: Ignoring redundant routes table %d (matches VRF table)", nd->id, r->table);
                     continue;
                 } else if (r->table != NETPLAN_ROUTE_TABLE_UNSPEC) {
-                    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
+                    g_set_error(error, NETPLAN_VALIDATION_ERROR, NETPLAN_ERROR_CONFIG_GENERIC,
                             "%s: VRF routes table mismatch (%d != %d)", nd->id, nd->vrf_table, r->table);
                     return FALSE;
                 } else {
@@ -518,7 +518,7 @@ adopt_and_validate_vrf_routes(const NetplanParser *npp, GHashTable *netdefs, GEr
                     g_debug("%s: Ignoring redundant routing-policy table %d (matches VRF table)", nd->id, r->table);
                     continue;
                 } else if (r->table != NETPLAN_ROUTE_TABLE_UNSPEC && r->table != nd->vrf_table) {
-                    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
+                    g_set_error(error, NETPLAN_VALIDATION_ERROR, NETPLAN_ERROR_CONFIG_GENERIC,
                             "%s: VRF routing-policy table mismatch (%d != %d)", nd->id, nd->vrf_table, r->table);
                     return FALSE;
                 } else {
@@ -557,7 +557,7 @@ defroute_err(struct _defroute_entry *entry, const char *new_netdef_id, GError **
     else
         snprintf(metric_name, sizeof(metric_name) - 1, "metric: %d", entry->metric);
 
-    g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT,
+    g_set_error(error, NETPLAN_VALIDATION_ERROR, NETPLAN_ERROR_CONFIG_GENERIC,
             "Conflicting default route declarations for %s (%s, %s), first declared in %s but also in %s",
             (entry->family == AF_INET) ? "IPv4" : "IPv6",
             table_name,

--- a/tests/cli/test_get_set.py
+++ b/tests/cli/test_get_set.py
@@ -25,7 +25,7 @@ import glob
 
 import yaml
 
-from netplan.libnetplan import LibNetplanException
+from netplan.libnetplan import NetplanException
 from tests.test_utils import call_cli
 
 
@@ -171,7 +171,7 @@ class TestSet(unittest.TestCase):
         via: 10.10.10.4
         table: 1005
 ''')
-        with self.assertRaises(LibNetplanException) as e:
+        with self.assertRaises(NetplanException) as e:
             self._set(['vrfs.vrf0.table=1004', '--origin-hint=90-snapd-config'])
         self.assertIn('vrf0: VRF routes table mismatch (1004 != 1005)', str(e.exception))
         # hint/output file should not exist
@@ -268,7 +268,7 @@ class TestSet(unittest.TestCase):
       mode: sit
       local: 1.2.3.4
       remote: 5.6.7.8''')
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(NetplanException) as context:
             self._set(['tunnels.tun0.keys.input=12345'])
         self.assertIn('tun0: \'input-key\' is not required for this tunnel type', str(context.exception))
 

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -19,7 +19,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from configparser import ConfigParser
-from netplan.libnetplan import _GError
+from netplan.libnetplan import _NetplanError
 import os
 import re
 import sys
@@ -78,7 +78,7 @@ class TestKeyfileBase(unittest.TestCase):
 
     def generate_from_keyfile(self, keyfile, netdef_id=None, expect_fail=False, filename=None):
         '''Call libnetplan with given keyfile string as configuration'''
-        err = ctypes.POINTER(_GError)()
+        err = ctypes.POINTER(_NetplanError)()
         # Autodetect default 'NM-<UUID>' netdef-id
         ssid = ''
         keyfile = re.sub(WOKE_REPLACE_REGEX, '', keyfile)

--- a/tests/test_sriov.py
+++ b/tests/test_sriov.py
@@ -578,7 +578,7 @@ class TestSRIOV(unittest.TestCase):
         gim.return_value = '00:01:02:03:04:05'
 
         # call method under test
-        with self.assertRaises(libnetplan.LibNetplanException) as e:
+        with self.assertRaises(libnetplan.NetplanValidationException) as e:
             sriov.apply_sriov_config(self.configmanager, rootdir=self.workdir.name)
 
         self.assertIn('vf1.15: missing \'id\' property', str(e.exception))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,7 +104,9 @@ def call_cli(args):
     f = io.StringIO()
     try:
         with redirect_stdout(f):
-            Netplan().main()
+            netplan = Netplan()
+            netplan.parse_args()
+            netplan.run_command()
             return f.getvalue()
     finally:
         sys.argv = old_sys_argv


### PR DESCRIPTION
libnetplan doesn't differentiate each type of error very well. It impacts mainly its frontend where we rely on error message interpretation to tell the user what happened.
As we are planning to offer the Python bindings as a module that will be consumed by others, such as cloud-init, it's important to improve the API error handling.

This RFC incorporates the ideas from #318 and defines specific libnetplan errors and exception for each type with some details.

Originally, this PR was intended to improve error handling to fix issues like the ones mentioned below (which is still addressed).

--------
Old description (still valid):

When netplan get or set fails for some reason, due to bad inputs or file permissions for example, netplan will crash. This handles these situations gracefully.

Examples:

```
$ netplan get
Traceback (most recent call last):
  File "/usr/sbin/netplan", line 23, in <module>
    netplan.main()
  File "/usr/share/netplan/netplan/cli/core.py", line 50, in main
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 241, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/get.py", line 43, in run
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 241, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/get.py", line 61, in command_get
    parser.load_yaml_hierarchy(rootdir=self.root_dir)
  File "/usr/share/netplan/netplan/libnetplan.py", line 122, in load_yaml_hierarchy
    _checked_lib_call(lib.netplan_parser_load_yaml_hierarchy, self._ptr, rootdir.encode('utf-8'))
  File "/usr/share/netplan/netplan/libnetplan.py", line 79, in _checked_lib_call
    raise LibNetplanException(err.contents.message.decode('utf-8'))
netplan.libnetplan.LibNetplanException: Cannot open /etc/netplan/90-test.yaml: Permission denied
```

```
$ netplan set bridges.eth0.dhcp4=false
Traceback (most recent call last):
  File "/usr/sbin/netplan", line 23, in <module>
    netplan.main()
  File "/usr/share/netplan/netplan/cli/core.py", line 50, in main
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 241, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/set.py", line 50, in run
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 241, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/set.py", line 81, in command_set
    parser.load_yaml_hierarchy(self.root_dir)
  File "/usr/share/netplan/netplan/libnetplan.py", line 122, in load_yaml_hierarchy
    _checked_lib_call(lib.netplan_parser_load_yaml_hierarchy, self._ptr, rootdir.encode('utf-8'))
  File "/usr/share/netplan/netplan/libnetplan.py", line 79, in _checked_lib_call
    raise LibNetplanException(err.contents.message.decode('utf-8'))
netplan.libnetplan.LibNetplanException: Cannot open /etc/netplan/90-test.yaml: Permission denied
```

```
$ netplan set --root-dir /tmp/a bridges.eth0.dhcp4=falsea
Traceback (most recent call last):
  File "/usr/sbin/netplan", line 23, in <module>
    netplan.main()
  File "/usr/share/netplan/netplan/cli/core.py", line 50, in main
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 241, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/set.py", line 50, in run
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 241, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/set.py", line 85, in command_set
    parser.load_yaml(tmp)
  File "/usr/share/netplan/netplan/libnetplan.py", line 119, in load_yaml
    _checked_lib_call(lib.netplan_parser_load_yaml_from_fd, self._ptr, input_file.fileno())
  File "/usr/share/netplan/netplan/libnetplan.py", line 79, in _checked_lib_call
    raise LibNetplanException(err.contents.message.decode('utf-8'))
netplan.libnetplan.LibNetplanException: (null):4:14: Error in network definition: invalid boolean value 'falsea'
(null)
             ^
```

```
$ netplan set --root-dir /tmp/a "bridges.eth0={dhcp4: false dhcp6: false}"
Traceback (most recent call last):
  File "/usr/sbin/netplan", line 23, in <module>
    netplan.main()
  File "/usr/share/netplan/netplan/cli/core.py", line 50, in main
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 241, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/set.py", line 50, in run
    self.run_command()
  File "/usr/share/netplan/netplan/cli/utils.py", line 241, in run_command
    self.func()
  File "/usr/share/netplan/netplan/cli/commands/set.py", line 72, in command_set
    libnetplan.create_yaml_patch(yaml_path, value, tmp)
  File "/usr/share/netplan/netplan/libnetplan.py", line 501, in create_yaml_patch
    _checked_lib_call(lib.netplan_util_create_yaml_patch,
  File "/usr/share/netplan/netplan/libnetplan.py", line 79, in _checked_lib_call
    raise LibNetplanException(err.contents.message.decode('utf-8'))
netplan.libnetplan.LibNetplanException: Error parsing YAML: did not find expected ',' or '}'
```

Same examples with this change:

```
$ NETPLAN_GENERATE_PATH=build/src/generate LD_LIBRARY_PATH=build/src/ PYTHONPATH=. ./src/netplan.script get
Command failed: Cannot open /etc/netplan/90-test.yaml: Permission denied
```
```
$ NETPLAN_GENERATE_PATH=build/src/generate LD_LIBRARY_PATH=build/src/ PYTHONPATH=. ./src/netplan.script set bridges.eth0.dhcp4=false
Command failed: Cannot open /etc/netplan/90-test.yaml: Permission denied
```

```
$ NETPLAN_GENERATE_PATH=build/src/generate LD_LIBRARY_PATH=build/src/ PYTHONPATH=. ./src/netplan.script set --root-dir /tmp/a bridges.eth0.dhcp4=falsea
Command failed: invalid boolean value 'falsea'
```

```
$ NETPLAN_GENERATE_PATH=build/src/generate LD_LIBRARY_PATH=build/src/ PYTHONPATH=. ./src/netplan.script set --root-dir /tmp/a "bridges.eth0={dhcp4: false dhcp6: false}"
Command failed: Error parsing YAML: did not find expected ',' or '}'
```

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

