### PR TITLE
Reimplement optional-addresses (LP: #1880029)

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -531,11 +531,12 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
 
 - **optional-addresses** (sequence of scalars)
 
-  > Specify types of addresses that are not required for a device to be
+  > Specify address families that are not required for a device to be
   > considered online. This changes the behavior of backends at boot time to
   > avoid waiting for addresses that are marked optional, and thus consider
   > the interface as "usable" sooner. This does not disable these addresses,
-  > which will be brought up anyway.
+  > which will be brought up anyway. Valid values are: ipv4, ipv6 and none.
+  > If "none" is used, ipv4 and ipv6 will be considered mandatory.
 
   Example:
 
@@ -545,7 +546,7 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
       eth7:
         dhcp4: true
         dhcp6: true
-        optional-addresses: [ ipv4-ll, dhcp6 ]
+        optional-addresses: [ ipv6 ]
   ```
 
 - **activation-mode** (scalar) – since **0.103**

--- a/src/abi.h
+++ b/src/abi.h
@@ -30,6 +30,9 @@ typedef enum {
     NETPLAN_OPTIONAL_DHCP4   = 1<<2,
     NETPLAN_OPTIONAL_DHCP6   = 1<<3,
     NETPLAN_OPTIONAL_STATIC  = 1<<4,
+    NETPLAN_OPTIONAL_IPV4    = 1<<5,
+    NETPLAN_OPTIONAL_IPV6    = 1<<6,
+    NETPLAN_OPTIONAL_NONE    = 1<<7,
 } NetplanOptionalAddressFlag;
 
 /* Fields below are valid for dhcp4 and dhcp6 unless otherwise noted. */

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -877,6 +877,12 @@ _serialize_yaml(
             YAML_SCALAR_PLAIN(event, emitter, "dhcp6")
         if (def->optional_addresses & NETPLAN_OPTIONAL_STATIC)
             YAML_SCALAR_PLAIN(event, emitter, "static")
+        if (def->optional_addresses & NETPLAN_OPTIONAL_IPV4)
+            YAML_SCALAR_PLAIN(event, emitter, "ipv4")
+        if (def->optional_addresses & NETPLAN_OPTIONAL_IPV6)
+            YAML_SCALAR_PLAIN(event, emitter, "ipv6")
+        if (def->optional_addresses & NETPLAN_OPTIONAL_NONE)
+            YAML_SCALAR_PLAIN(event, emitter, "none")
         YAML_SEQUENCE_CLOSE(event, emitter);
     }
 

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -739,15 +739,12 @@ netplan_netdef_write_network_file(
         is_optional = TRUE;
     }
 
-    if (is_optional || def->optional_addresses) {
-        if (is_optional) {
-            g_string_append(link, "RequiredForOnline=no\n");
-        }
-        for (unsigned i = 0; NETPLAN_OPTIONAL_ADDRESS_TYPES[i].name != NULL; ++i) {
-            if (def->optional_addresses & NETPLAN_OPTIONAL_ADDRESS_TYPES[i].flag) {
-            g_string_append_printf(link, "OptionalAddresses=%s\n", NETPLAN_OPTIONAL_ADDRESS_TYPES[i].name);
-            }
-        }
+    if (is_optional) {
+        g_string_append(link, "RequiredForOnline=no\n");
+    }
+
+    if (def->optional_addresses & NETPLAN_OPTIONAL_NONE) {
+        g_string_append(link, "RequiredFamilyForOnline=both\n");
     }
 
     if (def->mtubytes)

--- a/src/nm.c
+++ b/src/nm.c
@@ -926,6 +926,15 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
         }
     }
 
+    if (def->optional_addresses & NETPLAN_OPTIONAL_NONE) {
+            g_key_file_set_string(kf, "ipv4", "may-fail", "false");
+            g_key_file_set_string(kf, "ipv6", "may-fail", "false");
+    } else {
+        if (def->optional_addresses & NETPLAN_OPTIONAL_IPV4)
+            g_key_file_set_string(kf, "ipv4", "may-fail", "true");
+        if (def->optional_addresses & NETPLAN_OPTIONAL_IPV6)
+            g_key_file_set_string(kf, "ipv6", "may-fail", "true");
+    }
     /* NM connection files might contain secrets, and NM insists on tight permissions */
     full_path = g_strjoin(G_DIR_SEPARATOR_S, rootdir ?: "", conf_path, NULL);
     orig_umask = umask(077);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1530,6 +1530,10 @@ NETPLAN_OPTIONAL_ADDRESS_TYPES[] = {
     {"dhcp4",   NETPLAN_OPTIONAL_DHCP4},
     {"dhcp6",   NETPLAN_OPTIONAL_DHCP6},
     {"static",  NETPLAN_OPTIONAL_STATIC},
+    /* All above are deprecated */
+    {"ipv4",    NETPLAN_OPTIONAL_IPV4},
+    {"ipv6",    NETPLAN_OPTIONAL_IPV6},
+    {"none",    NETPLAN_OPTIONAL_NONE},
     {NULL},
 };
 
@@ -1543,6 +1547,14 @@ handle_optional_addresses(NetplanParser* npp, yaml_node_t* node, const void* _, 
 
         for (unsigned i = 0; NETPLAN_OPTIONAL_ADDRESS_TYPES[i].name != NULL; ++i) {
             if (g_ascii_strcasecmp(scalar(entry), NETPLAN_OPTIONAL_ADDRESS_TYPES[i].name) == 0) {
+
+                /* Values below NETPLAN_OPTIONAL_STATIC (including it) are not valid and
+                 * considered deprecated. See LP: #1880029
+                 */
+                if (NETPLAN_OPTIONAL_ADDRESS_TYPES[i].flag <= NETPLAN_OPTIONAL_STATIC)
+                    g_warning("Flag \"%s\" in optional-addresses is deprecated. Valid values are: "
+                            "\"ipv4\", \"ipv6\" and \"none\"\n", NETPLAN_OPTIONAL_ADDRESS_TYPES[i].name);
+
                 npp->current.netdef->optional_addresses |= NETPLAN_OPTIONAL_ADDRESS_TYPES[i].flag;
                 found = TRUE;
                 break;

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -405,7 +405,7 @@ class TestBase(unittest.TestCase):
     def get_optional_addresses(self, eth_name):
         config = self.get_network_config_for_link(eth_name)
         r = set()
-        prefix = "OptionalAddresses="
+        prefix = "RequiredFamilyForOnline="
         for line in config.splitlines():
             if line.startswith(prefix):
                 r.add(line[len(prefix):])


### PR DESCRIPTION
## Description

The Netplan's key "optional-addresses" only generates configuration for systemd-networkd. Although, the generated "OptionalAddresses" key doesn't exist so this property never worked on Netplan.

This PR re-implements the key "optional-addresses" to emit configuration for network manager, using the "may-fail" key, and for networkd, using the "RequiredFamilyForOnline" key.

Note that RequiredFamilyForOnline is actually the apposite of "optional addresses". It defaults to "any", meaning that either ipv4 or ipv6 will be enough to set the interface as online. Because of that, the only time when Netplan will generate RequiredFamilyForOnline is when the user enters "none", meaning that none of the addresses are optional, so RequiredFamilyForOnline=both will be emitted. 

For Network Manager, optional-addresses never generated configuration. Now, Netplan will emit the key "may-fail" for ipv4 and/or ipv6 according to the configuration.

All the old values accepted by optional-addresses are no-ops, so if any users out there have this configuration in their YAML files, nothing will break.

These changes seem to not be a perfect fit based on our documentation, but I guess it's close :sweat_smile: 

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

