### PR TITLE
libnetplan: don't try to read from a NULL file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,7 @@ test_env = [
     'NETPLAN_GENERATE_PATH=' + join_paths(meson.current_build_dir(), 'src', 'generate'),
     'NETPLAN_DBUS_CMD=' + join_paths(meson.current_build_dir(), 'dbus', 'netplan-dbus'),
     'COVERAGE_PROCESS_START=' + join_paths(meson.current_source_dir(), '.coveragerc'),
+    'G_DEBUG=fatal_criticals',
 ]
 
 if get_option('unit_testing')

--- a/src/error.c
+++ b/src/error.c
@@ -159,7 +159,7 @@ yaml_error(const NetplanParser *npp, const yaml_node_t* node, GError** error, co
 
     va_start(argp, msg);
     g_vasprintf(&s, msg, argp);
-    if (node != NULL) {
+    if (node != NULL && npp->current.filepath != NULL) {
         error_context = get_syntax_error_context(npp, node->start_mark.line, node->start_mark.column, error);
         g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_PARSE,
                     "%s:%zu:%zu: Error in network definition: %s\n%s",


### PR DESCRIPTION
When trying to build an error context for a file without a name (when using netplan set for example), the filename will be NULL. We are triggering some critical assertions from glib thanks to that:
```
GLib-GIO-CRITICAL ...: g_file_new_for_path: assertion 'path != NULL' failed
```
In this cases the context will be meaningless:
```
(null):4:14: Error in network definition: invalid boolean value 'falsea'
(null)
             ^
```
Also, add G_DEBUG=fatal_criticals to the test environment so we'll segfault if we assert on a critical issue again.


It will change the error message for the command `netplan set --root-dir /tmp/fakeroot bridges.eth12.dhcp4=falsea` from:
```
netplan.libnetplan.LibNetplanException: (null):4:14: Error in network definition: invalid boolean value 'falsea'
(null)
             ^
```
to:
```
netplan.libnetplan.LibNetplanException: Error in network definition: invalid boolean value 'falsea'
```

## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

