### PR TITLE
Some refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ clean:
 	rm -f netplan-dbus dbus/*.service
 	rm -f *.gcda *.gcno generate.info
 	rm -f tests/ctests/*.gcda tests/ctests/*.gcno
-	rm -rf test-coverage .coverage coverage.xml
+	rm -rf test-coverage .coverage
+	rm -f .coverage.* coverage.xml
 	find . | grep -E "(__pycache__|\.pyc)" | xargs rm -rf
 	rm -rf build
 	rm -rf _build

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -299,7 +299,7 @@ class NetplanApply(utils.NetplanCommand):
                 # wait a bit for 'connected (site/local-only)' or
                 # 'connected' to appear in 'nmcli general' STATE
                 for _ in range(10):
-                    out = subprocess.run(cmd, capture_output=True, universal_newlines=True)
+                    out = subprocess.run(cmd, capture_output=True, text=True)
                     # Handle nmcli's "not running" return code (8) gracefully,
                     # giving some more time for NetworkManager startup
                     if out.returncode == 8:

--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -290,7 +290,7 @@ class NetplanApply(utils.NetplanCommand):
                 utils.ip_addr_flush(iface)
             # clear NM state, especially the [device].managed=true config, as that might have been
             # re-set via an udev rule setting "NM_UNMANAGED=1"
-            subprocess.check_call(['rm', '-rf', '/run/NetworkManager/devices'])
+            shutil.rmtree('/run/NetworkManager/devices', ignore_errors=True)
             utils.systemctl_network_manager('start', sync=sync)
             if sync:
                 # 'nmcli' could be /usr/bin/nmcli or

--- a/netplan/cli/commands/ip.py
+++ b/netplan/cli/commands/ip.py
@@ -140,7 +140,7 @@ class NetplanIpLeases(utils.NetplanCommand):
         # Extract out of the generator our mapping in a dict.
         logging.debug('command ip leases: running %s', argv)
         try:
-            out = subprocess.check_output(argv, universal_newlines=True)
+            out = subprocess.check_output(argv, text=True)
         except CalledProcessError:  # pragma: nocover (better be covered in autopkgtest)
             print("No lease found for interface '%s' (not managed by Netplan)" % self.interface, file=sys.stderr)
             sys.exit(1)

--- a/netplan/cli/commands/status.py
+++ b/netplan/cli/commands/status.py
@@ -157,7 +157,7 @@ class Interface():
         output: str = None
         try:
             output = subprocess.check_output(['networkctl', 'status', ifname],
-                                             universal_newlines=True)
+                                             text=True)
         except Exception as e:
             logging.warning('Cannot query networkctl for {}: {}'.format(
                 ifname, str(e)))
@@ -358,7 +358,7 @@ class NetplanStatus(utils.NetplanCommand):
         data: JSON = None
         try:
             output: str = subprocess.check_output(['ip', '-d', '-j', 'addr'],
-                                                  universal_newlines=True)
+                                                  text=True)
             data = self.process_generic(output)
         except Exception as e:
             logging.critical('Cannot query iproute2 interface data: {}'.format(str(e)))
@@ -371,7 +371,7 @@ class NetplanStatus(utils.NetplanCommand):
         data: JSON = None
         try:
             output: str = subprocess.check_output(['networkctl', '--json=short'],
-                                                  universal_newlines=True)
+                                                  text=True)
             data = self.process_networkd(output)
         except Exception as e:
             logging.critical('Cannot query networkd interface data: {}'.format(str(e)))
@@ -409,10 +409,10 @@ class NetplanStatus(utils.NetplanCommand):
         data6 = None
         try:
             output4: str = subprocess.check_output(['ip', '-d', '-j', 'route'],
-                                                   universal_newlines=True)
+                                                   text=True)
             data4: JSON = self.process_generic(output4)
             output6: str = subprocess.check_output(['ip', '-d', '-j', '-6', 'route'],
-                                                   universal_newlines=True)
+                                                   text=True)
             data6: JSON = self.process_generic(output6)
         except Exception as e:
             logging.debug('Cannot query iproute2 route data: {}'.format(str(e)))

--- a/netplan/cli/commands/status.py
+++ b/netplan/cli/commands/status.py
@@ -156,8 +156,7 @@ class Interface():
     def query_networkctl(self, ifname: str) -> str:
         output: str = None
         try:
-            output = subprocess.check_output(['networkctl', 'status', ifname],
-                                             text=True)
+            output = subprocess.check_output(['networkctl', 'status', '--', ifname], text=True)
         except Exception as e:
             logging.warning('Cannot query networkctl for {}: {}'.format(
                 ifname, str(e)))

--- a/netplan/cli/ovs.py
+++ b/netplan/cli/ovs.py
@@ -88,7 +88,7 @@ def _del_global(type, iface, key, value):
         # * get-controller: netplan/global/set-controller=tcp:127.0.0.1:1337,unix:/some/socket
         # tcp:127.0.0.1:1337
         # unix:/some/socket
-        out = subprocess.check_output(args_get, universal_newlines=True)
+        out = subprocess.check_output(args_get, text=True)
         # Clean it only if the exact same value(s) were set by netplan.
         # Don't touch it if other values were set by another integration.
         if all(item in out for item in value.split(',')):
@@ -142,7 +142,7 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
         for t in (('Port', 'del-port'), ('Bridge', 'del-br'), ('Interface', 'del-br')):
             out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=name,external-ids',
                                            '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t[0]],
-                                          universal_newlines=True)
+                                          text=True)
             for line in out.splitlines():
                 if 'netplan=true' in line:
                     iface = line.split(',')[0]
@@ -163,7 +163,7 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
                 cols = '_uuid,external-ids'  # handle _uuid as if it would be the iface 'name'
             out = subprocess.check_output([OPENVSWITCH_OVS_VSCTL, '--columns=%s' % cols,
                                            '-f', 'csv', '-d', 'bare', '--no-headings', 'list', t],
-                                          universal_newlines=True)
+                                          text=True)
             for line in out.splitlines():
                 if 'netplan/' in line:
                     iface = '.'

--- a/netplan/cli/utils.py
+++ b/netplan/cli/utils.py
@@ -52,7 +52,7 @@ def nmcli(args):  # pragma: nocover (covered in autopkgtest)
 def nmcli_out(args: list) -> str:  # pragma: nocover (covered in autopkgtest)
     # 'nmcli' could be /usr/bin/nmcli or /snap/bin/nmcli -> /snap/bin/network-manager.nmcli
     # PATH is defined in cli/core.py
-    return subprocess.check_output(['nmcli'] + args, universal_newlines=True)
+    return subprocess.check_output(['nmcli'] + args, text=True)
 
 
 def nm_running():  # pragma: nocover (covered in autopkgtest)
@@ -101,7 +101,7 @@ def systemctl(action: str, services: list, sync: bool = False):
 
 def networkd_interfaces():
     interfaces = set()
-    out = subprocess.check_output(['networkctl', '--no-pager', '--no-legend'], universal_newlines=True)
+    out = subprocess.check_output(['networkctl', '--no-pager', '--no-legend'], text=True)
     for line in out.splitlines():
         s = line.strip().split(' ')
         if s[0].isnumeric() and s[-1] not in ['unmanaged', 'linger']:
@@ -129,7 +129,7 @@ def systemctl_is_masked(unit_pattern):
     '''Return True if output is "masked" or "masked-runtime"'''
     res = subprocess.run(['systemctl', 'is-enabled', unit_pattern],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                         universal_newlines=True)
+                         text=True)
     if res.returncode > 0 and 'masked' in res.stdout:
         return True
     return False

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -75,7 +75,7 @@ class TestStatus(unittest.TestCase):
         mock.return_value = IPROUTE2
         status = NetplanStatus()
         res = status.query_iproute2()
-        mock.assert_called_with(['ip', '-d', '-j', 'addr'], universal_newlines=True)
+        mock.assert_called_with(['ip', '-d', '-j', 'addr'], text=True)
         self.assertEqual(len(res), 6)
         self.assertListEqual([itf.get('ifname') for itf in res],
                              ['lo', 'enp0s31f6', 'wlan0', 'wg0', 'wwan0', 'tun0'])
@@ -86,7 +86,7 @@ class TestStatus(unittest.TestCase):
         status = NetplanStatus()
         with self.assertLogs() as cm:
             res = status.query_iproute2()
-            mock.assert_called_with(['ip', '-d', '-j', 'addr'], universal_newlines=True)
+            mock.assert_called_with(['ip', '-d', '-j', 'addr'], text=True)
             self.assertIsNone(res)
             self.assertIn('CRITICAL:root:Cannot query iproute2 interface data:', cm.output[0])
 
@@ -95,7 +95,7 @@ class TestStatus(unittest.TestCase):
         mock.return_value = NETWORKD
         status = NetplanStatus()
         res = status.query_networkd()
-        mock.assert_called_with(['networkctl', '--json=short'], universal_newlines=True)
+        mock.assert_called_with(['networkctl', '--json=short'], text=True)
         self.assertEqual(len(res), 6)
         self.assertListEqual([itf.get('Name') for itf in res],
                              ['lo', 'enp0s31f6', 'wlan0', 'wg0', 'wwan0', 'tun0'])
@@ -106,7 +106,7 @@ class TestStatus(unittest.TestCase):
         status = NetplanStatus()
         with self.assertLogs() as cm:
             res = status.query_networkd()
-            mock.assert_called_with(['networkctl', '--json=short'], universal_newlines=True)
+            mock.assert_called_with(['networkctl', '--json=short'], text=True)
             self.assertIsNone(res)
             self.assertIn('CRITICAL:root:Cannot query networkd interface data:', cm.output[0])
 
@@ -117,7 +117,7 @@ class TestStatus(unittest.TestCase):
         res = status.query_nm()
         mock.assert_called_with(['nmcli', '-t', '-f',
                                  'DEVICE,NAME,UUID,FILENAME,TYPE,AUTOCONNECT',
-                                 'con', 'show'], universal_newlines=True)
+                                 'con', 'show'], text=True)
         self.assertEqual(len(res), 1)
         self.assertListEqual([itf.get('device') for itf in res], ['wlan0'])
 
@@ -129,7 +129,7 @@ class TestStatus(unittest.TestCase):
             res = status.query_nm()
             mock.assert_called_with(['nmcli', '-t', '-f',
                                      'DEVICE,NAME,UUID,FILENAME,TYPE,AUTOCONNECT',
-                                     'con', 'show'], universal_newlines=True)
+                                     'con', 'show'], text=True)
             self.assertIsNone(res)
             self.assertIn('DEBUG:root:Cannot query NetworkManager interface data:', cm.output[0])
 
@@ -139,8 +139,8 @@ class TestStatus(unittest.TestCase):
         status = NetplanStatus()
         res4, res6 = status.query_routes()
         mock.assert_has_calls([
-            call(['ip', '-d', '-j', 'route'], universal_newlines=True),
-            call(['ip', '-d', '-j', '-6', 'route'], universal_newlines=True),
+            call(['ip', '-d', '-j', 'route'], text=True),
+            call(['ip', '-d', '-j', '-6', 'route'], text=True),
             ])
         self.assertEqual(len(res4), 6)
         self.assertListEqual([route.get('dev') for route in res4],
@@ -156,7 +156,7 @@ class TestStatus(unittest.TestCase):
         status = NetplanStatus()
         with self.assertLogs(level='DEBUG') as cm:
             res4, res6 = status.query_routes()
-            mock.assert_called_with(['ip', '-d', '-j', 'route'], universal_newlines=True)
+            mock.assert_called_with(['ip', '-d', '-j', 'route'], text=True)
             self.assertIsNone(res4)
             self.assertIsNone(res6)
             self.assertIn('DEBUG:root:Cannot query iproute2 route data:', cm.output[0])
@@ -528,7 +528,7 @@ class TestInterface(unittest.TestCase):
         res = itf.query_nm_ssid(con)
         mock.assert_called_with(['nmcli', '--get-values', '802-11-wireless.ssid',
                                  'con', 'show', 'id', con],
-                                universal_newlines=True)
+                                text=True)
         self.assertEqual(res, 'MYSSID')
 
     @patch('subprocess.check_output')
@@ -540,7 +540,7 @@ class TestInterface(unittest.TestCase):
             res = itf.query_nm_ssid(con)
             mock.assert_called_with(['nmcli', '--get-values', '802-11-wireless.ssid',
                                      'con', 'show', 'id', con],
-                                    universal_newlines=True)
+                                    text=True)
             self.assertIsNone(res)
             self.assertIn('WARNING:root:Cannot query NetworkManager SSID for {}:'.format(con), cm.output[0])
 
@@ -550,7 +550,7 @@ class TestInterface(unittest.TestCase):
         dev = 'fakedev0'
         itf = Interface(FAKE_DEV, [])
         res = itf.query_networkctl(dev)
-        mock.assert_called_with(['networkctl', 'status', dev], universal_newlines=True)
+        mock.assert_called_with(['networkctl', 'status', dev], text=True)
         self.assertEqual(res, mock.return_value)
 
     @patch('subprocess.check_output')
@@ -560,7 +560,7 @@ class TestInterface(unittest.TestCase):
         itf = Interface(FAKE_DEV, [])
         with self.assertLogs() as cm:
             res = itf.query_networkctl(dev)
-            mock.assert_called_with(['networkctl', 'status', dev], universal_newlines=True)
+            mock.assert_called_with(['networkctl', 'status', dev], text=True)
             self.assertIsNone(res)
             self.assertIn('WARNING:root:Cannot query networkctl for {}:'.format(dev), cm.output[0])
 

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -550,7 +550,7 @@ class TestInterface(unittest.TestCase):
         dev = 'fakedev0'
         itf = Interface(FAKE_DEV, [])
         res = itf.query_networkctl(dev)
-        mock.assert_called_with(['networkctl', 'status', dev], text=True)
+        mock.assert_called_with(['networkctl', 'status', '--', dev], text=True)
         self.assertEqual(res, mock.return_value)
 
     @patch('subprocess.check_output')
@@ -560,7 +560,7 @@ class TestInterface(unittest.TestCase):
         itf = Interface(FAKE_DEV, [])
         with self.assertLogs() as cm:
             res = itf.query_networkctl(dev)
-            mock.assert_called_with(['networkctl', 'status', dev], text=True)
+            mock.assert_called_with(['networkctl', 'status', '--', dev], text=True)
             self.assertIsNone(res)
             self.assertIn('WARNING:root:Cannot query networkctl for {}:'.format(dev), cm.output[0])
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -341,7 +341,7 @@ class TestBase(unittest.TestCase):
             subprocess.call(['bash', '-i'], cwd=self.workdir.name)
 
         p = subprocess.Popen(argv, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE, universal_newlines=True)
+                             stderr=subprocess.PIPE, text=True)
         (out, err) = p.communicate()
         if expect_fail:
             self.assertGreater(p.returncode, 0)

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -89,7 +89,7 @@ class TestConfigArgs(TestBase):
 
         p = subprocess.Popen([exe_generate, '--root-dir', self.workdir.name, '--help'],
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                             universal_newlines=True)
+                             text=True)
         (out, err) = p.communicate()
         self.assertEqual(err, '')
         self.assertEqual(p.returncode, 0)
@@ -99,7 +99,7 @@ class TestConfigArgs(TestBase):
     def test_unknown_cli_args(self):
         p = subprocess.Popen([exe_generate, '--foo'],
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                             universal_newlines=True)
+                             text=True)
         (out, err) = p.communicate()
         self.assertIn('nknown option --foo', err)
         self.assertNotEqual(p.returncode, 0)

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -134,10 +134,10 @@ class IntegrationTestsBase(unittest.TestCase):
         # the correct MAC address
         time.sleep(0.1)
         out = subprocess.check_output(['ip', '-br', 'link', 'show', 'dev', 'eth42'],
-                                      universal_newlines=True)
+                                      text=True)
         klass.dev_e_client_mac = out.split()[2]
         out = subprocess.check_output(['ip', '-br', 'link', 'show', 'dev', 'eth43'],
-                                      universal_newlines=True)
+                                      text=True)
         klass.dev_e2_client_mac = out.split()[2]
 
         # don't let NM trample over our test routers
@@ -273,7 +273,7 @@ class IntegrationTestsBase(unittest.TestCase):
         '''Assert that client interface has been created'''
 
         out = subprocess.check_output(['ip', '-d', 'a', 'show', 'dev', iface],
-                                      universal_newlines=True)
+                                      text=True)
         if expected_ip_a:
             for r in expected_ip_a:
                 self.assertRegex(out, r, out)
@@ -315,7 +315,7 @@ class IntegrationTestsBase(unittest.TestCase):
             cmd = cmd + ['--state', state_dir]
         out = ''
         try:
-            out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, universal_newlines=True)
+            out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
         except subprocess.CalledProcessError as e:
             self.assertTrue(False, 'netplan apply failed: {}'.format(e.output))
 
@@ -325,9 +325,9 @@ class IntegrationTestsBase(unittest.TestCase):
         subprocess.check_call(['systemctl', 'start', 'NetworkManager.service'])
 
         # Debugging output
-        # out = subprocess.check_output(['NetworkManager', '--print-config'], universal_newlines=True)
+        # out = subprocess.check_output(['NetworkManager', '--print-config'], text=True)
         # print(out, flush=True)
-        # out = subprocess.check_output(['nmcli', 'dev'], universal_newlines=True)
+        # out = subprocess.check_output(['nmcli', 'dev'], text=True)
         # print(out, flush=True)
 
         # Wait for interfaces to be ready:
@@ -381,7 +381,7 @@ class IntegrationTestsBase(unittest.TestCase):
     def wait_output(self, cmd, expected_output, timeout=10):
         for _ in range(timeout):
             try:
-                out = subprocess.check_output(cmd, universal_newlines=True)
+                out = subprocess.check_output(cmd, text=True)
             except subprocess.CalledProcessError:
                 out = ''
             if expected_output in out:
@@ -427,7 +427,7 @@ class IntegrationTestsWifi(IntegrationTestsBase):
         try:
             subprocess.check_call(['modprobe', 'cfg80211'])
             # set regulatory domain "EU", so that we can use 80211.a 5 GHz channels
-            out = subprocess.check_output(['iw', 'reg', 'get'], universal_newlines=True)
+            out = subprocess.check_output(['iw', 'reg', 'get'], text=True)
             m = re.match(r'^(?:global\n)?country (\S+):', out)
             assert m
             klass.orig_country = m.group(1)
@@ -512,6 +512,6 @@ class IntegrationTestsWifi(IntegrationTestsBase):
         super().assert_iface_up(iface, expected_ip_a, unexpected_ip_a)
         if iface == self.dev_w_client:
             out = subprocess.check_output(['iw', 'dev', iface, 'link'],
-                                          universal_newlines=True)
+                                          text=True)
             # self.assertIn('Connected to ' + self.mac_w_ap, out)
             self.assertIn('SSID: fake net', out)

--- a/tests/integration/bridges.py
+++ b/tests/integration/bridges.py
@@ -52,13 +52,13 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
 
         # ensure that they do not get managed by NM for foreign backends
         expected_state = (self.backend == 'NetworkManager') and 'connected' or 'unmanaged'
-        out = subprocess.check_output(['nmcli', 'dev'], universal_newlines=True)
+        out = subprocess.check_output(['nmcli', 'dev'], text=True)
         for i in [self.dev_e_client, self.dev_e2_client, 'mybr']:
             self.assertRegex(out, r'%s\s+(ethernet|bridge)\s+%s' % (i, expected_state))
 
@@ -83,7 +83,7 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/brif/%s/path_cost' % self.dev_e2_client) as f:
@@ -109,7 +109,7 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/bridge/ageing_time') as f:
@@ -135,7 +135,7 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/bridge/max_age') as f:
@@ -161,7 +161,7 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/bridge/hello_time') as f:
@@ -187,7 +187,7 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/bridge/forward_delay') as f:
@@ -214,7 +214,7 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/bridge/stp_state') as f:
@@ -241,7 +241,7 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/brif/%s/priority' % self.dev_e2_client) as f:
@@ -292,7 +292,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', [], ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
 
@@ -339,7 +339,7 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
         self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
         self.assert_iface_up('mybr', ['inet 192.168.6.[0-9]+/24'])
         lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
-                                        universal_newlines=True).splitlines()
+                                        text=True).splitlines()
         self.assertEqual(len(lines), 1, lines)
         self.assertIn(self.dev_e2_client, lines[0])
         with open('/sys/class/net/mybr/bridge/priority') as f:

--- a/tests/integration/dbus.py
+++ b/tests/integration/dbus.py
@@ -74,7 +74,7 @@ class _CommonTests():
         # be sure the process is not from a binary from an old package
         # (before the installation of the one being tested)
         cmd = ['ps', '-C', 'netplan-dbus', '-o', 'pid=']
-        out = subprocess.run(cmd, capture_output=True, universal_newlines=True)
+        out = subprocess.run(cmd, capture_output=True, text=True)
         if out.returncode == 0:
             pid = out.stdout.strip()
             os.kill(int(pid), signal.SIGTERM)
@@ -90,7 +90,7 @@ class _CommonTests():
         with open(self.config, 'w') as f:
             f.write(NETPLAN_YAML % {'nic': self.dev_e_client})
 
-        out = subprocess.run(BUSCTL_CONFIG, capture_output=True, universal_newlines=True)
+        out = subprocess.run(BUSCTL_CONFIG, capture_output=True, text=True)
 
         self.assertEqual(out.returncode, 0, msg=f"Busctl Config() failed with error: {out.stderr}")
 
@@ -102,7 +102,7 @@ class _CommonTests():
         BUSCTL_CONFIG_GET[5] = config_path
 
         # Retrieving the config
-        out = subprocess.run(BUSCTL_CONFIG_GET, capture_output=True, universal_newlines=True)
+        out = subprocess.run(BUSCTL_CONFIG_GET, capture_output=True, text=True)
         self.assertEqual(out.returncode, 0, msg=f"Busctl Get() failed with error: {out.stderr}")
 
         out_dict = json.loads(out.stdout)
@@ -143,7 +143,7 @@ class _CommonTests():
         with open(self.config, 'w') as f:
             f.write(NETPLAN_YAML_BEFORE % {'nic': self.dev_e_client})
 
-        out = subprocess.run(BUSCTL_CONFIG, capture_output=True, universal_newlines=True)
+        out = subprocess.run(BUSCTL_CONFIG, capture_output=True, text=True)
         self.assertEqual(out.returncode, 0, msg=f"Busctl Config() failed with error: {out.stderr}")
 
         out_dict = json.loads(out.stdout)
@@ -156,14 +156,14 @@ class _CommonTests():
         BUSCTL_CONFIG_SET[5] = config_path
 
         # Changing the configuration
-        out = subprocess.run(BUSCTL_CONFIG_SET, capture_output=True, universal_newlines=True)
+        out = subprocess.run(BUSCTL_CONFIG_SET, capture_output=True, text=True)
         self.assertEqual(out.returncode, 0, msg=f"Busctl Set() failed with error: {out.stderr}")
 
         out_dict = json.loads(out.stdout)
         self.assertEqual(out_dict.get('data')[0], True, msg="Set command failed")
 
         # Retrieving the configuration
-        out = subprocess.run(BUSCTL_CONFIG_GET, capture_output=True, universal_newlines=True)
+        out = subprocess.run(BUSCTL_CONFIG_GET, capture_output=True, text=True)
         self.assertEqual(out.returncode, 0, msg=f"Busctl Get() failed with error: {out.stderr}")
 
         out_dict = json.loads(out.stdout)
@@ -186,7 +186,7 @@ class _CommonTests():
         with open(self.config, 'w') as f:
             f.write(NETPLAN_YAML)
 
-        out = subprocess.run(BUSCTL_CONFIG, capture_output=True, universal_newlines=True)
+        out = subprocess.run(BUSCTL_CONFIG, capture_output=True, text=True)
         self.assertEqual(out.returncode, 0, msg=f"Busctl Config() failed with error: {out.stderr}")
 
         out_dict = json.loads(out.stdout)
@@ -198,7 +198,7 @@ class _CommonTests():
         BUSCTL_CONFIG_APPLY[5] = config_path
 
         # Applying the configuration
-        out = subprocess.run(BUSCTL_CONFIG_APPLY, capture_output=True, universal_newlines=True)
+        out = subprocess.run(BUSCTL_CONFIG_APPLY, capture_output=True, text=True)
         self.assertEqual(out.returncode, 0, msg=f"Busctl Apply() failed with error: {out.stderr}")
 
         out_dict = json.loads(out.stdout)

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -112,7 +112,7 @@ class _CommonTests():
 
         # ensure that they do not get managed by NM for foreign backends
         expected_state = (self.backend == 'NetworkManager') and 'connected' or 'unmanaged'
-        out = subprocess.check_output(['nmcli', 'dev'], universal_newlines=True)
+        out = subprocess.check_output(['nmcli', 'dev'], text=True)
         for i in [self.dev_e_client, self.dev_e2_client]:
             self.assertRegex(out, r'%s\s+(ethernet|bridge)\s+%s' % (i, expected_state))
 
@@ -125,12 +125,12 @@ class _CommonTests():
             self.assertRegex(resolv_conf, 'search.*fakesuffix')
             # not easy to peek dnsmasq's brain, so check its logging
             out = subprocess.check_output(['journalctl', '--quiet', '-tdnsmasq', '-ocat', '--since=-30s'],
-                                          universal_newlines=True)
+                                          text=True)
             self.assertIn('nameserver 172.1.2.3', out)
         elif resolved_in_use():
             sys.stdout.write('[resolved] ')
             sys.stdout.flush()
-            out = subprocess.check_output(['resolvectl', 'status'], universal_newlines=True)
+            out = subprocess.check_output(['resolvectl', 'status'], text=True)
             self.assertIn('DNS Servers: 172.1.2.3', out)
             self.assertIn('fakesuffix', out)
         else:

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -380,7 +380,7 @@ class _CommonTests():
             openvswitch: {}''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'ovs-br', 'non-ovs-bond'])
         # Basic verification that the interfaces/ports are set up in OVS
-        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'], universal_newlines=True)
+        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'], text=True)
         self.assertIn('    Bridge ovs-br', out)
         self.assertIn('''        Port non-ovs-bond
             Interface non-ovs-bond''', out)
@@ -426,7 +426,7 @@ class _CommonTests():
             mtu: 1500''' % {'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client, 'ovs0', 'eth42.21'])
         # Basic verification that the interfaces/ports are set up in OVS
-        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'], universal_newlines=True)
+        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'], text=True)
         self.assertIn('    Bridge ovs0', out)
         self.assertIn('''        Port %(ec)s.21
             Interface %(ec)s.21''' % {'ec': self.dev_e_client}, out)
@@ -451,7 +451,7 @@ class _CommonTests():
     ethernets:
       %(ec)s: {}''' % {'ec': self.dev_e_client})
         p = subprocess.Popen(['netplan', 'apply'], stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE, universal_newlines=True)
+                             stderr=subprocess.PIPE, text=True)
         (out, err) = p.communicate()
         self.assertIn('ovs0: The \'ovs-vsctl\' tool is required to setup OpenVSwitch interfaces.', err)
         self.assertNotEqual(p.returncode, 0)
@@ -469,7 +469,7 @@ class _CommonTests():
       br0:
         dhcp4: false''')
         p = subprocess.Popen(['netplan', 'apply'], stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE, universal_newlines=True)
+                             stderr=subprocess.PIPE, text=True)
         (_, err) = p.communicate()
         self.assertIn('Cannot call openvswitch: ovsdb-server.service is not running.', err)
         self.assertEqual(p.returncode, 0)
@@ -607,9 +607,9 @@ class _CommonTests():
     @unittest.skip("For debugging only")
     def test_zzz_ovs_debugging(self):  # Runs as the last test, to collect all logs
         """Display OVS logs of the previous tests"""
-        out = subprocess.check_output(['cat', '/var/log/openvswitch/ovs-vswitchd.log'], universal_newlines=True)
+        out = subprocess.check_output(['cat', '/var/log/openvswitch/ovs-vswitchd.log'], text=True)
         print(out)
-        out = subprocess.check_output(['ovsdb-tool', 'show-log'], universal_newlines=True)
+        out = subprocess.check_output(['ovsdb-tool', 'show-log'], text=True)
         print(out)
 
 

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -90,7 +90,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   renderer: %(r)s
   version: 2''' % {'r': self.backend})
             os.chmod(self.config, mode=0o600)
-        p = subprocess.Popen(['netplan', 'try'], bufsize=1, universal_newlines=True,
+        p = subprocess.Popen(['netplan', 'try'], bufsize=1, text=True,
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(2)
         p.send_signal(signal.SIGUSR1)
@@ -109,7 +109,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   renderer: %(r)s
   version: 2''' % {'r': self.backend})
             os.chmod(self.config, mode=0o600)
-        p = subprocess.Popen(['netplan', 'try'], bufsize=1, universal_newlines=True,
+        p = subprocess.Popen(['netplan', 'try'], bufsize=1, text=True,
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(2)
         p.send_signal(signal.SIGINT)
@@ -169,7 +169,7 @@ class TestDbus(IntegrationTestsBase):
 
         # Terminates netplan-dbus if it is running already
         cmd = ['ps', '-C', 'netplan-dbus', '-o', 'pid=']
-        out = subprocess.run(cmd, capture_output=True, universal_newlines=True)
+        out = subprocess.run(cmd, capture_output=True, text=True)
         if out.returncode == 0:
             pid = out.stdout.strip()
             os.kill(int(pid), signal.SIGTERM)
@@ -177,7 +177,7 @@ class TestDbus(IntegrationTestsBase):
         with open(self.config, 'w') as f:
             f.write(NETPLAN_YAML % {'nic': self.dev_e_client})
 
-        out = subprocess.run(BUSCTL_CONFIG, capture_output=True, universal_newlines=True)
+        out = subprocess.run(BUSCTL_CONFIG, capture_output=True, text=True)
         self.assertEqual(out.returncode, 0, msg=f"Busctl Config() failed with error: {out.stderr}")
 
         out_dict = json.loads(out.stdout)
@@ -188,7 +188,7 @@ class TestDbus(IntegrationTestsBase):
         BUSCTL_CONFIG_GET[5] = config_path
 
         # Retrieving the config
-        out = subprocess.run(BUSCTL_CONFIG_GET, capture_output=True, universal_newlines=True)
+        out = subprocess.run(BUSCTL_CONFIG_GET, capture_output=True, text=True)
         self.assertEqual(out.returncode, 0, msg=f"Busctl Get() failed with error: {out.stderr}")
 
         out_dict = json.loads(out.stdout)

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -49,7 +49,7 @@ class _CommonTests():
         self.generate_and_settle([self.dev_e_client])
         self.assert_iface_up(self.dev_e_client, ['inet6 9876:bbbb::11/70'])
         out = subprocess.check_output(['ip', '-6', 'route', 'show', 'dev', self.dev_e_client],
-                                      universal_newlines=True)
+                                      text=True)
         # NM routes have a (default) 'metric' in between 'proto static' and 'onlink'
         self.assertRegex(out, r'2001:f00f:f00f::/64 via 9876:bbbb::5 proto static[^\n]* onlink')
 
@@ -71,7 +71,7 @@ class _CommonTests():
         self.generate_and_settle([self.dev_e_client])
         self.assert_iface_up(self.dev_e_client, ['inet 192.168.14.2'])
         out = subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_e_client],
-                                      universal_newlines=True)
+                                      text=True)
         self.assertIn('10.10.10.0/24 via 192.168.14.20 proto static src 192.168.14.2', out)
 
     # Supposed to fail if tested against NetworkManager < 1.10
@@ -96,7 +96,7 @@ class _CommonTests():
         self.generate_and_settle([self.dev_e_client])
         self.assert_iface_up(self.dev_e_client, ['inet '])
         out = subprocess.check_output(['ip', 'route', 'show', 'table', table_id, 'dev',
-                                      self.dev_e_client], universal_newlines=True)
+                                      self.dev_e_client], text=True)
         # NM routes have a (default) 'metric' in between 'proto static' and 'onlink'
         self.assertRegex(out, r'10\.0\.0\.0/8 via 11\.0\.0\.1 proto static[^\n]* onlink')
 
@@ -307,19 +307,19 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e_client, ['inet 10.10.10.22', 'master vrf0'])  # wokeignore:rule=master
         self.assert_iface_up('vrf0', ['MASTER'])  # wokeignore:rule=master
         # verify routes didn't leak into the main routing table
-        out = subprocess.check_output(['ip', 'route', 'show'], universal_newlines=True)
+        out = subprocess.check_output(['ip', 'route', 'show'], text=True)
         self.assertNotIn('10.10.0.0/16', out)
         self.assertNotIn('11.11.11.0/24', out)
         # verify routes were added to the VRF's routing table
         out = subprocess.check_output(['ip', 'route', 'show', 'table', '1000'],
-                                      universal_newlines=True)
+                                      text=True)
         self.assertIn('10.10.0.0/16 via 10.10.10.1 dev vrf0', out)
         self.assertIn('11.11.11.0/24 via 10.10.10.2 dev {}'.format(self.dev_e_client), out)
 
         # verify routing policy was setup correctly to the VRF's table
         # 'routing-policy' is not supported on NetworkManager
         if self.backend == 'networkd':
-            out = subprocess.check_output(['ip', 'rule', 'show'], universal_newlines=True)
+            out = subprocess.check_output(['ip', 'rule', 'show'], text=True)
             self.assertIn('from 10.10.10.42 lookup 1000', out)
 
 

--- a/tests/integration/tunnels.py
+++ b/tests/integration/tunnels.py
@@ -99,11 +99,11 @@ class _CommonTests():
         self.wait_output(['wg', 'show', 'wg0'], 'latest handshake')
         self.wait_output(['wg', 'show', 'wg1'], 'latest handshake')
         # Verify server
-        out = subprocess.check_output(['wg', 'show', 'wg0', 'private-key'], universal_newlines=True)
+        out = subprocess.check_output(['wg', 'show', 'wg0', 'private-key'], text=True)
         self.assertIn("4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=", out)
-        out = subprocess.check_output(['wg', 'show', 'wg0', 'preshared-keys'], universal_newlines=True)
+        out = subprocess.check_output(['wg', 'show', 'wg0', 'preshared-keys'], text=True)
         self.assertIn("7voRZ/ojfXgfPOlswo3Lpma1RJq7qijIEEUEMShQFV8=", out)
-        out = subprocess.check_output(['wg', 'show', 'wg0'], universal_newlines=True)
+        out = subprocess.check_output(['wg', 'show', 'wg0'], text=True)
         self.assertIn("public key: rlbInAj0qV69CysWPQY7KEBnKxpYCpaWqOs/dLevdWc=", out)
         self.assertIn("listening port: 51820", out)
         self.assertIn("fwmark: 0x2a", out)
@@ -113,11 +113,11 @@ class _CommonTests():
         self.assertRegex(out, r'transfer: \d+.*B received, \d+.*B sent')
         self.assert_iface('wg0', ['inet 10.10.10.20/24'])
         # Verify client
-        out = subprocess.check_output(['wg', 'show', 'wg1', 'private-key'], universal_newlines=True)
+        out = subprocess.check_output(['wg', 'show', 'wg1', 'private-key'], text=True)
         self.assertIn("KPt9BzQjejRerEv8RMaFlpsD675gNexELOQRXt/AcH0=", out)
-        out = subprocess.check_output(['wg', 'show', 'wg1', 'preshared-keys'], universal_newlines=True)
+        out = subprocess.check_output(['wg', 'show', 'wg1', 'preshared-keys'], text=True)
         self.assertIn("7voRZ/ojfXgfPOlswo3Lpma1RJq7qijIEEUEMShQFV8=", out)
-        out = subprocess.check_output(['wg', 'show', 'wg1'], universal_newlines=True)
+        out = subprocess.check_output(['wg', 'show', 'wg1'], text=True)
         self.assertIn("public key: M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=", out)
         self.assertIn("peer: rlbInAj0qV69CysWPQY7KEBnKxpYCpaWqOs/dLevdWc=", out)
         self.assertIn("endpoint: 10.10.10.20:51820", out)
@@ -174,7 +174,7 @@ class _CommonTests():
 ''' % {'r': self.backend})
         self.generate_and_settle(['tun0'])
         self.assert_iface('tun0', ['tun0@NONE', 'link.* 192.168.5.1 peer 99.99.99.99'])
-        out = subprocess.check_output(['ip', 'tunnel', 'show', 'tun0'], universal_newlines=True)
+        out = subprocess.check_output(['ip', 'tunnel', 'show', 'tun0'], text=True)
         self.assertIn("ikey 1234 okey 5678", out)
 
     def test_tunnel_gre6_with_keys(self):
@@ -192,7 +192,7 @@ class _CommonTests():
 ''' % {'r': self.backend})
         self.generate_and_settle(['tun0'])
         self.assert_iface('tun0', ['tun0@NONE', 'link.* fe80::1 brd 2001:dead:beef::2'])
-        out = subprocess.check_output(['ip', '-6', 'tunnel', 'show', 'tun0'], universal_newlines=True)
+        out = subprocess.check_output(['ip', '-6', 'tunnel', 'show', 'tun0'], text=True)
         self.assertIn("key 1234", out)
 
     def test_tunnel_vxlan(self):
@@ -287,7 +287,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       remote: 99.99.99.99
 ''' % {'r': self.backend})
         self.generate_and_settle(['tun0'])
-        out = subprocess.check_output(['ip', '-details', 'link', 'show', 'tun0'], universal_newlines=True)
+        out = subprocess.check_output(['ip', '-details', 'link', 'show', 'tun0'], text=True)
         self.assertIn("gretap remote 99.99.99.99 local 192.168.5.1", out)
         self.assertIn("ikey 1.2.3.4 okey 5.6.7.8", out)
 
@@ -305,7 +305,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       remote: 2001:dead:beef::2
 ''' % {'r': self.backend})
         self.generate_and_settle(['tun0'])
-        out = subprocess.check_output(['ip', '-details', 'link', 'show', 'tun0'], universal_newlines=True)
+        out = subprocess.check_output(['ip', '-details', 'link', 'show', 'tun0'], text=True)
         self.assertIn("gretap remote 2001:dead:beef::2 local fe80::1", out)
         self.assertIn("ikey 1.2.3.4 okey 1.2.3.4", out)
 

--- a/tests/integration/wifi.py
+++ b/tests/integration/wifi.py
@@ -69,12 +69,12 @@ class _CommonTests():
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_w_client]))
         if self.backend == 'NetworkManager':
             out = subprocess.check_output(['nmcli', 'dev', 'show', self.dev_w_client],
-                                          universal_newlines=True)
+                                          text=True)
             self.assertRegex(out, 'GENERAL.CONNECTION.*netplan-%s-fake net' % self.dev_w_client)
             self.assertRegex(out, 'IP4.DNS.*192.168.5.1')
         else:
             out = subprocess.check_output(['networkctl', 'status', self.dev_w_client],
-                                          universal_newlines=True)
+                                          text=True)
             self.assertRegex(out, 'DNS.*192.168.5.1')
 
     def test_wifi_ipv4_wpa2(self):
@@ -103,12 +103,12 @@ wpa_passphrase=12345678
                       subprocess.check_output(['ip', 'route', 'show', 'dev', self.dev_w_client]))
         if self.backend == 'NetworkManager':
             out = subprocess.check_output(['nmcli', 'dev', 'show', self.dev_w_client],
-                                          universal_newlines=True)
+                                          text=True)
             self.assertRegex(out, 'GENERAL.CONNECTION.*netplan-%s-fake net' % self.dev_w_client)
             self.assertRegex(out, 'IP4.DNS.*192.168.5.1')
         else:
             out = subprocess.check_output(['networkctl', 'status', self.dev_w_client],
-                                          universal_newlines=True)
+                                          text=True)
             self.assertRegex(out, 'DNS.*192.168.5.1')
 
     def test_wifi_regdom(self):
@@ -121,7 +121,7 @@ wpa_pairwise=TKIP
 wpa_passphrase=12345678
 ''', None)
 
-        out = subprocess.check_output(['iw', 'reg', 'get'], universal_newlines=True)
+        out = subprocess.check_output(['iw', 'reg', 'get'], text=True)
         self.assertNotIn('country GB', out)
         with open(self.config, 'w') as f:
             f.write('''network:
@@ -135,7 +135,7 @@ wpa_passphrase=12345678
           password: 12345678''' % {'r': self.backend, 'wc': self.dev_w_client})
         self.generate_and_settle([self.dev_w_client])
         self.assert_iface_up(self.dev_w_client, ['inet 192.168.1.42/24'])
-        out = subprocess.check_output(['iw', 'reg', 'get'], universal_newlines=True)
+        out = subprocess.check_output(['iw', 'reg', 'get'], text=True)
         self.assertIn('global\ncountry GB', out)
 
 
@@ -165,7 +165,7 @@ class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
           mode: ap''' % {'wc': self.dev_w_client})
         self.generate_and_settle([self.state(self.dev_w_client, 'inet 10.')])
         out = subprocess.check_output(['iw', 'dev', self.dev_w_client, 'info'],
-                                      universal_newlines=True)
+                                      text=True)
         self.assertIn('type AP', out)
         self.assertIn('ssid fake net', out)
 
@@ -173,10 +173,10 @@ class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
         subprocess.check_call(['ip', 'link', 'set', self.dev_w_ap, 'up'])
         subprocess.check_call(['iw', 'dev', self.dev_w_ap, 'connect', 'fake net'])
         out = subprocess.check_output(['dhclient', '-1', '-v', self.dev_w_ap],
-                                      stderr=subprocess.STDOUT, universal_newlines=True)
+                                      stderr=subprocess.STDOUT, text=True)
         self.assertIn('DHCPACK', out)
         out = subprocess.check_output(['iw', 'dev', self.dev_w_ap, 'info'],
-                                      universal_newlines=True)
+                                      text=True)
         self.assertIn('type managed', out)
         self.assertIn('ssid fake net', out)
         self.assert_iface_up(self.dev_w_ap, ['inet 10.'])

--- a/tests/netplan_dbus/test_dbus.py
+++ b/tests/netplan_dbus/test_dbus.py
@@ -295,7 +295,7 @@ class TestNetplanDBus(unittest.TestCase):
             "io.netplan.Netplan.Config",
             "Get",
         ]
-        out = subprocess.check_output(BUSCTL_NETPLAN_CMD, universal_newlines=True)
+        out = subprocess.check_output(BUSCTL_NETPLAN_CMD, text=True)
         self.assertIn(r's ""', out)  # No output as 'netplan get' is actually mocked
         self.assertEqual(self.mock_netplan_cmd.calls(), [[
             "netplan", "get", "all", "--root-dir={}".format(tmpdir)
@@ -351,7 +351,7 @@ class TestNetplanDBus(unittest.TestCase):
             "io.netplan.Netplan.Config",
             "Get",
         ]
-        out = subprocess.check_output(BUSCTL_NETPLAN_CMD, universal_newlines=True)
+        out = subprocess.check_output(BUSCTL_NETPLAN_CMD, text=True)
         self.assertIn(r's "network:\n  eth42:\n    dhcp6: true\n"', out)
         self.assertEqual(self.mock_netplan_cmd.calls(), [[
             "netplan", "get", "all", "--root-dir={}".format(tmpdir)

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -173,7 +173,7 @@ class TestKeyfileBase(unittest.TestCase):
     def assert_nm_regenerate(self, file_contents_map):
         argv = [exe_generate, '--root-dir', self.workdir.name]
         p = subprocess.Popen(argv, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE, universal_newlines=True)
+                             stderr=subprocess.PIPE, text=True)
         returncode = p.wait(5)
         (out, err) = p.communicate()
         self.assertEqual(returncode, 0, err)

--- a/tests/test_ovs.py
+++ b/tests/test_ovs.py
@@ -42,7 +42,7 @@ Certificate: /another/cert.pem
 CA Certificate: /some/ca-cert.pem
 Bootstrap: false'''
         ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/private/key.pem,/another/cert.pem,/some/ca-cert.pem')
-        mock_out.assert_called_once_with([OVS, 'get-ssl'], universal_newlines=True)
+        mock_out.assert_called_once_with([OVS, 'get-ssl'], text=True)
         mock.assert_has_calls([
             call([OVS, 'del-ssl']),
             call([OVS, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
@@ -57,7 +57,7 @@ Certificate: /another/cert.pem
 CA Certificate: /some/ca-cert.pem
 Bootstrap: false'''
         ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/some/key.pem,/other/cert.pem,/some/cert.pem')
-        mock_out.assert_called_once_with([OVS, 'get-ssl'], universal_newlines=True)
+        mock_out.assert_called_once_with([OVS, 'get-ssl'], text=True)
         mock.assert_has_calls([
             call([OVS, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
         ])
@@ -71,7 +71,7 @@ Bootstrap: false'''
     def test_clear_global(self, mock, mock_out):
         mock_out.return_value = 'tcp:127.0.0.1:1337\nunix:/some/socket'
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337,unix:/some/socket')
-        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], universal_newlines=True)
+        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], text=True)
         mock.assert_has_calls([
             call([OVS, 'del-controller', 'ovs0']),
             call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
@@ -82,7 +82,7 @@ Bootstrap: false'''
     def test_no_clear_global_different(self, mock, mock_out):
         mock_out.return_value = 'unix:/var/run/openvswitch/ovs0.mgmt'
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337,unix:/some/socket')
-        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], universal_newlines=True)
+        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], text=True)
         mock.assert_has_calls([
             call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
         ])


### PR DESCRIPTION
## Description
Cleanup a few basic things like:
* using `shutil.rmtree()` over `rm -rf` subprocess call
* clean up all the coverage data from the Makefile (`make clean`)
* Use the more readable `text=True` alias to subprocess calls (over `universal_newlines=True`) – it's available since Python 3.7
* Improve parameter passing to `networkctl`, accounting for network interfaces names that contain a leading `-`

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

