### PR TITLE
Wireguard fixes

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -330,7 +330,6 @@ write_bridge_params(const NetplanNetDefinition* def, GKeyFile *kf)
 static gboolean
 write_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError** error)
 {
-    gchar* tmp_group = NULL;
     g_assert(def->tunnel.private_key);
 
     /* The key was already validated via validate_tunnel_grammar(), but we need
@@ -351,7 +350,7 @@ write_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError** e
     for (guint i = 0; i < def->wireguard_peers->len; i++) {
         NetplanWireguardPeer *peer = g_array_index (def->wireguard_peers, NetplanWireguardPeer*, i);
         g_assert(peer->public_key);
-        tmp_group = g_strdup_printf("wireguard-peer.%s", peer->public_key);
+        g_autofree gchar* tmp_group = g_strdup_printf("wireguard-peer.%s", peer->public_key);
 
         if (peer->keepalive)
             g_key_file_set_integer(kf, tmp_group, "persistent-keepalive", peer->keepalive);
@@ -377,7 +376,6 @@ write_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError** e
                 list[j] = g_array_index(peer->allowed_ips, char*, j);
             g_key_file_set_string_list(kf, tmp_group, "allowed-ips", list, peer->allowed_ips->len);
         }
-        g_free(tmp_group);
     }
     return TRUE;
 }

--- a/src/validation.c
+++ b/src/validation.c
@@ -218,7 +218,7 @@ validate_tunnel_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
             if (peer->preshared_key && peer->preshared_key[0] != '/' && !is_wireguard_key(peer->preshared_key))
                 return yaml_error(npp, node, error, "%s: invalid wireguard shared key", nd->id);
             if (!peer->allowed_ips || peer->allowed_ips->len == 0)
-                return yaml_error(npp, node, error, "%s: 'to' is required to define the allowed IPs.", nd->id);
+                return yaml_error(npp, node, error, "%s: 'allowed-ips' is required for wireguard peers.", nd->id);
             if (peer->keepalive > 65535)
                 return yaml_error(npp, node, error, "%s: keepalive must be 0-65535 inclusive.", nd->id);
         }

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -332,7 +332,7 @@ must be X.X.X.X/NN or X:X:X:X:X:X:X:X/NN", out)
                                            'keepalive': 14,
                                            'endpoint': '1.2.3.4:1005'}], renderer=self.backend)
         out = self.generate(config, expect_fail=True)
-        self.assertIn("Error in network definition: wg0: 'to' is required to define the allowed IPs.", out)
+        self.assertIn("Error in network definition: wg0: 'allowed-ips' is required for wireguard peers.", out)
 
     def test_vxlan_port_range_fail(self):
         out = self.generate('''network:


### PR DESCRIPTION
As #350 became more complex than anticipated, I'm creating a separate PR for the wireguard part.

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

