### PR TITLE
ovs: don't allow peers with the same name

### DIFF
--- a/netplan/cli/commands/apply.py
+++ b/netplan/cli/commands/apply.py
@@ -414,4 +414,4 @@ class NetplanApply(utils.NetplanCommand):
             if exit_on_error:
                 sys.exit(1)
         except OvsDbServerNotRunning as e:
-            logging.warning('Cannot call openvswitch: {}.'.format(e))
+            logging.warning('Cannot call Open vSwitch: {}.'.format(e))

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -50,7 +50,7 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     if (!cleanup) {
         g_string_append_printf(s, "After=netplan-ovs-cleanup.service\n");
     } else {
-        /* The netplan-ovs-cleanup unit shall not run on systems where openvswitch is not installed. */
+        /* The netplan-ovs-cleanup unit shall not run on systems where Open vSwitch is not installed. */
         g_string_append(s, "ConditionFileIsExecutable=" OPENVSWITCH_OVS_VSCTL "\n");
     }
     g_string_append(s, "Before=network.target\nWants=network.target\n");
@@ -221,7 +221,7 @@ write_ovs_bond_mode(const NetplanNetDefinition* def, GString* cmds, GError** err
         append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set Port %s bond_mode=%s", def->id, value);
         write_ovs_tag_setting(def->id, "Port", "bond_mode", NULL, value, cmds);
     } else {
-        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "%s: bond mode '%s' not supported by openvswitch\n",
+        g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "%s: bond mode '%s' not supported by Open vSwitch\n",
                   def->id, def->bond_params.mode);
         return FALSE;
     }
@@ -274,7 +274,7 @@ check_ovs_ssl(const NetplanOVSSettings* settings, gchar* target, gboolean* needs
         /* Check if SSL is configured in settings->ssl */
         if (!settings->ssl.ca_certificate || !settings->ssl.client_certificate ||
             !settings->ssl.client_key) {
-            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: openvswitch bridge controller target '%s' needs SSL configuration, but global 'openvswitch.ssl' settings are not set\n", target);
+            g_set_error(error, G_MARKUP_ERROR, G_MARKUP_ERROR_INVALID_CONTENT, "ERROR: Open vSwitch bridge controller target '%s' needs SSL configuration, but global 'openvswitch.ssl' settings are not set\n", target);
             return FALSE;
         }
         *needs_ssl = TRUE;
@@ -426,7 +426,7 @@ netplan_netdef_write_ovs(const NetplanState* np_state, const NetplanNetDefinitio
                 return FALSE;
             }
         } else {
-            g_debug("openvswitch: definition %s is not for us (backend %i)", def->id, def->backend);
+            g_debug("Open vSwitch: definition %s is not for us (backend %i)", def->id, def->backend);
             SET_OPT_OUT_PTR(has_been_written, FALSE);
             return TRUE;
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -603,7 +603,7 @@ handle_netdef_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, GE
         *dest = ref;
 
         if (netdef->type == NETPLAN_DEF_TYPE_VLAN && ref->backend == NETPLAN_BACKEND_OVS) {
-            g_debug("%s: VLAN defined for openvswitch interface, choosing OVS backend", netdef->id);
+            g_debug("%s: VLAN defined for Open vSwitch interface, choosing OVS backend", netdef->id);
             netdef->backend = NETPLAN_BACKEND_OVS;
         }
     }
@@ -1417,7 +1417,7 @@ handle_bridge_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data
             set_str_if_null(component->bridge, npp->current.netdef->id);
             component->bridge_link = npp->current.netdef;
             if (component->backend == NETPLAN_BACKEND_OVS) {
-                g_debug("%s: Bridge contains openvswitch interface, choosing OVS backend", npp->current.netdef->id);
+                g_debug("%s: Bridge contains Open vSwitch interface, choosing OVS backend", npp->current.netdef->id);
                 npp->current.netdef->backend = NETPLAN_BACKEND_OVS;
             }
         }
@@ -1448,7 +1448,7 @@ handle_bond_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError
     /* Implicitly set NETPLAN_BACKEND_OVS if ovs-only mode selected */
     if (!strcmp(scalar(node), "balance-tcp") ||
         !strcmp(scalar(node), "balance-slb")) {
-        g_debug("%s: mode '%s' only supported with openvswitch, choosing this backend",
+        g_debug("%s: mode '%s' only supported with Open vSwitch, choosing this backend",
                 npp->current.netdef->id, scalar(node));
         npp->current.netdef->backend = NETPLAN_BACKEND_OVS;
     }
@@ -1482,7 +1482,7 @@ handle_bond_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data, 
             component->bond = g_strdup(npp->current.netdef->id);
             component->bond_link = npp->current.netdef;
             if (component->backend == NETPLAN_BACKEND_OVS) {
-                g_debug("%s: Bond contains openvswitch interface, choosing OVS backend", npp->current.netdef->id);
+                g_debug("%s: Bond contains Open vSwitch interface, choosing OVS backend", npp->current.netdef->id);
                 npp->current.netdef->backend = NETPLAN_BACKEND_OVS;
             }
         }
@@ -2478,7 +2478,7 @@ static gboolean
 handle_ovs_bond_lacp(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BOND)
-        return yaml_error(npp, node, error, "Key 'lacp' is only valid for interface type 'openvswitch bond'");
+        return yaml_error(npp, node, error, "Key 'lacp' is only valid for interface type 'Open vSwitch bond'");
 
     if (g_strcmp0(scalar(node), "active") && g_strcmp0(scalar(node), "passive") && g_strcmp0(scalar(node), "off"))
         return yaml_error(npp, node, error, "Value of 'lacp' needs to be 'active', 'passive' or 'off");
@@ -2490,7 +2490,7 @@ static gboolean
 handle_ovs_bridge_bool(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
-        return yaml_error(npp, node, error, "Key is only valid for interface type 'openvswitch bridge'");
+        return yaml_error(npp, node, error, "Key is only valid for interface type 'Open vSwitch bridge'");
 
     return handle_netdef_bool(npp, node, data, error);
 }
@@ -2499,7 +2499,7 @@ static gboolean
 handle_ovs_bridge_fail_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
-        return yaml_error(npp, node, error, "Key 'fail-mode' is only valid for interface type 'openvswitch bridge'");
+        return yaml_error(npp, node, error, "Key 'fail-mode' is only valid for interface type 'Open vSwitch bridge'");
 
     if (g_strcmp0(scalar(node), "standalone") && g_strcmp0(scalar(node), "secure"))
         return yaml_error(npp, node, error, "Value of 'fail-mode' needs to be 'standalone' or 'secure'");
@@ -2523,7 +2523,7 @@ handle_ovs_protocol(NetplanParser* npp, yaml_node_t* node, void* entryptr, const
         assert_type(npp, entry, YAML_SCALAR_NODE);
 
         if (!g_strcmp0(scalar(entry), deprecated[0])) {
-            g_warning("openvswitch: Ignoring deprecated protocol: %s", scalar(entry));
+            g_warning("Open vSwitch: Ignoring deprecated protocol: %s", scalar(entry));
             continue;
         }
 
@@ -2551,7 +2551,7 @@ static gboolean
 handle_ovs_bridge_protocol(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
-        return yaml_error(npp, node, error, "Key 'protocols' is only valid for interface type 'openvswitch bridge'");
+        return yaml_error(npp, node, error, "Key 'protocols' is only valid for interface type 'Open vSwitch bridge'");
 
     return handle_ovs_protocol(npp, node, npp->current.netdef, data, error);
 }
@@ -2560,7 +2560,7 @@ static gboolean
 handle_ovs_bridge_controller_connection_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
-        return yaml_error(npp, node, error, "Key 'controller.connection-mode' is only valid for interface type 'openvswitch bridge'");
+        return yaml_error(npp, node, error, "Key 'controller.connection-mode' is only valid for interface type 'Open vSwitch bridge'");
 
     if (g_strcmp0(scalar(node), "in-band") && g_strcmp0(scalar(node), "out-of-band"))
         return yaml_error(npp, node, error, "Value of 'connection-mode' needs to be 'in-band' or 'out-of-band'");
@@ -2572,7 +2572,7 @@ static gboolean
 handle_ovs_bridge_controller_addresses(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
-        return yaml_error(npp, node, error, "Key 'controller.addresses' is only valid for interface type 'openvswitch bridge'");
+        return yaml_error(npp, node, error, "Key 'controller.addresses' is only valid for interface type 'Open vSwitch bridge'");
 
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         gchar** vec = NULL;
@@ -2918,7 +2918,7 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
         item = pair->data.sequence.items.start;
         /* A peer port definition must contain exactly 2 ports */
         if (item+2 != pair->data.sequence.items.top) {
-            return yaml_error(npp, pair, error, "An openvswitch peer port sequence must have exactly two entries");
+            return yaml_error(npp, pair, error, "An Open vSwitch peer port sequence must have exactly two entries");
         }
 
         port = yaml_document_get_node(&npp->doc, *item);
@@ -2945,7 +2945,7 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
         }
 
         if (component1->peer && g_strcmp0(component1->peer, scalar(peer)))
-            return yaml_error(npp, port, error, "openvswitch port '%s' is already assigned to peer '%s'",
+            return yaml_error(npp, port, error, "Open vSwitch port '%s' is already assigned to peer '%s'",
                               component1->id, component1->peer);
 
         /* Create port 2 (peer) netdef */
@@ -2964,7 +2964,7 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
         }
 
         if (component2->peer && g_strcmp0(component2->peer, scalar(port)))
-            return yaml_error(npp, peer, error, "openvswitch port '%s' is already assigned to peer '%s'",
+            return yaml_error(npp, peer, error, "Open vSwitch port '%s' is already assigned to peer '%s'",
                               component2->id, component2->peer);
 
         component1->peer = g_strdup(scalar(peer));

--- a/src/parse.c
+++ b/src/parse.c
@@ -2926,6 +2926,9 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
         peer = yaml_document_get_node(&npp->doc, *(item+1));
         assert_type(npp, peer, YAML_SCALAR_NODE);
 
+        if (!g_strcmp0(scalar(port), scalar(peer)))
+            return yaml_error(npp, peer, error, "Open vSwitch patch ports must be of different name");
+
         /* Create port 1 netdef */
         component1 = npp->parsed_defs ? g_hash_table_lookup(npp->parsed_defs, scalar(port)) : NULL;
         if (!component1) {

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -1095,3 +1095,12 @@ ExecStart=/usr/bin/ovs-vsctl set-controller br123 tcp:127.0.0.1:6653\n\
 ExecStart=/usr/bin/ovs-vsctl set Bridge br123 external-ids:netplan/global/set-controller=tcp:127.0.0.1:6653\n\
 ')},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+
+    def test_both_ports_with_same_name(self):
+        err = self.generate('''network:
+    version: 2
+    openvswitch:
+      ports:
+        - [portname, portname]
+''', expect_fail=True)
+        self.assertIn('Open vSwitch patch ports must be of different name', err)

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -129,7 +129,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/other-confi
   bridges:
     ovs0:
       openvswitch: {}''', skip_generated_yaml_validation=True)  # OpenFlow16 won't be re-generated
-        self.assertIn('openvswitch: Ignoring deprecated protocol: OpenFlow16', out)
+        self.assertIn('Open vSwitch: Ignoring deprecated protocol: OpenFlow16', out)
         self.assert_ovs({'ovs0.service': OVS_VIRTUAL % {'iface': 'ovs0', 'extra': '''
 [Service]
 Type=oneshot
@@ -300,7 +300,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=active
       openvswitch:
         lacp: passive
 ''', expect_fail=True)
-        self.assertIn("Key 'lacp' is only valid for interface type 'openvswitch bond'", err)
+        self.assertIn("Key 'lacp' is only valid for interface type 'Open vSwitch bond'", err)
 
     def test_bond_mode_implicit_params(self):
         self.generate('''network:
@@ -399,7 +399,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode=activ
       interfaces: [bond0]
       openvswitch: {}
 ''', expect_fail=True)
-        self.assertIn("bond0: bond mode 'balance-rr' not supported by openvswitch", err)
+        self.assertIn("bond0: bond mode 'balance-rr' not supported by Open vSwitch", err)
 
     def test_bridge_setup(self):
         self.generate('''network:
@@ -509,7 +509,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/rstp_enable=tru
       openvswitch:
         fail-mode: glorious
 ''', expect_fail=True)
-        self.assertIn("Key 'fail-mode' is only valid for interface type 'openvswitch bridge'", err)
+        self.assertIn("Key 'fail-mode' is only valid for interface type 'Open vSwitch bridge'", err)
 
     def test_rstp_non_bridge(self):
         err = self.generate('''network:
@@ -519,7 +519,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/rstp_enable=tru
       openvswitch:
         rstp: true
 ''', expect_fail=True)
-        self.assertIn("Key is only valid for interface type 'openvswitch bridge'", err)
+        self.assertIn("Key is only valid for interface type 'Open vSwitch bridge'", err)
 
     def test_bridge_set_protocols(self):
         self.generate('''network:
@@ -561,7 +561,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/protocols=OpenF
       openvswitch:
         protocols: [OpenFlow10, OpenFlow15]
 ''', expect_fail=True)
-        self.assertIn("Key 'protocols' is only valid for interface type 'openvswitch bridge'", err)
+        self.assertIn("Key 'protocols' is only valid for interface type 'Open vSwitch bridge'", err)
 
     def test_bridge_controller(self):
         self.generate('''network:
@@ -666,7 +666,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
         controller:
           connection-mode: in-band
 ''', expect_fail=True)
-        self.assertIn("Key 'controller.connection-mode' is only valid for interface type 'openvswitch bridge'", err)
+        self.assertIn("Key 'controller.connection-mode' is only valid for interface type 'Open vSwitch bridge'", err)
         self.assert_ovs({})
         self.assert_networkd({})
 
@@ -679,7 +679,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
         controller:
           addresses: [unix:/some/socket]
 ''', expect_fail=True)
-        self.assertIn("Key 'controller.addresses' is only valid for interface type 'openvswitch bridge'", err)
+        self.assertIn("Key 'controller.addresses' is only valid for interface type 'Open vSwitch bridge'", err)
         self.assert_ovs({})
         self.assert_networkd({})
 
@@ -714,7 +714,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
   openvswitch:
     ssl: {}
 ''', expect_fail=True)
-        self.assertIn("ERROR: openvswitch bridge controller target 'ssl:10.10.10.1' needs SSL configuration, but global \
+        self.assertIn("ERROR: Open vSwitch bridge controller target 'ssl:10.10.10.1' needs SSL configuration, but global \
 'openvswitch.ssl' settings are not set", err)
         self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({})
@@ -737,7 +737,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
     ports:
       - [patch0-1]
 ''', expect_fail=True)
-        self.assertIn("An openvswitch peer port sequence must have exactly two entries", err)
+        self.assertIn("An Open vSwitch peer port sequence must have exactly two entries", err)
         self.assertIn("- [patch0-1]", err)
         self.assert_ovs({})
         self.assert_networkd({})
@@ -749,7 +749,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
     ports:
       - [patch0-1, "patchx", patchy]
 ''', expect_fail=True)
-        self.assertIn("An openvswitch peer port sequence must have exactly two entries", err)
+        self.assertIn("An Open vSwitch peer port sequence must have exactly two entries", err)
         self.assertIn("- [patch0-1, \"patchx\", patchy]", err)
         self.assert_ovs({})
         self.assert_networkd({})
@@ -762,7 +762,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
       - [patchx, patchy]
       - [patchx, patchz]
 ''', expect_fail=True)
-        self.assertIn("openvswitch port 'patchx' is already assigned to peer 'patchy'", err)
+        self.assertIn("Open vSwitch port 'patchx' is already assigned to peer 'patchy'", err)
         self.assert_ovs({})
         self.assert_networkd({})
 
@@ -774,7 +774,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
       - [patchx, patchy]
       - [patchz, patchx]
 ''', expect_fail=True)
-        self.assertIn("openvswitch port 'patchx' is already assigned to peer 'patchy'", err)
+        self.assertIn("Open vSwitch port 'patchx' is already assigned to peer 'patchy'", err)
         self.assert_ovs({})
         self.assert_networkd({})
 

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -471,7 +471,7 @@ class _CommonTests():
         p = subprocess.Popen(['netplan', 'apply'], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, text=True)
         (_, err) = p.communicate()
-        self.assertIn('Cannot call openvswitch: ovsdb-server.service is not running.', err)
+        self.assertIn('Cannot call Open vSwitch: ovsdb-server.service is not running.', err)
         self.assertEqual(p.returncode, 0)
 
     def test_settings_tag_cleanup(self):


### PR DESCRIPTION
I found it thanks to a memory leak. If both peers have the same name, the netdef will end up with a `netdef->peer_link` pointing to itself and `netdef->link` strdup'ed twice. 

## Description

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

