### PR TITLE
Add a netplan_parser_load_keyfile() Python binding

### DIFF
--- a/netplan/libnetplan.py
+++ b/netplan/libnetplan.py
@@ -103,6 +103,9 @@ class Parser:
             [_NetplanParserP, c_int, c_char_p, _GErrorPP]
         lib.netplan_parser_load_nullable_overrides.restype = c_int
 
+        lib.netplan_parser_load_keyfile.argtypes = [_NetplanParserP, c_char_p, _GErrorPP]
+        lib.netplan_parser_load_keyfile.restype = c_int
+
         cls._abi_loaded = True
 
     def __init__(self):
@@ -127,6 +130,9 @@ class Parser:
     def load_nullable_overrides(self, input_file: IO, constraint: str):
         _checked_lib_call(lib.netplan_parser_load_nullable_overrides,
                           self._ptr, input_file.fileno(), constraint.encode('utf-8'))
+
+    def load_keyfile(self, input_file: str):
+        _checked_lib_call(lib.netplan_parser_load_keyfile, self._ptr, input_file.encode('utf-8'))
 
 
 class State:

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -211,6 +211,30 @@ class TestParser(TestBase):
                 parser.load_yaml(f)
             self.assertIn('Invalid YAML', str(context.exception))
 
+    def test_load_keyfile(self):
+        parser = libnetplan.Parser()
+        state = libnetplan.State()
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(b'''[connection]
+id=Bridge connection 1
+type=bridge
+uuid=990548be-01ed-42d7-9f9f-cd4966b25c08
+interface-name=bridge0
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+addr-gen-mode=1''')
+            f.seek(0, io.SEEK_SET)
+            parser.load_keyfile(f.name)
+            state.import_parser_results(parser)
+            output = io.StringIO()
+            state.dump_yaml(output)
+            yaml_data = yaml.safe_load(output.getvalue())
+            self.assertIsNotNone(yaml_data.get('network'))
+
 
 class TestState(TestBase):
     def test_get_netdef(self):


### PR DESCRIPTION
## Description

Also, enable the dump_yaml() API to dump the data to a StringIO object.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

