### PR TITLE
vrfs: skip policies parsing if list is NULL (LP: #2016427)

### DIFF
--- a/src/validation.c
+++ b/src/validation.c
@@ -503,7 +503,11 @@ adopt_and_validate_vrf_routes(const NetplanParser *npp, GHashTable *netdefs, GEr
                 g_debug("%s: Adopted VRF routes table to %d", nd->id, nd->vrf_table);
             }
         }
+
         /* IP Rules */
+        if (!nd->ip_rules)
+            continue;
+
         for (size_t i = 0; i < nd->ip_rules->len; i++) {
             NetplanIPRule* r = g_array_index(nd->ip_rules, NetplanIPRule*, i);
             if (r->table == nd->vrf_table) {

--- a/tests/generator/test_vrfs.py
+++ b/tests/generator/test_vrfs.py
@@ -186,3 +186,17 @@ class TestConfigErrors(TestBase):
         from: 2.3.4.5
 ''', expect_fail=True)
         self.assertIn("vrf0: VRF routing-policy table mismatch (45 != 46)", err)
+
+    def test_vrf_without_routing_policies_lp2016427(self):
+        '''
+        Test that a VRF without policies will not crash.
+        See LP: #2016427
+        '''
+        self.generate('''network:
+  version: 2
+  vrfs:
+    vrf1005:
+      table: 1005
+      routes:
+      - to: default
+        via: 1.2.3.4''')

--- a/tests/generator/test_vrfs.py
+++ b/tests/generator/test_vrfs.py
@@ -200,3 +200,27 @@ class TestConfigErrors(TestBase):
       routes:
       - to: default
         via: 1.2.3.4''')
+
+        self.assert_networkd({'vrf1005.network': ND_EMPTY % ('vrf1005', 'ipv6') + '''
+[Route]
+Destination=0.0.0.0/0
+Gateway=1.2.3.4
+Table=1005
+''',
+                              'vrf1005.netdev': ND_VRF % ('vrf1005', 1005)})
+
+    def test_vrf_without_routes(self):
+        self.generate('''network:
+  version: 2
+  vrfs:
+    vrf1005:
+      table: 1005
+      routing-policy:
+      - from: 2.3.4.5''')
+
+        self.assert_networkd({'vrf1005.network': ND_EMPTY % ('vrf1005', 'ipv6') + '''
+[RoutingPolicyRule]
+From=2.3.4.5
+Table=1005
+''',
+                              'vrf1005.netdev': ND_VRF % ('vrf1005', 1005)})


### PR DESCRIPTION
It addresses LP: #2016427


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#2016427

