### PR TITLE
keyfile parser: add support for all tunnel types (LP: #2016473)

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1564,9 +1564,8 @@ The specific settings for tunnels are defined below.
 - **mode** (scalar)
 
   > Defines the tunnel mode. Valid options are `sit`, `gre`, `ip6gre`,
-  > `ipip`, `ipip6`, `ip6ip6`, `vti`, `vti6`, `wireguard` and `vxlan`.
-  > Additionally, the `networkd` backend also supports `gretap` and
-  > `ip6gretap` modes.
+  > `ipip`, `ipip6`, `ip6ip6`, `vti`, `vti6`, `wireguard`, `vxlan`,
+  > `gretap` and `ip6gretap` modes.
   > In addition, the `NetworkManager` backend supports `isatap` tunnels.
 
 - **local** (scalar)

--- a/src/abi.h
+++ b/src/abi.h
@@ -91,12 +91,13 @@ typedef enum {
     NETPLAN_TUNNEL_MODE_IPIP6       = 7,
     NETPLAN_TUNNEL_MODE_IP6GRE      = 8,
     NETPLAN_TUNNEL_MODE_VTI6        = 9,
-    NETPLAN_TUNNEL_MODE_VXLAN       = 10,
+    NETPLAN_TUNNEL_MODE_GRETAP      = 10,
+    NETPLAN_TUNNEL_MODE_IP6GRETAP   = 11,
+    /* "ip-tunnel" modes supported by Network Manager end here */
+    NETPLAN_TUNNEL_MODE_NM_MAX      = 12,
 
-    /* systemd-only, apparently? */
-    NETPLAN_TUNNEL_MODE_GRETAP      = 101,
-    NETPLAN_TUNNEL_MODE_IP6GRETAP   = 102,
-    NETPLAN_TUNNEL_MODE_WIREGUARD   = 103,
+    NETPLAN_TUNNEL_MODE_VXLAN       = 100,
+    NETPLAN_TUNNEL_MODE_WIREGUARD   = 101,
 
     NETPLAN_TUNNEL_MODE_MAX_,
 } NetplanTunnelMode;

--- a/src/names.c
+++ b/src/names.c
@@ -81,9 +81,9 @@ netplan_tunnel_mode_to_str[NETPLAN_TUNNEL_MODE_MAX_] = {
     [NETPLAN_TUNNEL_MODE_IPIP6] = "ipip6",
     [NETPLAN_TUNNEL_MODE_IP6GRE] = "ip6gre",
     [NETPLAN_TUNNEL_MODE_VTI6] = "vti6",
-    [NETPLAN_TUNNEL_MODE_VXLAN] = "vxlan",
     [NETPLAN_TUNNEL_MODE_GRETAP] = "gretap",
     [NETPLAN_TUNNEL_MODE_IP6GRETAP] = "ip6gretap",
+    [NETPLAN_TUNNEL_MODE_VXLAN] = "vxlan",
     [NETPLAN_TUNNEL_MODE_WIREGUARD] = "wireguard",
 };
 

--- a/src/nm.c
+++ b/src/nm.c
@@ -511,7 +511,7 @@ write_vxlan_parameters(const NetplanNetDefinition* def, GKeyFile* kf)
         }
     }
 
-    if (def->vxlan->checksums || def->vxlan->extensions || def->vxlan->flow_label != G_MAXUINT || def->vxlan->do_not_fragment)
+    if (def->vxlan->checksums || def->vxlan->extensions || def->vxlan->flow_label != G_MAXUINT || def->vxlan->do_not_fragment != NETPLAN_TRISTATE_UNSET)
         g_warning("%s: checksums/extensions/flow-lable/do-not-fragment are not supported by NetworkManager\n", def->id);
 }
 

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -112,7 +112,7 @@ set_true_on_match(GKeyFile* kf, const gchar* group, const gchar* key, const gcha
 }
 
 static void
-handle_generic_bool(GKeyFile* kf, const gchar* group, const gchar* key, gboolean* dataptr)
+keyfile_handle_generic_bool(GKeyFile* kf, const gchar* group, const gchar* key, gboolean* dataptr)
 {
     g_assert(dataptr);
     *dataptr = g_key_file_get_boolean(kf, group, key, NULL);
@@ -120,7 +120,7 @@ handle_generic_bool(GKeyFile* kf, const gchar* group, const gchar* key, gboolean
 }
 
 static void
-handle_generic_str(GKeyFile* kf, const gchar* group, const gchar* key, char** dataptr)
+keyfile_handle_generic_str(GKeyFile* kf, const gchar* group, const gchar* key, char** dataptr)
 {
     g_assert(dataptr);
     g_assert(!*dataptr);
@@ -130,7 +130,7 @@ handle_generic_str(GKeyFile* kf, const gchar* group, const gchar* key, char** da
 }
 
 static void
-handle_generic_uint(GKeyFile* kf, const gchar* group, const gchar* key, guint* dataptr, guint default_value)
+keyfile_handle_generic_uint(GKeyFile* kf, const gchar* group, const gchar* key, guint* dataptr, guint default_value)
 {
     g_assert(dataptr);
     if (g_key_file_has_key(kf, group, key, NULL)) {
@@ -142,16 +142,16 @@ handle_generic_uint(GKeyFile* kf, const gchar* group, const gchar* key, guint* d
 }
 
 static void
-handle_common(GKeyFile* kf, NetplanNetDefinition* nd, const gchar* group) {
-    handle_generic_str(kf, group, "cloned-mac-address", &nd->set_mac);
-    handle_generic_uint(kf, group, "mtu", &nd->mtubytes, NETPLAN_MTU_UNSPEC);
-    handle_generic_str(kf, group, "mac-address", &nd->match.mac);
+keyfile_handle_common(GKeyFile* kf, NetplanNetDefinition* nd, const gchar* group) {
+    keyfile_handle_generic_str(kf, group, "cloned-mac-address", &nd->set_mac);
+    keyfile_handle_generic_uint(kf, group, "mtu", &nd->mtubytes, NETPLAN_MTU_UNSPEC);
+    keyfile_handle_generic_str(kf, group, "mac-address", &nd->match.mac);
     if (nd->match.mac)
         nd->has_match = TRUE;
 }
 
 static void
-handle_bridge_uint(GKeyFile* kf, const gchar* key, NetplanNetDefinition* nd, char** dataptr) {
+keyfile_handle_bridge_uint(GKeyFile* kf, const gchar* key, NetplanNetDefinition* nd, char** dataptr) {
     if (g_key_file_get_uint64(kf, "bridge", key, NULL)) {
         nd->custom_bridging = TRUE;
         *dataptr = g_strdup_printf("%"G_GUINT64_FORMAT, g_key_file_get_uint64(kf, "bridge", key, NULL));
@@ -307,7 +307,7 @@ parse_dhcp_overrides(GKeyFile* kf, const gchar* group, NetplanDHCPOverrides* dat
         _kf_clear_key(kf, group, "ignore-auto-routes");
         _kf_clear_key(kf, group, "never-default");
     }
-    handle_generic_uint(kf, group, "route-metric", &(*dataptr).metric, NETPLAN_METRIC_UNSPEC);
+    keyfile_handle_generic_uint(kf, group, "route-metric", &(*dataptr).metric, NETPLAN_METRIC_UNSPEC);
 }
 
 /*
@@ -388,15 +388,15 @@ parse_dot1x_auth(GKeyFile* kf, NetplanAuthenticationSettings* auth)
         g_strfreev(split);
     }
 
-    handle_generic_str(kf, "802-1x", "identity", &auth->identity);
-    handle_generic_str(kf, "802-1x", "anonymous-identity", &auth->anonymous_identity);
+    keyfile_handle_generic_str(kf, "802-1x", "identity", &auth->identity);
+    keyfile_handle_generic_str(kf, "802-1x", "anonymous-identity", &auth->anonymous_identity);
     if (!auth->password)
-        handle_generic_str(kf, "802-1x", "password", &auth->password);
-    handle_generic_str(kf, "802-1x", "ca-cert", &auth->ca_certificate);
-    handle_generic_str(kf, "802-1x", "client-cert", &auth->client_certificate);
-    handle_generic_str(kf, "802-1x", "private-key", &auth->client_key);
-    handle_generic_str(kf, "802-1x", "private-key-password", &auth->client_key_password);
-    handle_generic_str(kf, "802-1x", "phase2-auth", &auth->phase2_auth);
+        keyfile_handle_generic_str(kf, "802-1x", "password", &auth->password);
+    keyfile_handle_generic_str(kf, "802-1x", "ca-cert", &auth->ca_certificate);
+    keyfile_handle_generic_str(kf, "802-1x", "client-cert", &auth->client_certificate);
+    keyfile_handle_generic_str(kf, "802-1x", "private-key", &auth->client_key);
+    keyfile_handle_generic_str(kf, "802-1x", "private-key-password", &auth->client_key_password);
+    keyfile_handle_generic_str(kf, "802-1x", "phase2-auth", &auth->phase2_auth);
 }
 
 static void
@@ -679,8 +679,8 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
     parse_addresses(kf, "ipv6", &nd->ip6_addresses);
 
     /* Default gateways */
-    handle_generic_str(kf, "ipv4", "gateway", &nd->gateway4);
-    handle_generic_str(kf, "ipv6", "gateway", &nd->gateway6);
+    keyfile_handle_generic_str(kf, "ipv4", "gateway", &nd->gateway4);
+    keyfile_handle_generic_str(kf, "ipv6", "gateway", &nd->gateway6);
 
     /* Routes */
     parse_routes(kf, "ipv4", &nd->routes);
@@ -706,7 +706,7 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
         }
     }
     g_free(tmp_str);
-    handle_generic_str(kf, "ipv6", "token", &nd->ip6_addr_gen_token);
+    keyfile_handle_generic_str(kf, "ipv6", "token", &nd->ip6_addr_gen_token);
 
     /* ip6-privacy is not fully supported, NM supports additional modes, like -1 or 1
      * handle known modes, but keep any unsupported "ip6-privacy" value in passthrough */
@@ -728,26 +728,26 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
      * combines them as "modems". We need to parse a basic set of parameters
      * to enable the generator (in nm.c) to detect GSM vs CDMA connections,
      * using its modem_is_gsm() util. */
-    handle_generic_bool(kf, "gsm", "auto-config", &nd->modem_params.auto_config);
-    handle_generic_str(kf, "gsm", "apn", &nd->modem_params.apn);
-    handle_generic_str(kf, "gsm", "device-id", &nd->modem_params.device_id);
-    handle_generic_str(kf, "gsm", "network-id", &nd->modem_params.network_id);
-    handle_generic_str(kf, "gsm", "pin", &nd->modem_params.pin);
-    handle_generic_str(kf, "gsm", "sim-id", &nd->modem_params.sim_id);
-    handle_generic_str(kf, "gsm", "sim-operator-id", &nd->modem_params.sim_operator_id);
+    keyfile_handle_generic_bool(kf, "gsm", "auto-config", &nd->modem_params.auto_config);
+    keyfile_handle_generic_str(kf, "gsm", "apn", &nd->modem_params.apn);
+    keyfile_handle_generic_str(kf, "gsm", "device-id", &nd->modem_params.device_id);
+    keyfile_handle_generic_str(kf, "gsm", "network-id", &nd->modem_params.network_id);
+    keyfile_handle_generic_str(kf, "gsm", "pin", &nd->modem_params.pin);
+    keyfile_handle_generic_str(kf, "gsm", "sim-id", &nd->modem_params.sim_id);
+    keyfile_handle_generic_str(kf, "gsm", "sim-operator-id", &nd->modem_params.sim_operator_id);
 
     /* GSM & CDMA */
-    handle_generic_uint(kf, "cdma", "mtu", &nd->mtubytes, NETPLAN_MTU_UNSPEC);
-    handle_generic_uint(kf, "gsm", "mtu", &nd->mtubytes, NETPLAN_MTU_UNSPEC);
-    handle_generic_str(kf, "gsm", "number", &nd->modem_params.number);
+    keyfile_handle_generic_uint(kf, "cdma", "mtu", &nd->mtubytes, NETPLAN_MTU_UNSPEC);
+    keyfile_handle_generic_uint(kf, "gsm", "mtu", &nd->mtubytes, NETPLAN_MTU_UNSPEC);
+    keyfile_handle_generic_str(kf, "gsm", "number", &nd->modem_params.number);
     if (!nd->modem_params.number)
-        handle_generic_str(kf, "cdma", "number", &nd->modem_params.number);
-    handle_generic_str(kf, "gsm", "password", &nd->modem_params.password);
+        keyfile_handle_generic_str(kf, "cdma", "number", &nd->modem_params.number);
+    keyfile_handle_generic_str(kf, "gsm", "password", &nd->modem_params.password);
     if (!nd->modem_params.password)
-        handle_generic_str(kf, "cdma", "password", &nd->modem_params.password);
-    handle_generic_str(kf, "gsm", "username", &nd->modem_params.username);
+        keyfile_handle_generic_str(kf, "cdma", "password", &nd->modem_params.password);
+    keyfile_handle_generic_str(kf, "gsm", "username", &nd->modem_params.username);
     if (!nd->modem_params.username)
-        handle_generic_str(kf, "cdma", "username", &nd->modem_params.username);
+        keyfile_handle_generic_str(kf, "cdma", "username", &nd->modem_params.username);
 
     /* Ethernets */
     if (g_key_file_has_group(kf, "ethernet")) {
@@ -764,7 +764,7 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
                 _kf_clear_key(kf, "ethernet", "wake-on-lan"); // value "off" is supported
         }
 
-        handle_common(kf, nd, "ethernet");
+        keyfile_handle_common(kf, nd, "ethernet");
     }
 
     /* Wifis */
@@ -776,7 +776,7 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
             nd->wowlan = NETPLAN_WIFI_WOWLAN_DEFAULT;
         }
 
-        handle_common(kf, nd, "wifi");
+        keyfile_handle_common(kf, nd, "wifi");
     }
 
     /* Cleanup some implicit keys */
@@ -795,48 +795,48 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
     g_free(tmp_str);
 
     /* Vlan: XXX: find a way to parse the "link:" (parent) connection */
-    handle_generic_uint(kf, "vlan", "id", &nd->vlan_id, G_MAXUINT);
+    keyfile_handle_generic_uint(kf, "vlan", "id", &nd->vlan_id, G_MAXUINT);
 
     /* Bridge: XXX: find a way to parse the bridge-port.priority & bridge-port.path-cost values */
-    handle_generic_uint(kf, "bridge", "priority", &nd->bridge_params.priority, 0);
+    keyfile_handle_generic_uint(kf, "bridge", "priority", &nd->bridge_params.priority, 0);
     if (nd->bridge_params.priority)
         nd->custom_bridging = TRUE;
-    handle_bridge_uint(kf, "ageing-time", nd, &nd->bridge_params.ageing_time);
-    handle_bridge_uint(kf, "hello-time", nd, &nd->bridge_params.hello_time);
-    handle_bridge_uint(kf, "forward-delay", nd, &nd->bridge_params.forward_delay);
-    handle_bridge_uint(kf, "max-age", nd, &nd->bridge_params.max_age);
+    keyfile_handle_bridge_uint(kf, "ageing-time", nd, &nd->bridge_params.ageing_time);
+    keyfile_handle_bridge_uint(kf, "hello-time", nd, &nd->bridge_params.hello_time);
+    keyfile_handle_bridge_uint(kf, "forward-delay", nd, &nd->bridge_params.forward_delay);
+    keyfile_handle_bridge_uint(kf, "max-age", nd, &nd->bridge_params.max_age);
     /* STP needs to be handled last, for its different default value in custom_bridging mode */
     if (g_key_file_has_key(kf, "bridge", "stp", NULL)) {
         nd->custom_bridging = TRUE;
-        handle_generic_bool(kf, "bridge", "stp", &nd->bridge_params.stp);
+        keyfile_handle_generic_bool(kf, "bridge", "stp", &nd->bridge_params.stp);
     } else if(nd->custom_bridging) {
         nd->bridge_params.stp = TRUE; //set default value if not specified otherwise
     }
 
     /* Bonds */
-    handle_generic_str(kf, "bond", "mode", &nd->bond_params.mode);
-    handle_generic_str(kf, "bond", "lacp_rate", &nd->bond_params.lacp_rate);
-    handle_generic_str(kf, "bond", "miimon", &nd->bond_params.monitor_interval);
-    handle_generic_str(kf, "bond", "xmit_hash_policy", &nd->bond_params.transmit_hash_policy);
-    handle_generic_str(kf, "bond", "ad_select", &nd->bond_params.selection_logic);
-    handle_generic_str(kf, "bond", "arp_interval", &nd->bond_params.arp_interval);
-    handle_generic_str(kf, "bond", "arp_validate", &nd->bond_params.arp_validate);
-    handle_generic_str(kf, "bond", "arp_all_targets", &nd->bond_params.arp_all_targets);
-    handle_generic_str(kf, "bond", "updelay", &nd->bond_params.up_delay);
-    handle_generic_str(kf, "bond", "downdelay", &nd->bond_params.down_delay);
-    handle_generic_str(kf, "bond", "fail_over_mac", &nd->bond_params.fail_over_mac_policy);
-    handle_generic_str(kf, "bond", "primary_reselect", &nd->bond_params.primary_reselect_policy);
-    handle_generic_str(kf, "bond", "lp_interval", &nd->bond_params.learn_interval);
-    handle_generic_str(kf, "bond", "primary", &nd->bond_params.primary_member);
-    handle_generic_uint(kf, "bond", "min_links", &nd->bond_params.min_links, 0);
-    handle_generic_uint(kf, "bond", "resend_igmp", &nd->bond_params.resend_igmp, 0);
-    handle_generic_uint(kf, "bond", "packets_per_slave", &nd->bond_params.packets_per_member, 0); /* wokeignore:rule=slave */
-    handle_generic_uint(kf, "bond", "num_grat_arp", &nd->bond_params.gratuitous_arp, 0);
+    keyfile_handle_generic_str(kf, "bond", "mode", &nd->bond_params.mode);
+    keyfile_handle_generic_str(kf, "bond", "lacp_rate", &nd->bond_params.lacp_rate);
+    keyfile_handle_generic_str(kf, "bond", "miimon", &nd->bond_params.monitor_interval);
+    keyfile_handle_generic_str(kf, "bond", "xmit_hash_policy", &nd->bond_params.transmit_hash_policy);
+    keyfile_handle_generic_str(kf, "bond", "ad_select", &nd->bond_params.selection_logic);
+    keyfile_handle_generic_str(kf, "bond", "arp_interval", &nd->bond_params.arp_interval);
+    keyfile_handle_generic_str(kf, "bond", "arp_validate", &nd->bond_params.arp_validate);
+    keyfile_handle_generic_str(kf, "bond", "arp_all_targets", &nd->bond_params.arp_all_targets);
+    keyfile_handle_generic_str(kf, "bond", "updelay", &nd->bond_params.up_delay);
+    keyfile_handle_generic_str(kf, "bond", "downdelay", &nd->bond_params.down_delay);
+    keyfile_handle_generic_str(kf, "bond", "fail_over_mac", &nd->bond_params.fail_over_mac_policy);
+    keyfile_handle_generic_str(kf, "bond", "primary_reselect", &nd->bond_params.primary_reselect_policy);
+    keyfile_handle_generic_str(kf, "bond", "lp_interval", &nd->bond_params.learn_interval);
+    keyfile_handle_generic_str(kf, "bond", "primary", &nd->bond_params.primary_member);
+    keyfile_handle_generic_uint(kf, "bond", "min_links", &nd->bond_params.min_links, 0);
+    keyfile_handle_generic_uint(kf, "bond", "resend_igmp", &nd->bond_params.resend_igmp, 0);
+    keyfile_handle_generic_uint(kf, "bond", "packets_per_slave", &nd->bond_params.packets_per_member, 0); /* wokeignore:rule=slave */
+    keyfile_handle_generic_uint(kf, "bond", "num_grat_arp", &nd->bond_params.gratuitous_arp, 0);
     /* num_unsol_na might overwrite num_grat_arp, but we're fine if they are equal:
      * https://github.com/NetworkManager/NetworkManager/commit/42b0bef33c77a0921590b2697f077e8ea7805166 */
     if (g_key_file_get_uint64(kf, "bond", "num_unsol_na", NULL) == nd->bond_params.gratuitous_arp)
         _kf_clear_key(kf, "bond", "num_unsol_na");
-    handle_generic_bool(kf, "bond", "all_slaves_active", &nd->bond_params.all_members_active); /* wokeignore:rule=slave */
+    keyfile_handle_generic_bool(kf, "bond", "all_slaves_active", &nd->bond_params.all_members_active); /* wokeignore:rule=slave */
     parse_bond_arp_ip_targets(kf, &nd->bond_params.arp_ip_targets);
 
     /* Special handling for WiFi "access-points:" mapping */
@@ -864,8 +864,8 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
         }
         g_free(tmp_str);
 
-        handle_generic_bool(kf, "wifi", "hidden", &ap->hidden);
-        handle_generic_str(kf, "wifi", "bssid", &ap->bssid);
+        keyfile_handle_generic_bool(kf, "wifi", "hidden", &ap->hidden);
+        keyfile_handle_generic_str(kf, "wifi", "bssid", &ap->bssid);
 
         /* Wifi band & channel */
         tmp_str = g_key_file_get_string(kf, "wifi", "band", NULL);
@@ -877,7 +877,7 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
             _kf_clear_key(kf, "wifi", "band");
         }
         g_free(tmp_str);
-        handle_generic_uint(kf, "wifi", "channel", &ap->channel, 0);
+        keyfile_handle_generic_uint(kf, "wifi", "channel", &ap->channel, 0);
 
         /* Wifi security */
         tmp_str = g_key_file_get_string(kf, "wifi-security", "key-mgmt", NULL);
@@ -896,7 +896,7 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
         }
         g_free(tmp_str);
 
-        handle_generic_str(kf, "wifi-security", "psk", &ap->auth.password);
+        keyfile_handle_generic_str(kf, "wifi-security", "psk", &ap->auth.password);
         if (ap->auth.password)
             ap->has_auth = TRUE;
 

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -450,7 +450,7 @@ read_passthrough(GKeyFile* kf, GData** list)
                 }
                 group_key = g_strconcat(groups[i], ".", keys[j], NULL);
                 g_datalist_set_data_full(list, group_key, value, g_free);
-                /* no need to free group_key and value: they stay in the list */
+                g_free(group_key);
             }
             g_strfreev(keys);
         }

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -921,8 +921,6 @@ only_passthrough:
         read_passthrough(kf, &nd->backend_settings.passthrough);
     }
 
-    g_key_file_free(kf);
-
     /* validate definition-level conditions */
     if (!npp->missing_id)
         npp->missing_id = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, g_free);

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -51,10 +51,9 @@ type_from_str(const char* type_str)
     else if (!g_strcmp0(type_str, "vlan"))
         return NETPLAN_DEF_TYPE_VLAN;
     */
-    /* TODO: Tunnels are not yet supported by the keyfile parser
-    else if (!g_strcmp0(type_str, "ip-tunnel") || !g_strcmp0(type_str, "wireguard"))
+    /* TODO: Tunnels are partially supported by the keyfile parser */
+    else if (!g_strcmp0(type_str, "wireguard"))
         return NETPLAN_DEF_TYPE_TUNNEL;
-    */
     /* Unsupported type, needs to be specified via passthrough */
     return NETPLAN_DEF_TYPE_NM;
 }
@@ -70,6 +69,14 @@ ap_type_from_str(const char* type_str)
         return NETPLAN_WIFI_MODE_ADHOC;
     /* Unsupported mode, like "mesh" */
     return NETPLAN_WIFI_MODE_OTHER;
+}
+
+static const NetplanTunnelMode
+tunnel_mode_from_str(const char* type_str)
+{
+    if (!g_strcmp0(type_str, "wireguard"))
+        return NETPLAN_TUNNEL_MODE_WIREGUARD;
+    return NETPLAN_TUNNEL_MODE_UNKNOWN;
 }
 
 static void
@@ -447,6 +454,79 @@ read_passthrough(GKeyFile* kf, GData** list)
     }
 }
 
+/*
+ * Network Manager differentiates Wireguard (connection.type=wireguard),
+ * VXLAN (connection.type=vxlan) and all the other types of tunnels (connection.type=ip-tunnel).
+ *
+ * Each of these three classes have different requirements so we handle them separately
+ * in this function.
+ */
+static void
+parse_tunnels(GKeyFile* kf, NetplanNetDefinition* nd)
+{
+    /* Handle wireguard tunnel */
+    if (nd->tunnel.mode == NETPLAN_TUNNEL_MODE_WIREGUARD) {
+
+        /* Reading the private key */
+        nd->tunnel.private_key = g_key_file_get_string(kf, "wireguard", "private-key", NULL);
+        _kf_clear_key(kf, "wireguard", "private-key");
+
+        gchar** keyfile_groups = g_key_file_get_groups(kf, NULL);
+
+        /* Handling peers
+         * Network Manager creates a keyfile group for each Wireguard peer.
+         * The group name has the form [wireguard-peer.<peer's public key>] so,
+         * in order to read the peer's public key we need to split up the group name
+         * and read its second component.
+         * */
+        for (int i = 0; keyfile_groups[i] != NULL; i++) {
+            gchar* group = keyfile_groups[i];
+
+            if (g_str_has_prefix(group, "wireguard-peer.")) {
+                gchar** peer_split = g_strsplit(group, ".", 2);
+
+                if (!is_wireguard_key(peer_split[1])) {
+                    g_warning("Wireguard peer's name is malformed: %s", group);
+                    g_strfreev(peer_split);
+                    continue;
+                }
+
+                if (!nd->wireguard_peers)
+                    nd->wireguard_peers = g_array_new(FALSE, FALSE, sizeof(NetplanWireguardPeer*));
+
+                NetplanWireguardPeer* wireguard_peer = g_new0(NetplanWireguardPeer, 1);
+                wireguard_peer->public_key = g_strdup(peer_split[1]);
+                g_strfreev(peer_split);
+
+                /* Handle allowed-ips */
+                gchar* allowed_ips_str = g_key_file_get_string(kf, group, "allowed-ips", NULL);
+                if (allowed_ips_str) {
+                    wireguard_peer->allowed_ips = g_array_new(FALSE, FALSE, sizeof(NetplanAddressOptions*));
+                    gchar** allowed_ips_split = g_strsplit(allowed_ips_str, ";", 0);
+
+                    for (int i = 0; allowed_ips_split[i] != NULL; i++) {
+                        gchar* ip = allowed_ips_split[i];
+                        if (g_strcmp0(ip, "")) {
+                            gchar* address = g_strdup(ip);
+                            g_array_append_val(wireguard_peer->allowed_ips, address);
+                        }
+                    }
+                    g_free(allowed_ips_str);
+                    g_strfreev(allowed_ips_split);
+                    _kf_clear_key(kf, group, "allowed-ips");
+                }
+
+                /* Handle endpoint */
+                wireguard_peer->endpoint = g_key_file_get_string(kf, group, "endpoint", NULL);
+                _kf_clear_key(kf, group, "endpoint");
+
+                g_array_append_val(nd->wireguard_peers, wireguard_peer);
+            }
+        }
+        g_strfreev(keyfile_groups);
+    }
+}
+
 /**
  * Parse keyfile into a NetplanNetDefinition struct
  * @filename: full path to the NetworkManager keyfile
@@ -506,6 +586,13 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
     g_free(tmp_str);
     nd = netplan_netdef_new(npp, nd_id, nd_type, NETPLAN_BACKEND_NM);
 
+    if (nd_type == NETPLAN_DEF_TYPE_TUNNEL) {
+        nd->tunnel.mode = tunnel_mode_from_str(type);
+    }
+
+    /* Handle tunnels */
+    parse_tunnels(kf, nd);
+
     /* Handle uuid & NM name/id */
     nd->backend_settings.uuid = g_strdup(uuid);
     _kf_clear_key(kf, "connection", "uuid");
@@ -530,7 +617,8 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
         || nd_type == NETPLAN_DEF_TYPE_WIFI
         || nd_type == NETPLAN_DEF_TYPE_MODEM
         || nd_type == NETPLAN_DEF_TYPE_BRIDGE
-        || nd_type == NETPLAN_DEF_TYPE_BOND)
+        || nd_type == NETPLAN_DEF_TYPE_BOND
+        || nd->tunnel.mode != NETPLAN_TUNNEL_MODE_UNKNOWN)
         _kf_clear_key(kf, "connection", "type");
 
     /* Handle match: Netplan usually defines a connection per interface, while

--- a/src/validation.c
+++ b/src/validation.c
@@ -313,16 +313,9 @@ validate_tunnel_backend_rules(const NetplanParser* npp, NetplanNetDefinition* nd
                 case NETPLAN_TUNNEL_MODE_GRE:
                 case NETPLAN_TUNNEL_MODE_IP6GRE:
                 case NETPLAN_TUNNEL_MODE_WIREGUARD:
-                    break;
-
                 case NETPLAN_TUNNEL_MODE_GRETAP:
                 case NETPLAN_TUNNEL_MODE_IP6GRETAP:
-                    return yaml_error(npp, node, error,
-                                      "%s: %s tunnel mode is not supported by NetworkManager",
-                                      nd->id,
-                                      g_ascii_strup(netplan_tunnel_mode_name(nd->tunnel.mode), -1));
                     break;
-
                 default:
                     if (nd->tunnel.input_key)
                         return yaml_error(npp, node, error, "%s: 'input-key' is not required for this tunnel type", nd->id);

--- a/tests/ctests/meson.build
+++ b/tests/ctests/meson.build
@@ -5,6 +5,7 @@ tests = {
   'test_netplan_misc': false,
   'test_netplan_deprecated': false,
   'test_netplan_validation': false,
+  'test_netplan_keyfile': false,
 }
 
 cmocka = dependency('cmocka', required: true)

--- a/tests/ctests/test_netplan_keyfile.c
+++ b/tests/ctests/test_netplan_keyfile.c
@@ -1,0 +1,261 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "netplan.h"
+#include "parse-nm.h"
+#include "parse.h"
+
+#include "error.c"
+#include "names.c"
+#include "netplan.c"
+#include "validation.c"
+#include "types.c"
+#include "util.c"
+#include "parse.c"
+#include "parse-nm.c"
+
+#include "test_utils.h"
+#include "test_utils_keyfile.h"
+
+void
+test_load_keyfile_wifi_wpa_eap(void** state)
+{
+    NetplanState *np_state = NULL;
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+    NetplanWifiAccessPoint* ap = NULL;
+
+    const char* keyfile =
+        "[connection]\n"
+        "id=mywifi\n"
+        "uuid=03c8f2a7-268d-4765-b626-efcc02dd686c\n"
+        "type=wifi\n"
+        "interface-name=wlp2s0\n"
+        "[wifi]\n"
+        "mode=infrastructure\n"
+        "ssid=mywifi\n"
+        "[wifi-security]\n"
+        "auth-alg=open\n"
+        "key-mgmt=wpa-eap\n"
+        "[802-1x]\n"
+        "ca-cert=/path/to/cert.crt\n"
+        "eap=peap;\n"
+        "identity=username\n"
+        "password=mypassword\n"
+        "phase2-auth=mschapv2\n"
+        "[ipv4]\n"
+        "method=auto\n";
+
+    np_state = load_keyfile_string_to_netplan_state(keyfile);
+
+    netplan_state_iterator_init(np_state, &iter);
+    netdef = netplan_state_iterator_next(&iter);
+    ap = g_hash_table_lookup(netdef->access_points, "mywifi");
+
+    assert_string_equal(netdef->id, "NM-03c8f2a7-268d-4765-b626-efcc02dd686c");
+    assert_string_equal(ap->ssid, "mywifi");
+    assert_string_equal(ap->auth.identity, "username");
+    assert_string_equal(ap->auth.ca_certificate, "/path/to/cert.crt");
+
+    netplan_state_clear(&np_state);
+}
+
+
+void
+test_load_keyfile_simple_wireguard(void** state)
+{
+    NetplanState *np_state = NULL;
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+
+    const char* keyfile =
+        "[connection]\n"
+        "id=wg0\n"
+        "type=wireguard\n"
+        "uuid=19f501f5-9984-429a-a8b5-3f5a89aa460c\n"
+        "interface-name=wg0\n"
+        "[ipv4]\n"
+        "method=auto\n";
+
+    np_state = load_keyfile_string_to_netplan_state(keyfile);
+
+    netplan_state_iterator_init(np_state, &iter);
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_string_equal(netdef->id, "wg0");
+    assert_null(netdef->wireguard_peers);
+
+    netplan_state_clear(&np_state);
+}
+
+void
+test_load_keyfile_wireguard_with_key_and_peer(void** state)
+{
+    NetplanState *np_state = NULL;
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+
+    const char* keyfile =
+        "[connection]\n"
+        "id=client-wg0\n"
+        "type=wireguard\n"
+        "uuid=6352c897-174c-4f61-9623-556eddad05b2\n"
+        "interface-name=wg0\n"
+        "[wireguard]\n"
+        "private-key=aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A=\n"
+        "[wireguard-peer.cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI=]\n"
+        "endpoint=1.2.3.4:12345\n"
+        "allowed-ips=192.168.0.0/24;\n"
+        "[ipv4]\n"
+        "method=auto\n";
+
+    np_state = load_keyfile_string_to_netplan_state(keyfile);
+
+    netplan_state_iterator_init(np_state, &iter);
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_string_equal(netdef->id, "wg0");
+    assert_string_equal(netdef->tunnel.private_key, "aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A=");
+
+    NetplanWireguardPeer* peer = g_array_index(netdef->wireguard_peers, NetplanWireguardPeer*, 0);
+    assert_string_equal(peer->public_key, "cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI=");
+    assert_string_equal(peer->endpoint, "1.2.3.4:12345");
+
+    gchar* allowed_ip = g_array_index(peer->allowed_ips, gchar*, 0);
+    assert_string_equal(allowed_ip, "192.168.0.0/24");
+
+    netplan_state_clear(&np_state);
+}
+
+void
+test_load_keyfile_wireguard_with_bad_peer_key(void** state)
+{
+    NetplanState *np_state = NULL;
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+
+    const char* keyfile =
+        "[connection]\n"
+        "id=client-wg0\n"
+        "type=wireguard\n"
+        "uuid=6352c897-174c-4f61-9623-556eddad05b2\n"
+        "interface-name=wg0\n"
+        "[wireguard]\n"
+        "private-key=aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A=\n"
+        "[wireguard-peer.this_is_not_a_valid_peer_public_key]\n"
+        "endpoint=1.2.3.4:12345\n"
+        "allowed-ips=192.168.0.0/24;\n"
+        "[ipv4]\n"
+        "method=auto\n";
+
+    np_state = load_keyfile_string_to_netplan_state(keyfile);
+
+    netplan_state_iterator_init(np_state, &iter);
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_null(netdef->wireguard_peers);
+
+    netplan_state_clear(&np_state);
+}
+
+void
+test_load_keyfile_vxlan(void** state)
+{
+    NetplanState *np_state = NULL;
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+
+    const char* keyfile =
+        "[connection]\n"
+        "id=vxlan0\n"
+        "type=vxlan\n"
+        "uuid=6352c897-174c-4f61-9623-556eddad05b2\n"
+        "interface-name=vxlan0\n"
+        "[vxlan]\n"
+        "id=10\n"
+        "local=1.2.3.4\n"
+        "remote=4.3.2.1\n"
+        "[ipv4]\n"
+        "method=auto\n";
+
+    np_state = load_keyfile_string_to_netplan_state(keyfile);
+
+    netplan_state_iterator_init(np_state, &iter);
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_string_equal(netdef->id, "vxlan0");
+    assert_int_equal(netdef->vxlan->vni, 10);
+    assert_string_equal(netdef->tunnel.local_ip, "1.2.3.4");
+    assert_string_equal(netdef->tunnel.remote_ip, "4.3.2.1");
+
+    netplan_state_clear(&np_state);
+}
+
+void
+test_load_keyfile_multiple_addresses_and_routes(void** state)
+{
+    NetplanState *np_state = NULL;
+    NetplanStateIterator iter;
+    NetplanNetDefinition* netdef = NULL;
+
+    const char* keyfile =
+        "[connection]\n"
+        "id=netplan-enp3s0\n"
+        "type=ethernet\n"
+        "interface-name=enp3s0\n"
+        "uuid=6352c897-174c-4f61-9623-556eddad05b2\n"
+        "[ipv4]\n"
+        "method=manual\n"
+        "address1=10.100.1.38/24\n"
+        "address2=10.100.1.39/24\n"
+        "route1=0.0.0.0/0,10.100.1.1\n"
+        "route2=192.168.0.0/24,1.2.3.4\n"
+        "[ipv6]\n"
+        "method=manual\n"
+        "address1=2001:cafe:face::1/64\n"
+        "address2=2001:cafe:face::2/64\n"
+        "ip6-privacy=0\n"
+        "route1=::/0,2001:cafe:face::3/64\n";
+
+    np_state = load_keyfile_string_to_netplan_state(keyfile);
+
+    netplan_state_iterator_init(np_state, &iter);
+    netdef = netplan_state_iterator_next(&iter);
+
+    assert_string_equal(netdef->id, "NM-6352c897-174c-4f61-9623-556eddad05b2");
+
+    netplan_state_clear(&np_state);
+}
+
+int
+setup(void** state)
+{
+    return 0;
+}
+
+int
+tear_down(void** state)
+{
+    return 0;
+}
+
+int
+main()
+{
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_load_keyfile_wifi_wpa_eap),
+        cmocka_unit_test(test_load_keyfile_simple_wireguard),
+        cmocka_unit_test(test_load_keyfile_wireguard_with_key_and_peer),
+        cmocka_unit_test(test_load_keyfile_wireguard_with_bad_peer_key),
+        cmocka_unit_test(test_load_keyfile_vxlan),
+        cmocka_unit_test(test_load_keyfile_multiple_addresses_and_routes),
+    };
+
+    return cmocka_run_group_tests(tests, setup, tear_down);
+
+}

--- a/tests/ctests/test_utils_keyfile.h
+++ b/tests/ctests/test_utils_keyfile.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <stdio.h>
+#include <sys/mman.h>
+
+#include "types.h"
+#include "netplan.h"
+#include "parse.h"
+#include "parse-nm.h"
+#include "util.h"
+#include "types-internal.h"
+
+// LCOV_EXCL_START
+NetplanState*
+load_keyfile_string_to_netplan_state(const char* keyfile)
+{
+    NetplanError** error = NULL;
+    NetplanState* np_state = NULL;
+
+    NetplanParser* npp = netplan_parser_new();
+
+    int fd = memfd_create("keyfile.nmconnection", 0);
+
+    char* ptr = (char*) keyfile;
+    while (*ptr) {
+        if (write(fd, ptr, 1) <= 0) break;
+        ptr++;
+    }
+
+    g_autofree gchar* path = g_strdup_printf("/proc/self/fd/%d", fd);
+    netplan_parser_load_keyfile(npp, path, error);
+    if (error && *error) {
+        netplan_error_clear(error);
+    } else {
+        np_state = netplan_state_new();
+        netplan_state_import_parser_results(np_state, npp, error);
+    }
+
+    netplan_parser_clear(&npp);
+
+    if (error && *error) {
+        netplan_state_clear(&np_state);
+    }
+
+    return np_state;
+}
+
+// LCOV_EXCL_STOP

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -300,22 +300,6 @@ must be X.X.X.X/NN or X:X:X:X:X:X:X:X/NN", out)
         out = self.generate(config, expect_fail=True)
         self.assertIn("Error in network definition: unknown key 'bogus'", out)
 
-    def test_fail_missing_private_key(self):
-        """[wireguard] Show an error for a missing private key"""
-        config = prepare_wg_config(listen=12345,
-                                   peers=[{'public-key': 'M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=',
-                                           'allowed-ips': '[0.0.0.0/0, "2001:fe:ad:de:ad:be:ef:1/24"]',
-                                           'keepalive': 14,
-                                           'endpoint': '1.2.3.4:1005'}], renderer=self.backend)
-        out = self.generate(config, expect_fail=True)
-        self.assertIn("Error in network definition: wg0: missing 'key' property (private key) for wireguard", out)
-
-    def test_fail_no_peers(self):
-        """[wireguard] Show an error for missing peers"""
-        config = prepare_wg_config(listen=12345, privkey="4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=", renderer=self.backend)
-        out = self.generate(config, expect_fail=True)
-        self.assertIn("Error in network definition: wg0: at least one peer is required.", out)
-
     def test_fail_no_public_key(self):
         """[wireguard] Show an error for missing public_key"""
         config = prepare_wg_config(listen=12345, privkey='4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=',
@@ -323,16 +307,7 @@ must be X.X.X.X/NN or X:X:X:X:X:X:X:X/NN", out)
                                            'keepalive': 14,
                                            'endpoint': '1.2.3.4:1005'}], renderer=self.backend)
         out = self.generate(config, expect_fail=True)
-        self.assertIn("Error in network definition: wg0: keys.public is required.", out)
-
-    def test_fail_no_allowed_ips(self):
-        """[wireguard] Show an error for a missing allowed_ips"""
-        config = prepare_wg_config(listen=12345, privkey='4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=',
-                                   peers=[{'public-key': 'M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=',
-                                           'keepalive': 14,
-                                           'endpoint': '1.2.3.4:1005'}], renderer=self.backend)
-        out = self.generate(config, expect_fail=True)
-        self.assertIn("Error in network definition: wg0: 'allowed-ips' is required for wireguard peers.", out)
+        self.assertIn("Error in network definition: wg0: a public key is required.", out)
 
     def test_vxlan_port_range_fail(self):
         out = self.generate('''network:
@@ -1590,19 +1565,13 @@ class TestConfigErrors(TestBase):
       local: 10.10.10.10
 '''
         out = self.generate(config, expect_fail=True)
-        self.assertIn("Error in network definition: tun0: missing 'mode' property for tunnel", out)
+        self.assertIn("Error in network definition: tun0: missing or invalid 'mode' property for tunnel", out)
 
     def test_invalid_mode(self):
         """Ensure an invalid tunnel mode shows an error message"""
         config = prepare_config_for_mode('networkd', 'invalid')
         out = self.generate(config, expect_fail=True)
         self.assertIn("Error in network definition: tun0: tunnel mode 'invalid' is not supported", out)
-
-    def test_invalid_mode_for_nm(self):
-        """Show an error if a mode is selected that can't be handled by the renderer"""
-        config = prepare_config_for_mode('NetworkManager', 'gretap')
-        out = self.generate(config, expect_fail=True)
-        self.assertIn("Error in network definition: tun0: GRETAP tunnel mode is not supported by NetworkManager", out)
 
     def test_malformed_tunnel_ip(self):
         """Fail if local/remote IP for tunnel are malformed"""

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -382,10 +382,7 @@ route2=4:5:6:7:8:9:0:1/63,,5
         self._template_keyfile_type('nm-devices', 'vlan', False)
 
     def test_keyfile_type_tunnel(self):
-        self._template_keyfile_type('nm-devices', 'ip-tunnel', False)
-
-    def test_keyfile_type_wireguard(self):
-        self._template_keyfile_type('nm-devices', 'wireguard', False)
+        self._template_keyfile_type('tunnels', 'ip-tunnel', False)
 
     def test_keyfile_type_other(self):
         self._template_keyfile_type('nm-devices', 'dummy', False)  # wokeignore:rule=dummy
@@ -1180,25 +1177,25 @@ method=auto
 '''.format(UUID))
         self.assert_netplan({UUID: '''network:
   version: 2
-  nm-devices:
+  tunnels:
     NM-{}:
       renderer: NetworkManager
+      dhcp4: true
+      dhcp6: true
+      ipv6-address-generation: "stable-privacy"
+      mode: "gre"
+      local: "10.20.20.1"
+      remote: "10.20.20.2"
       networkmanager:
         uuid: "{}"
         name: "IP tunnel connection 1"
         passthrough:
-          connection.type: "ip-tunnel"
           connection.autoconnect: "false"
           connection.interface-name: "gre10"
           connection.permissions: ""
-          ip-tunnel.local: "10.20.20.1"
-          ip-tunnel.mode: "2"
-          ip-tunnel.remote: "10.20.20.2"
           ipv4.dns-search: ""
-          ipv4.method: "auto"
-          ipv6.addr-gen-mode: "stable-privacy"
           ipv6.dns-search: ""
-          ipv6.method: "auto"
+          ipv6.ip6-privacy: "-1"
           proxy._: ""
 '''.format(UUID, UUID)})
 
@@ -1491,3 +1488,200 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "MyWifi"
 '''.format(UUID, UUID, UUID)})
+
+    def test_simple_wireguard(self):
+        self.generate_from_keyfile('''[connection]
+id=wg0
+type=wireguard
+uuid={}
+interface-name=wg0
+
+[ipv4]
+method=auto\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "wireguard"
+      networkmanager:
+        uuid: "{}"
+        name: "wg0"
+        passthrough:
+          connection.interface-name: "wg0"
+'''.format(UUID, UUID)})
+
+    def test_wireguard_with_key(self):
+        self.generate_from_keyfile('''[connection]
+id=wg0
+type=wireguard
+uuid={}
+interface-name=wg0
+
+[wireguard]
+private-key=aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A=
+
+[ipv4]
+method=auto\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "wireguard"
+      keys:
+        private: "aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A="
+      networkmanager:
+        uuid: "{}"
+        name: "wg0"
+        passthrough:
+          connection.interface-name: "wg0"
+'''.format(UUID, UUID)})
+
+    def test_wireguard_with_key_and_peer(self):
+        self.generate_from_keyfile('''[connection]
+id=wg0
+type=wireguard
+uuid={}
+interface-name=wg0
+
+[wireguard]
+private-key=aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A=
+
+[wireguard-peer.cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI=]
+endpoint=1.2.3.4:12345
+allowed-ips=192.168.0.0/24;
+
+[ipv4]
+method=auto\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "wireguard"
+      keys:
+        private: "aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A="
+      peers:
+      - endpoint: "1.2.3.4:12345"
+        keys:
+          public: "cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI="
+        allowed-ips:
+        - "192.168.0.0/24"
+      networkmanager:
+        uuid: "{}"
+        name: "wg0"
+        passthrough:
+          connection.interface-name: "wg0"
+'''.format(UUID, UUID)})
+
+    def test_wireguard_with_key_and_peer_without_allowed_ips(self):
+        self.generate_from_keyfile('''[connection]
+id=wg0
+type=wireguard
+uuid={}
+interface-name=wg0
+
+[wireguard]
+private-key=aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A=
+
+[wireguard-peer.cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI=]
+endpoint=1.2.3.4:12345
+
+[ipv4]
+method=auto\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "wireguard"
+      keys:
+        private: "aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A="
+      peers:
+      - endpoint: "1.2.3.4:12345"
+        keys:
+          public: "cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI="
+      networkmanager:
+        uuid: "{}"
+        name: "wg0"
+        passthrough:
+          connection.interface-name: "wg0"
+'''.format(UUID, UUID)})
+
+    def test_vxlan_with_local_and_remote(self):
+        self.generate_from_keyfile('''[connection]
+id=vxlan10
+type=vxlan
+uuid={}
+interface-name=vxlan10
+
+[vxlan]
+id=10
+local=198.51.100.2
+remote=203.0.113.1
+
+[ipv4]
+method=auto\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "vxlan"
+      local: "198.51.100.2"
+      remote: "203.0.113.1"
+      id: 10
+      networkmanager:
+        uuid: "{}"
+        name: "vxlan10"
+        passthrough:
+          connection.interface-name: "vxlan10"
+'''.format(UUID, UUID)})
+
+    def test_simple_vxlan(self):
+        self.generate_from_keyfile('''[connection]
+id=vxlan10
+type=vxlan
+uuid={}
+interface-name=vxlan10
+
+[vxlan]
+id=10
+
+[ipv4]
+method=auto\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "vxlan"
+      id: 10
+      networkmanager:
+        uuid: "{}"
+        name: "vxlan10"
+        passthrough:
+          connection.interface-name: "vxlan10"
+'''.format(UUID, UUID)})
+
+    def test_invalid_tunnel_mode(self):
+        out = self.generate_from_keyfile('''[connection]
+id=tun0
+type=ip-tunnel
+uuid={}
+interface-name=tun0
+
+[ip-tunnel]
+mode=42
+
+[ipv4]
+method=auto\n'''.format(UUID), expect_fail=True)
+
+        self.assertIn('missing or invalid \'mode\' property for tunnel', out)


### PR DESCRIPTION
## Description

Support for Wireguard keyfiles parsing is required to get the new Network Manager autopkgtests passing [1]. The original plan was to add support only for WG, but I ended up including all tunnel types.

There is a not-so-nice function renaming in src/parse-nm.c that was required to get new ctests compiling.

[1] - https://code.launchpad.net/~danilogondolfo/network-manager/+git/network-manager/+merge/443011

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#2016473

