### PR TITLE
doc: make us of sphinx copybutton plugin

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ author = 'Netplan team'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx_design', 'myst_parser']
+extensions = ['sphinx_design', 'myst_parser', 'sphinx_copybutton']
 myst_enable_extensions = ["colon_fence"]
 smartquotes_action = 'qe'
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,3 +5,4 @@ sphinxcontrib-spelling
 sphinx-autobuild
 pyenchant
 myst-parser
+sphinx-copybutton


### PR DESCRIPTION
## Description
This plugin will allow our YAML examples to be easily copied by the reader of our documentation.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

