### PR TITLE
CI: update canonical/setup-lxd to v0.1.1

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -19,7 +19,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       # Setup LXD + Docker fixes
-      - uses: canonical/setup-lxd@v0.1.0
+      - uses: canonical/setup-lxd@v0.1.1
         with:
           channel: latest/stable  # switch from distro's LTS channel to latest/stable
       - run: |

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -10,7 +10,7 @@ jobs:
   spread:
     runs-on: ubuntu-latest
     steps:
-      - uses: canonical/setup-lxd@ea57509243d3cf39f8ab926e021bb353947b01b5
+      - uses: canonical/setup-lxd@v0.1.1
       - uses: actions/checkout@v2
       - name: Install spread
         run: |


### PR DESCRIPTION
There is a bug in canonical/setup-lxd@v0.1.0 where the `channel` input is ignored. This has been fixed in v0.1.1. See https://github.com/canonical/setup-lxd/pull/8