### PR TITLE
parse: set the backend on nm-devices to NM by default

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3034,6 +3034,11 @@ handle_network_type(NetplanParser* npp, yaml_node_t* node, const char* key_prefi
             case NETPLAN_DEF_TYPE_NM:
                 g_warning("netplan: %s: handling NetworkManager passthrough device, settings are not fully supported.", npp->current.netdef->id);
                 handlers = ethernet_def_handlers;
+                if (npp->current.netdef->backend != NETPLAN_BACKEND_NM) {
+                    g_warning("nm-device: %s: the renderer for nm-devices must be NetworkManager, it will be used instead of the defined one.",
+                            npp->current.netdef->id);
+                    npp->current.netdef->backend = NETPLAN_BACKEND_NM;
+                }
                 break;
             default: g_assert_not_reached(); // LCOV_EXCL_LINE
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -3036,7 +3036,7 @@ handle_network_type(NetplanParser* npp, yaml_node_t* node, const char* key_prefi
                 handlers = ethernet_def_handlers;
                 if (npp->current.netdef->backend != NETPLAN_BACKEND_NM) {
                     g_warning("nm-device: %s: the renderer for nm-devices must be NetworkManager, it will be used instead of the defined one.",
-                            npp->current.netdef->id);
+                              npp->current.netdef->id);
                     npp->current.netdef->backend = NETPLAN_BACKEND_NM;
                 }
                 break;

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -236,6 +236,32 @@ test_netplan_parser_process_document_missing_interface_error(void** state)
     assert_true(found);
 }
 
+void
+test_nm_device_backend_is_nm_by_default(void** state)
+{
+    const char* yaml =
+        "network:\n"
+        "  version: 2\n"
+        "  nm-devices:\n"
+        "    device0:\n"
+        "      networkmanager:\n"
+        "        uuid: db5f0f67-1f4c-4d59-8ab8-3d278389cf87\n"
+        "        name: connection-123\n"
+        "        passthrough:\n"
+        "          connection.type: vpn\n";
+
+    NetplanState* np_state = load_string_to_netplan_state(yaml);
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+    netplan_state_iterator_init(np_state, &iter);
+
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_true(netdef->backend == NETPLAN_BACKEND_NM);
+
+    netplan_state_clear(&np_state);
+}
+
 int
 setup(void** state)
 {
@@ -264,6 +290,7 @@ main()
            cmocka_unit_test(test_netplan_parser_sriov_embedded_switch),
            cmocka_unit_test(test_netplan_parser_process_document_proper_error),
            cmocka_unit_test(test_netplan_parser_process_document_missing_interface_error),
+           cmocka_unit_test(test_nm_device_backend_is_nm_by_default),
        };
 
        return cmocka_run_group_tests(tests, setup, tear_down);


### PR DESCRIPTION
By definition, the renderer on nm-devices must be NetworkManager. Not defining it will default to networkd. Apart from the fact it doesn't make sense, it is causing a memory leak because the function g_datalist_clear() will no be called in reset_backend_settings() if the backend is not NM.


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

