### PR TITLE
parse: plug a memory leak

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -527,7 +527,8 @@ handle_generic_datalist(NetplanParser *npp, yaml_node_t* node, const char* key_p
                 continue;
         }
 
-        g_datalist_set_data_full(list, scalar(key), g_strdup(scalar(value)), g_free);
+        g_datalist_id_set_data_full(list, g_quark_from_string(scalar(key)),
+                                    g_strdup(scalar(value)), g_free);
     }
     mark_data_as_dirty(npp, list);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -527,7 +527,7 @@ handle_generic_datalist(NetplanParser *npp, yaml_node_t* node, const char* key_p
                 continue;
         }
 
-        g_datalist_set_data_full(list, g_strdup(scalar(key)), g_strdup(scalar(value)), g_free);
+        g_datalist_set_data_full(list, scalar(key), g_strdup(scalar(value)), g_free);
     }
     mark_data_as_dirty(npp, list);
 


### PR DESCRIPTION
The key doesn't need to be duplicated before being passed to g_datalist_set_data_full. It will not be freed.


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

