### PR TITLE
Fix 8021x eap method parsing (LP: #2016625)

### DIFF
--- a/tools/keyfile_to_yaml.py
+++ b/tools/keyfile_to_yaml.py
@@ -1,0 +1,28 @@
+# A simple tool to convert a Network Manager keyfile to Netplan YAML
+# How to use:
+#   From the Netplan source directory, run:
+#     PYTHONPATH=. python3 tools/keyfile_to_yaml.py path/to/the/file.nmconnection
+
+import io
+import sys
+
+from netplan import libnetplan
+
+if len(sys.argv) < 2:
+    print("Pass the NM keyfile as parameter")
+    sys.exit(1)
+
+parser = libnetplan.Parser()
+state = libnetplan.State()
+
+try:
+    parser.load_keyfile(sys.argv[1])
+    state.import_parser_results(parser)
+except Exception as e:
+    print(e)
+    sys.exit(1)
+
+output = io.StringIO()
+state.dump_yaml(output)
+
+print(output.getvalue())


### PR DESCRIPTION
## Description

See [LP: #2016625](https://bugs.launchpad.net/netplan/+bug/2016625) for more details.

I'm also including a little tool that was useful during investigation and tests.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

