### PR TITLE
parse: use "--" with systemd-escape

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -469,7 +469,7 @@ systemd_escape(char* string)
     gint exit_status = 0;
     gchar *escaped;
 
-    gchar *argv[] = {"bin" "/" "systemd-escape", string, NULL};
+    gchar *argv[] = {"bin" "/" "systemd-escape", "--", string, NULL};
     g_spawn_sync("/", argv, NULL, 0, NULL, NULL, &escaped, &stderrh, &exit_status, &err);
     #if GLIB_CHECK_VERSION (2, 70, 0)
     g_spawn_check_wait_status(exit_status, &err);


### PR DESCRIPTION
Strings starting with "-" will be interpreted as systemd-escape parameters.

Like in:

```
network:
  wifis:
    '--version':
      access-points:
        aasasd:
          password: "asdasdasdasd"
```

```
$ ./build/src/generate --root-dir /tmp/fakeroot3/
ERROR: cannot create file /run/systemd/system/netplan-wpa-systemd 252 (252.5-2ubuntu3)
+PAM +AUDIT +SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 -PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD -BPF_FRAMEWORK -XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified.service: Failed to create file “/tmp/fakeroot3/run/systemd/system/netplan-wpa-systemd 252 (252.5-2ubuntu3)
+PAM +AUDIT +SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 -PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD -BPF_FRAMEWORK -XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified.service.P99R31”: File name too long
```

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

