### PR TITLE
nm: return if write_routes() fails

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -667,8 +667,8 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
             write_bridge_params(def, kf);
         if (def->type == NETPLAN_DEF_TYPE_VRF) {
             g_key_file_set_uint64(kf, "vrf", "table", def->vrf_table);
-            write_routes(def, kf, AF_INET, error);
-            write_routes(def, kf, AF_INET6, error);
+            if (!write_routes(def, kf, AF_INET, error) || !write_routes(def, kf, AF_INET6, error))
+                return FALSE;
         }
     }
     if (def->type == NETPLAN_DEF_TYPE_MODEM) {

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -985,3 +985,17 @@ class TestConfigErrors(TestBase):
     engreen:
       activation-mode: invalid''', expect_fail=True)
         self.assertIn("needs to be 'manual' or 'off'", err)
+
+    def test_nm_only_supports_unicast_routes(self):
+        err = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  vrfs:
+    vrf100:
+      table: 100
+      routes:
+        - to: 1.2.3.4/24
+          type: throw
+      routing-policy:
+        - to: 1.2.3.4/24''', expect_fail=True)
+        self.assertIn("NetworkManager only supports unicast routes", err)


### PR DESCRIPTION
When routes validation fails we should return. It's also hitting an assertion later because the "error" object is already built:
```
(generate:246468): GLib-CRITICAL **: 09:45:27.526: g_key_file_save_to_file: assertion 'error == NULL || *error == NULL' failed
```

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

