### PR TITLE
Netplan docs rework (Part 2)

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -9,6 +9,10 @@ apply <netplan-apply>
 try <netplan-try>
 get <netplan-get>
 set <netplan-set>
+info <netplan-info>
+ip <netplan-ip>
+rebind <netplan-rebind>
+status <netplan-status>
 ```
 Netplan provides a command line interface, called `netplan`, which a user can
 utilize to control certain aspects of the Netplan configuration.
@@ -23,4 +27,7 @@ utilize to control certain aspects of the Netplan configuration.
 | [try](/netplan-try) | Try to apply a new netplan config to running system, with automatic rollback |
 | [get](/netplan-get) | Get a setting by specifying a nested key like `"ethernets.eth0.addresses"`, or "all" |
 | [set](/netplan-set) | Add new setting by specifying a dotted `key=value` pair like `"ethernets.eth0.dhcp4=true"` |
-| rebind | Rebind SR-IOV virtual functions of given physical functions to their driver |
+| [info](/netplan-info) | Show available features |
+| [ip](/netplan-ip) | Retrieve IP information from the system |
+| [rebind](/netplan-rebind) | Rebind SR-IOV virtual functions of given physical functions to their driver |
+| [status](/netplan-status) | Query networking state of the running system |

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -20,14 +20,12 @@ utilize to control certain aspects of the Netplan configuration.
 | Tool | Description |
 | --- | --- |
 | help | Show a generic help message |
-| info | Show the available feature flags |
-| ip | Query DHCP leases |
 | [generate](/netplan-generate) | Generate backend specific configuration files from `/etc/netplan/*.yaml` |
 | [apply](/netplan-apply) | Apply current netplan config to running system |
 | [try](/netplan-try) | Try to apply a new netplan config to running system, with automatic rollback |
 | [get](/netplan-get) | Get a setting by specifying a nested key like `"ethernets.eth0.addresses"`, or "all" |
 | [set](/netplan-set) | Add new setting by specifying a dotted `key=value` pair like `"ethernets.eth0.dhcp4=true"` |
 | [info](/netplan-info) | Show available features |
-| [ip](/netplan-ip) | Retrieve IP information from the system |
+| [ip](/netplan-ip) | Retrieve IP information (like DHCP leases) from the system |
 | [rebind](/netplan-rebind) | Rebind SR-IOV virtual functions of given physical functions to their driver |
 | [status](/netplan-status) | Query networking state of the running system |

--- a/doc/manpage-footer.md
+++ b/doc/manpage-footer.md
@@ -1,3 +1,3 @@
 # SEE ALSO
 
-  **netplan-generate**(8), **netplan-apply**(8), **netplan-try**(8), **netplan-get**(8), **netplan-set**(8), **netplan-dbus**(8), **systemd-networkd**(8), **NetworkManager**(8)
+  **netplan-generate**(8), **netplan-apply**(8), **netplan-try**(8), **netplan-get**(8), **netplan-set**(8), **netplan-info**(8), **netplan-ip**(8), **netplan-rebind**(8), **netplan-status**(8), **netplan-dbus**(8), **systemd-networkd**(8), **NetworkManager**(8)

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -11,7 +11,10 @@ if pandoc.found()
         command: [pandoc, '-s', '--metadata', 'title="Netplan reference"', '--toc', '-o', '@OUTPUT@', '@INPUT@'],
         install: true,
         install_dir: join_paths(get_option('datadir'), 'doc', 'netplan'))
-    foreach doc : ['netplan-apply', 'netplan-dbus', 'netplan-generate', 'netplan-get', 'netplan-set', 'netplan-try']
+    foreach doc : [
+      'netplan-apply', 'netplan-dbus', 'netplan-generate', 'netplan-get', 'netplan-set',
+      'netplan-try', 'netplan-info', 'netplan-ip', 'netplan-status', 'netplan-rebind',
+      ]
         markdown = files(doc + '.md')
         manpage = doc + '.8'
         custom_target(

--- a/doc/netplan-info.md
+++ b/doc/netplan-info.md
@@ -1,0 +1,38 @@
+---
+title: netplan-info
+section: 8
+author:
+- Danilo Egea Gondolfo (danilo.egea.gondolfo@canonical.com)
+...
+
+## NAME
+
+netplan-info - show available features
+
+## SYNOPSIS
+
+  **netplan** [--debug] **info** -h | --help
+
+  **netplan** [--debug] **info** [--json | --yaml]
+
+## DESCRIPTION
+
+**netplan info** displays the supported features.
+
+## OPTIONS
+
+  -h, --help
+:   Print basic help.
+
+  --debug
+:   Print debugging output during the process.
+
+  --json
+:   Output version and features in JSON format.
+
+  --yaml
+:   Output version and features in YAML format (default).
+
+## SEE ALSO
+
+  **netplan**(5)

--- a/doc/netplan-ip.md
+++ b/doc/netplan-ip.md
@@ -7,7 +7,7 @@ author:
 
 ## NAME
 
-netplan-ip - retrieve IP information from the system
+netplan-ip - retrieve IP information (like DHCP leases) from the system
 
 ## SYNOPSIS
 
@@ -17,11 +17,11 @@ netplan-ip - retrieve IP information from the system
 
 ## DESCRIPTION
 
-**netplan ip** retrieves IP information from the system.
+**netplan ip** retrieves IP information (like DHCP leases) from the system.
 
 ## DHCP COMMANDS
 
-**leases** `INTERFACE`: Displays IP leases
+**leases** `INTERFACE`: Displays DHCP IP leases
 
 Example: netplan ip leases enp5s0
 

--- a/doc/netplan-ip.md
+++ b/doc/netplan-ip.md
@@ -1,0 +1,41 @@
+---
+title: netplan-ip
+section: 8
+author:
+- Danilo Egea Gondolfo (danilo.egea.gondolfo@canonical.com)
+...
+
+## NAME
+
+netplan-ip - retrieve IP information from the system
+
+## SYNOPSIS
+
+  **netplan** [--debug] **ip** -h | --help
+
+  **netplan** [--debug] **ip** COMMAND [--root-dir=ROOT_DIR] ARGUMENTS
+
+## DESCRIPTION
+
+**netplan ip** retrieves IP information from the system.
+
+## DHCP COMMANDS
+
+**leases** `INTERFACE`: Displays IP leases
+
+Example: netplan ip leases enp5s0
+
+## OPTIONS
+
+  -h, --help
+:   Print basic help.
+
+  --debug
+:   Print debugging output during the process.
+
+  --root-dir
+:   Read YAML files from this root instead of /
+
+## SEE ALSO
+
+  **netplan**(5), **netplan-get**(8), **netplan-status**(8)

--- a/doc/netplan-rebind.md
+++ b/doc/netplan-rebind.md
@@ -13,11 +13,11 @@ netplan-rebind - rebind SR-IOV virtual functions to their driver
 
   **netplan** [--debug] **rebind** -h | --help
 
-  **netplan** [--debug] **rebind** [netdevs]
+  **netplan** [--debug] **rebind** [interfaces]
 
 ## DESCRIPTION
 
-**netplan rebind [netdevs]** rebinds SR-IOV virtual functions of given physical functions to their driver.
+**netplan rebind [interfaces]** rebinds SR-IOV virtual functions of given physical functions to their driver.
 
 ## OPTIONS
 
@@ -27,7 +27,7 @@ netplan-rebind - rebind SR-IOV virtual functions to their driver
   --debug
 :   Print debugging output during the process.
 
-  netdevs
+  interfaces
 :   Space separated list of PF interface names.
 
 ## SEE ALSO

--- a/doc/netplan-rebind.md
+++ b/doc/netplan-rebind.md
@@ -1,0 +1,35 @@
+---
+title: netplan-rebind
+section: 8
+author:
+- Danilo Egea Gondolfo (danilo.egea.gondolfo@canonical.com)
+...
+
+## NAME
+
+netplan-rebind - rebind SR-IOV virtual functions to their driver
+
+## SYNOPSIS
+
+  **netplan** [--debug] **rebind** -h | --help
+
+  **netplan** [--debug] **rebind** [netdevs]
+
+## DESCRIPTION
+
+**netplan rebind [netdevs]** rebinds SR-IOV virtual functions of given physical functions to their driver.
+
+## OPTIONS
+
+  -h, --help
+:   Print basic help.
+
+  --debug
+:   Print debugging output during the process.
+
+  netdevs
+:   Space separated list of PF interface names.
+
+## SEE ALSO
+
+  **netplan**(5), **netplan-set**(8), **netplan-apply**(8)

--- a/doc/netplan-status.md
+++ b/doc/netplan-status.md
@@ -1,0 +1,42 @@
+---
+title: netplan-status
+section: 8
+author:
+- Danilo Egea Gondolfo (danilo.egea.gondolfo@canonical.com)
+...
+
+## NAME
+
+netplan-status - query networking state of the running system
+
+## SYNOPSIS
+
+  **netplan** [--debug] **status** -h | --help
+
+  **netplan** [--debug] **status** [interface]
+
+## DESCRIPTION
+
+**netplan status [interface]** queries the current network configuration and displays it in human readable format.
+
+You can specify ``interface`` to display the status of a specific interface.
+
+Currently, **netplan status** depends on `systemd-networkd` as a source of data and will try to start it if it's not masked.
+
+## OPTIONS
+
+  -h, --help
+:   Print basic help.
+
+  --debug
+:   Print debugging output during the process.
+
+  -a, --all
+:   Show all interface data including inactive
+
+  -f FORMAT, --format FORMAT
+:   Output in machine readable `json` or `yaml` format
+
+## SEE ALSO
+
+  **netplan**(5), **netplan-get**(8), **netplan-ip**(8)

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -895,7 +895,11 @@ interfaces, as well as individual wifi networks, by means of the `auth` block.
 
 **Purpose**: Use the `ethernets` key to configure Ethernet interfaces.
 
-**Structure**: The key consists of a mapping of interface names. Each `ethernet` has a number of configuration options. You don't need to define each interface by their names inside the `ethernets` mapping. You can use any name that describes the interface and match the actual network card using the `match` key. The general configuration structure for ethernets is shown below.
+**Structure**: The key consists of a mapping of Ethernet interface IDs. Each
+`ethernet` has a number of configuration options. You don't need to define each
+interface by their name inside the `ethernets` mapping. You can use any ID that
+describes the interface and match the actual network card using the `match` key.
+The general configuration structure for Ethernets is shown below.
 
 
 ```yaml
@@ -989,9 +993,13 @@ some additional properties that can be used for SR-IOV devices.
 
 **Status**: Optional.
 
-**Purpose**: Use the `modems` key to configure Modems. GSM/CDMA modem configuration is only supported for the `NetworkManager` backend. `systemd-networkd` does not support modems.
+**Purpose**: Use the `modems` key to configure Modem interfaces. GSM/CDMA modem
+configuration is only supported for the `NetworkManager` backend.
+`systemd-networkd` does not support modems.
 
-**Structure**: The key consists of a mapping of modem names. Each `modem` has a number of configuration options. The general configuration structure for modems is shown below.
+**Structure**: The key consists of a mapping of Modem IDs. Each `modem` has a
+number of configuration options. The general configuration structure for Modems
+is shown below.
 
 ```yaml
 network:
@@ -1069,10 +1077,17 @@ network:
 
 ## Properties for device type `wifis:`
 
-The general YAML structure for Wifi devices is shown below.
+**Status**: Optional.
+
+**Purpose**: Use the `wifis` key to configure WiFi access points.
+
+**Structure**: The key consists of a mapping of WiFi IDs. Each `wifi` has a
+number of configuration options. The general configuration structure for WiFis
+is shown below.
 
 ```yaml
 network:
+  version: 2
   wifis:
     wlp0s1:
       access-points:
@@ -1161,7 +1176,11 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
 
 **Purpose**: Use the `bridges` key to create Bridge interfaces.
 
-**Structure**: The key consists of a mapping of interface names. Each `bridge` has an optional list of interfaces that will be bridged together. The interfaces listed in the `interfaces` key (`enp5s0` and `enp5s1` below) must also be defined in your Netplan configuration. The general configuration structure for bridges is shown below.
+**Structure**: The key consists of a mapping of Bridge interface names. Each
+`bridge` has an optional list of interfaces that will be bridged together. The
+interfaces listed in the `interfaces` key (`enp5s0` and `enp5s1` below) must
+also be defined in your Netplan configuration. The general configuration
+structure for Bridges is shown below.
 
 ```yaml
 network:
@@ -1268,7 +1287,11 @@ The specific settings for bridges are defined below.
 
 **Purpose**: Use the `bonds` key to create Bond (Link Aggregation) interfaces.
 
-**Structure**: The key consists of a mapping of interface names. Each `bond` has an optional list of interfaces that will be part of the aggregation. The interfaces listed in the `interfaces` key must also be defined in your Netplan configuration. The general configuration structure for bonds is shown below.
+**Structure**: The key consists of a mapping of Bond interface names. Each
+`bond` has an optional list of interfaces that will be part of the aggregation.
+The interfaces listed in the `interfaces` key must also be defined in your
+Netplan configuration. The general configuration structure for Bonds is shown
+below.
 
 ```yaml
 network:
@@ -1475,9 +1498,12 @@ The specific settings for bonds are defined below.
 
 **Status**: Optional.
 
-**Purpose**: Use the `tunnels` key to create different virtual tunnel interfaces.
+**Purpose**: Use the `tunnels` key to create virtual tunnel interfaces.
 
-**Structure**: The key consists of a mapping of tunnel names. Each `tunnel` requires the identification of the tunnel mode (see the section `mode` below for the list of supported modes). The general configuration structure for bridges is shown below.
+**Structure**: The key consists of a mapping of tunnel interface names. Each
+`tunnel` requires the identification of the tunnel mode (see the section `mode`
+below for the list of supported modes). The general configuration structure for
+Tunnels is shown below.
 
 ```yaml
 network:
@@ -1766,7 +1792,10 @@ VXLAN specific keys:
 
 **Purpose**: Use the `vlans` key to create VLAN interfaces.
 
-**Structure**: The key consists of a mapping of VLAN names. The interface used in the `link` option (`enp5s0` in the example below) must also be defined in the Netplan configuration. The general configuration structure for bridges is shown below.
+**Structure**: The key consists of a mapping of VLAN interface names. The
+interface used in the `link` option (`enp5s0` in the example below) must also be
+defined in the Netplan configuration. The general configuration structure for
+Vlans is shown below.
 
 ```yaml
 network:
@@ -1809,9 +1838,13 @@ network:
 
 **Status**: Optional.
 
-**Purpose**: Use the `vrfs` key to create Virtual Routing and Forwarding (VRF) interfaces.
+**Purpose**: Use the `vrfs` key to create Virtual Routing and Forwarding (VRF)
+interfaces.
 
-**Structure**: The key consists of a mapping of VRF interface names. The interface used in the `link` option (`enp5s0` in the example below) must also be defined in the Netplan configuration. The general configuration structure for VRFs is shown below.
+**Structure**: The key consists of a mapping of VRF interface names. The
+interface used in the `link` option (`enp5s0` in the example below) must also be
+defined in the Netplan configuration. The general configuration structure for
+VRFs is shown below.
 
 ```yaml
 network:
@@ -1871,11 +1904,14 @@ network:
 
 **Status**: Optional. Its use is not recommended.
 
-**Purpose**: Use the `nm-devices` key to configure device types that are not supported by Netplan. This is Network Manager (NM) specific configuration.
+**Purpose**: Use the `nm-devices` key to configure device types that are not
+supported by Netplan. This is NetworkManager specific configuration.
 
-**Structure**: The key consists of a mapping of NM connection names. The `nm-devices` device type is for internal use only and should not be used in
+**Structure**: The key consists of a mapping of NetworkManager connections. The
+`nm-devices` device type is for internal use only and should not be used in
 normal configuration files. It enables a fallback mode for unsupported settings,
-using the `passthrough` mapping. The general configuration structure for NM connections is shown below.
+using the `passthrough` mapping. The general configuration structure for NM
+connections is shown below.
 
 ```yaml
 network:

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -29,39 +29,39 @@ network:
 
   > Defines what network configuration tool will be used to set up your configuration. Valid values are `networkd` and `NetworkManager`. Defaults to `networkd` if not defined.
 
-- **bonds** (mapping)
+- [**bonds**](#properties-for-device-type-bonds) (mapping)
 
   > Creates and configures link aggregation (bonding) devices.
 
-- **bridges** (mapping)
+- [**bridges**](#properties-for-device-type-bridges) (mapping)
 
   > Creates and configures bridge devices.
 
-- **ethernets** (mapping)
+- [**ethernets**](#properties-for-device-type-ethernets) (mapping)
 
   > Configures physical Ethernet interfaces.
 
-- **modems** (mapping)
+- [**modems**](#properties-for-device-type-modems) (mapping)
 
   > Configures modems
 
-- **tunnels** (mapping)
+- [**tunnels**](#properties-for-device-type-tunnels) (mapping)
 
   > Creates and configures different types of virtual tunnels.
 
-- **vlans** (mapping)
+- [**vlans**](#properties-for-device-type-vlans) (mapping)
 
   > Creates and configures VLANs.
 
-- **vrfs** (mapping)
+- [**vrfs**](#properties-for-device-type-vrfs) (mapping)
 
-  > Configures Virtual Functions for SR-IOV devices.
+  > Configures Virtual Routing and Forwarding (VRF) devices.
 
-- **wifis** (mapping)
+- [**wifis**](#properties-for-device-type-wifis) (mapping)
 
   > Configures physical Wifi interfaces as client, adhoc or access point.
 
-- **nm-devices** (mapping)
+- [**nm-devices**](#properties-for-device-type-nm-devices) (mapping)
 
   > `nm-devices` are used in situations where Netplan doesn't support the connection type. The raw configuration expected by NetworkManager can be defined and will be passed as is (passthrough) to the `.nmconnection` file. Users will not normally use this type of device.
 
@@ -891,7 +891,12 @@ interfaces, as well as individual wifi networks, by means of the `auth` block.
 
 ## Properties for device type `ethernets:`
 
-The general structure for Ethernet devices is shown below.
+**Status**: Optional.
+
+**Purpose**: Use the `ethernets` key to configure Ethernet interfaces.
+
+**Structure**: The key consists of a mapping of interface names. Each `ethernet` has a number of configuration options. You don't need to define each interface by their names inside the `ethernets` mapping. You can use any name that describes the interface and match the actual network card using the `match` key. The general configuration structure for ethernets is shown below.
+
 
 ```yaml
 network:
@@ -981,8 +986,30 @@ some additional properties that can be used for SR-IOV devices.
   > **Requires feature: infiniband**
 
 ## Properties for device type `modems:`
-GSM/CDMA modem configuration is only supported for the `NetworkManager`
-backend. `systemd-networkd` does not support modems.
+
+**Status**: Optional.
+
+**Purpose**: Use the `modems` key to configure Modems. GSM/CDMA modem configuration is only supported for the `NetworkManager` backend. `systemd-networkd` does not support modems.
+
+**Structure**: The key consists of a mapping of modem names. Each `modem` has a number of configuration options. The general configuration structure for modems is shown below.
+
+```yaml
+network:
+  version: 2
+  renderer: NetworkManager
+  modems:
+    cdc-wdm1:
+      mtu: 1600
+      apn: ISP.CINGULAR
+      username: ISP@CINGULARGPRS.COM
+      password: CINGULAR1
+      number: "*99#"
+      network-id: 24005
+      device-id: da812de91eec16620b06cd0ca5cbc7ea25245222
+      pin: 2345
+      sim-id: 89148000000060671234
+      sim-operator-id: 310260
+```
 
 **Requires feature: modems**
 
@@ -1130,12 +1157,20 @@ wpasupplicant installed if you let the `networkd` renderer handle wifi.
 
 ## Properties for device type `bridges:`
 
-The general structure for bridges is shown below.
+**Status**: Optional.
+
+**Purpose**: Use the `bridges` key to create Bridge interfaces.
+
+**Structure**: The key consists of a mapping of interface names. Each `bridge` has an optional list of interfaces that will be bridged together. The interfaces listed in the `interfaces` key (`enp5s0` and `enp5s1` below) must also be defined in your Netplan configuration. The general configuration structure for bridges is shown below.
 
 ```yaml
 network:
   bridges:
     br0:
+      interfaces:
+        - enp5s0
+        - enp5s1
+      dhcp4: true
       ...
 ```
 
@@ -1229,12 +1264,21 @@ The specific settings for bridges are defined below.
 
 ## Properties for device type `bonds:`
 
-The general configuration structure for bonds is shown below.
+**Status**: Optional.
+
+**Purpose**: Use the `bonds` key to create Bond (Link Aggregation) interfaces.
+
+**Structure**: The key consists of a mapping of interface names. Each `bond` has an optional list of interfaces that will be part of the aggregation. The interfaces listed in the `interfaces` key must also be defined in your Netplan configuration. The general configuration structure for bonds is shown below.
 
 ```yaml
 network:
   bonds:
     bond0:
+      interfaces:
+        - enp5s0
+        - enp5s1
+        - enp5s2
+      mode: active-backup
       ...
 ```
 
@@ -1429,7 +1473,11 @@ The specific settings for bonds are defined below.
 
 ## Properties for device type `tunnels:`
 
-The general configuration structure for tunnels is shown below.
+**Status**: Optional.
+
+**Purpose**: Use the `tunnels` key to create different virtual tunnel interfaces.
+
+**Structure**: The key consists of a mapping of tunnel names. Each `tunnel` requires the identification of the tunnel mode (see the section `mode` below for the list of supported modes). The general configuration structure for bridges is shown below.
 
 ```yaml
 network:
@@ -1714,6 +1762,23 @@ VXLAN specific keys:
 
 ## Properties for device type `vlans:`
 
+**Status**: Optional.
+
+**Purpose**: Use the `vlans` key to create VLAN interfaces.
+
+**Structure**: The key consists of a mapping of VLAN names. The interface used in the `link` option (`enp5s0` in the example below) must also be defined in the Netplan configuration. The general configuration structure for bridges is shown below.
+
+```yaml
+network:
+  vlans:
+    vlan123:
+      id: 123
+      link: enp5s0
+      dhcp4: yes
+```
+
+The specific settings for VLANs are defined below.
+
 - **id** (scalar)
 
   > VLAN ID, a number between `0` and `4094`.
@@ -1742,14 +1807,35 @@ network:
 
 ## Properties for device type `vrfs:`
 
+**Status**: Optional.
+
+**Purpose**: Use the `vrfs` key to create Virtual Routing and Forwarding (VRF) interfaces.
+
+**Structure**: The key consists of a mapping of VRF interface names. The interface used in the `link` option (`enp5s0` in the example below) must also be defined in the Netplan configuration. The general configuration structure for VRFs is shown below.
+
+```yaml
+network:
+  renderer: networkd
+  vrfs:
+    vrf1:
+      table: 1
+      interfaces:
+        - enp5s0
+      routes:
+        - to: default
+          via: 10.10.10.4
+      routing-policy:
+        - from: 10.10.10.42
+```
+
 - **table** (scalar) – since **0.105**
 
   > The numeric routing table identifier. This setting is compulsory.
 
 - **interfaces** (sequence of scalars) – since **0.105**
 
-  > All devices matching this ID list will be added to the vrf. This may
-  > be an empty list, in which case the vrf will be brought online with
+  > All devices matching this ID list will be added to the VRF. This may
+  > be an empty list, in which case the VRF will be brought online with
   > no member interfaces.
 
 - **routes** (sequence of mappings) – since **0.105**
@@ -1783,10 +1869,34 @@ network:
 
 ## Properties for device type `nm-devices:`
 
-The `nm-devices` device type is for internal use only and should not be used in
-normal configuration files. It enables a fallback mode for unsupported settings,
-using the `passthrough` mapping.
+**Status**: Optional. Its use is not recommended.
 
+**Purpose**: Use the `nm-devices` key to configure device types that are not supported by Netplan. This is Network Manager (NM) specific configuration.
+
+**Structure**: The key consists of a mapping of NM connection names. The `nm-devices` device type is for internal use only and should not be used in
+normal configuration files. It enables a fallback mode for unsupported settings,
+using the `passthrough` mapping. The general configuration structure for NM connections is shown below.
+
+```yaml
+network:
+  version: 2
+  nm-devices:
+    NM-db5f0f67-1f4c-4d59-8ab8-3d278389cf87:
+      renderer: NetworkManager
+      networkmanager:
+        uuid: "db5f0f67-1f4c-4d59-8ab8-3d278389cf87"
+        name: "myvpnconnection"
+        passthrough:
+          connection.type: "vpn"
+          vpn.ca: "path to ca.crt"
+          vpn.cert: "path to client.crt"
+          vpn.cipher: "AES-256-GCM"
+          vpn.connection-type: "tls"
+          vpn.dev: "tun"
+          vpn.key: "path to client.key"
+          vpn.remote: "1.2.3.4:1194"
+          vpn.service-type: "org.freedesktop.NetworkManager.openvpn"
+```
 
 ## Backend-specific configuration parameters
 


### PR DESCRIPTION
## Description

Adding man pages for all the commands.

Improving the network types descriptions a little.

Follow-up for #333 

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

