### PR TITLE
rtd: set the OS and Python versions explicitly

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and environment
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 # Build documentation in the doc/ directory with Sphinx
 sphinx:
   configuration: doc/conf.py


### PR DESCRIPTION
The RTD build is failing due to a new version of urllib3. According to [1], this change should fix the problem.

[1] - https://github.com/readthedocs/readthedocs.org/issues/10290


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

