### PR TITLE
netplan: adjust the maximum buffer size to 1MB

### DIFF
--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -56,7 +56,7 @@ lib.netplan_get_id_from_nm_filename.restype = ctypes.c_char_p
 
 def _string_realloc_call_no_error(function):
     size = 16
-    while size < 1073741824:  # 1MB
+    while size < 1048576:  # 1MB
         buffer = ctypes.create_string_buffer(size)
         code = function(buffer)
         if code == -2:


### PR DESCRIPTION
It says it's 1MB but the value is actually 1GB


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

