### PR TITLE
Add support for "dummy" interfaces (LP: #1774203)

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -103,14 +103,6 @@ rules:
       - foreperson
     severity: warning
 
-  - name: dummy
-    terms:
-      - dummy
-    alternatives:
-      - placeholder
-      - sample
-    severity: warning
-
   - name: grandfathered
     terms:
       - grandfathered
@@ -178,3 +170,4 @@ rules:
     severity: warning
   # Ignore rules
   - name: he
+  - name: dummy

--- a/abi-compat/suppressions.abignore
+++ b/abi-compat/suppressions.abignore
@@ -7,3 +7,8 @@
 [suppress_variable]
   name = global_state
   type_name = NetplanState
+
+[suppress_type]
+  type_kind = typedef
+  name = NetplanDefType
+  changed_enumerators = NetplanDefType

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -12,6 +12,7 @@ network:
   renderer: STRING
   bonds: MAPPING
   bridges: MAPPING
+  dummy-devices: MAPPING
   ethernets: MAPPING
   modems: MAPPING
   tunnels: MAPPING
@@ -36,6 +37,10 @@ network:
 - [**bridges**](#properties-for-device-type-bridges) (mapping)
 
   > Creates and configures bridge devices.
+
+- [**dummy-devices**](#properties-for-device-type-dummy-devices) (mapping)
+
+  > Creates and configures virtual devices.
 
 - [**ethernets**](#properties-for-device-type-ethernets) (mapping)
 
@@ -1315,6 +1320,31 @@ The specific settings for bridges are defined below.
     > Define whether the bridge should use Spanning Tree Protocol. The
     > default value is "true", which means that Spanning Tree should be
     > used.
+
+
+## Properties for device type `dummy-devices:`
+
+**Status**: Optional.
+
+**Purpose**: Use the `dummy-devices` key to create virtual interfaces.
+
+**Structure**: The key consists of a mapping of interface names.
+Dummy devices are virtual devices that can be used to route packets to
+without actually transmitting them.
+
+```yaml
+network:
+  dummy-devices:
+    dm0:
+      addresses:
+        - 192.168.0.123/24
+      ...
+```
+
+When applied, a virtual interface called `dm0` will be created in the system.
+
+[See this section](#properties-for-all-device-types) for the list of properties that can be
+used with this type of interface.
 
 
 ## Properties for device type `bonds:`

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1343,7 +1343,7 @@ network:
 
 When applied, a virtual interface called `dm0` will be created in the system.
 
-[See this section](#properties-for-all-device-types) for the list of properties that can be
+See the ["Properties for all device types"](#properties-for-all-device-types) section for the list of properties that can be
 used with this type of interface.
 
 

--- a/examples/dummy-devices.yaml
+++ b/examples/dummy-devices.yaml
@@ -1,0 +1,11 @@
+network:
+  renderer: networkd
+  version: 2
+  dummy-devices:
+    dm0:
+      addresses:
+        - 10.1.2.3/24
+    dm1:
+      addresses:
+        - 192.168.1.2/28
+        - 2001:cafe:face:beef::dead:dead/64

--- a/include/types.h
+++ b/include/types.h
@@ -46,9 +46,9 @@ typedef enum {
     NETPLAN_DEF_TYPE_TUNNEL,
     NETPLAN_DEF_TYPE_PORT,
     NETPLAN_DEF_TYPE_VRF,
-    NETPLAN_DEF_TYPE_DUMMY,     /* wokeignore:rule=dummy */
     /* Type fallback/passthrough */
     NETPLAN_DEF_TYPE_NM,
+    NETPLAN_DEF_TYPE_DUMMY,     /* wokeignore:rule=dummy */
     NETPLAN_DEF_TYPE_MAX_
 } NetplanDefType;
 

--- a/include/types.h
+++ b/include/types.h
@@ -46,6 +46,7 @@ typedef enum {
     NETPLAN_DEF_TYPE_TUNNEL,
     NETPLAN_DEF_TYPE_PORT,
     NETPLAN_DEF_TYPE_VRF,
+    NETPLAN_DEF_TYPE_DUMMY,     /* wokeignore:rule=dummy */
     /* Type fallback/passthrough */
     NETPLAN_DEF_TYPE_NM,
     NETPLAN_DEF_TYPE_MAX_

--- a/src/names.c
+++ b/src/names.c
@@ -49,6 +49,7 @@ netplan_def_type_to_str[NETPLAN_DEF_TYPE_MAX_] = {
     [NETPLAN_DEF_TYPE_VLAN] = "vlans",
     [NETPLAN_DEF_TYPE_VRF] = "vrfs",
     [NETPLAN_DEF_TYPE_TUNNEL] = "tunnels",
+    [NETPLAN_DEF_TYPE_DUMMY] = "dummy-devices",       /* wokeignore:rule=dummy */
     [NETPLAN_DEF_TYPE_PORT] = "_ovs-ports",
     [NETPLAN_DEF_TYPE_NM] = "nm-devices",
 };

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -520,6 +520,10 @@ write_netdev_file(const NetplanNetDefinition* def, const char* rootdir, const ch
             g_string_append_printf(s, "Kind=vrf\n\n[VRF]\nTable=%u\n", def->vrf_table);
             break;
 
+        case NETPLAN_DEF_TYPE_DUMMY:                        /* wokeignore:rule=dummy */
+            g_string_append_printf(s, "Kind=dummy\n");      /* wokeignore:rule=dummy */
+            break;
+
         case NETPLAN_DEF_TYPE_TUNNEL:
             switch(def->tunnel.mode) {
                 case NETPLAN_TUNNEL_MODE_GRE:

--- a/src/nm.c
+++ b/src/nm.c
@@ -86,6 +86,8 @@ type_str(const NetplanNetDefinition* def)
             return "vlan";
         case NETPLAN_DEF_TYPE_VRF:
             return "vrf";
+        case NETPLAN_DEF_TYPE_DUMMY:    /* wokeignore:rule=dummy */
+            return "dummy";             /* wokeignore:rule=dummy */
         case NETPLAN_DEF_TYPE_TUNNEL:
             if (def->tunnel.mode == NETPLAN_TUNNEL_MODE_WIREGUARD)
                 return "wireguard";

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -47,6 +47,8 @@ type_from_str(const char* type_str)
         return NETPLAN_DEF_TYPE_BRIDGE;
     else if (!g_strcmp0(type_str, "bond"))
         return NETPLAN_DEF_TYPE_BOND;
+    else if (!g_strcmp0(type_str, "dummy"))     /* wokeignore:rule=dummy */
+        return NETPLAN_DEF_TYPE_DUMMY;          /* wokeignore:rule=dummy */
     /* TODO: Vlans are not yet fully supported by the keyfile parser
     else if (!g_strcmp0(type_str, "vlan"))
         return NETPLAN_DEF_TYPE_VLAN;
@@ -664,6 +666,7 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
         || nd_type == NETPLAN_DEF_TYPE_MODEM
         || nd_type == NETPLAN_DEF_TYPE_BRIDGE
         || nd_type == NETPLAN_DEF_TYPE_BOND
+        || nd_type == NETPLAN_DEF_TYPE_DUMMY       /* wokeignore:rule=dummy */
         || (nd_type == NETPLAN_DEF_TYPE_TUNNEL && nd->tunnel.mode != NETPLAN_TUNNEL_MODE_UNKNOWN))
         _kf_clear_key(kf, "connection", "type");
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -2825,6 +2825,12 @@ static const mapping_entry_handler modem_def_handlers[] = {
     {"username", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(modem_params.username)},
 };
 
+static const mapping_entry_handler dummy_def_handlers[] = {     /* wokeignore:rule=dummy */
+    COMMON_LINK_HANDLERS,
+    COMMON_BACKEND_HANDLERS,
+    {NULL}
+};
+
 static const mapping_entry_handler tunnel_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     COMMON_BACKEND_HANDLERS,
@@ -3090,6 +3096,7 @@ handle_network_type(NetplanParser* npp, yaml_node_t* node, const char* key_prefi
             case NETPLAN_DEF_TYPE_VLAN: handlers = vlan_def_handlers; break;
             case NETPLAN_DEF_TYPE_VRF: handlers = vrf_def_handlers; break;
             case NETPLAN_DEF_TYPE_WIFI: handlers = wifi_def_handlers; break;
+            case NETPLAN_DEF_TYPE_DUMMY: handlers = dummy_def_handlers; break;      /* wokeignore:rule=dummy */
             case NETPLAN_DEF_TYPE_NM:
                 g_warning("netplan: %s: handling NetworkManager passthrough device, settings are not fully supported.", npp->current.netdef->id);
                 handlers = ethernet_def_handlers;
@@ -3179,6 +3186,7 @@ static const mapping_entry_handler network_handlers[] = {
     {"vrfs", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_VRF)},
     {"wifis", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_WIFI)},
     {"modems", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_MODEM)},
+    {"dummy-devices", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_DUMMY)},    /* wokeignore:rule=dummy */
     {"nm-devices", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_NM)},
     {"openvswitch", YAML_MAPPING_NODE, {.map={.handlers=ovs_network_settings_handlers}}},
     {NULL}

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -83,6 +83,7 @@ ND_WG = '[NetDev]\nName=wg0\nKind=wireguard\n\n[WireGuard]\nPrivateKey%s\nListen
 ND_VLAN = '[NetDev]\nName=%s\nKind=vlan\n\n[VLAN]\nId=%d\n'
 ND_VXLAN = '[NetDev]\nName=%s\nKind=vxlan\n\n[VXLAN]\nVNI=%d\n'
 ND_VRF = '[NetDev]\nName=%s\nKind=vrf\n\n[VRF]\nTable=%d\n'
+ND_DUMMY = '[NetDev]\nName=%s\nKind=dummy\n'        # wokeignore:rule=dummy
 SD_WPA = '''[Unit]
 Description=WPA supplicant for netplan %(iface)s
 DefaultDependencies=no

--- a/tests/generator/test_dummies.py
+++ b/tests/generator/test_dummies.py
@@ -1,0 +1,94 @@
+#
+# Tests for dummy devices config generated via netplan      # wokeignore:rule=dummy
+#
+# Copyright (C) 2023 Canonical, Ltd.
+# Author: Danilo Egea Gondolfo <danilo.egea.gondolfo@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from .base import ND_DUMMY, ND_WITHIP, TestBase    # wokeignore:rule=dummy
+
+
+class NetworkManager(TestBase):
+
+    def test_basic(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  dummy-devices:            # wokeignore:rule=dummy
+    dm0:
+      addresses:
+        - 192.168.1.2/24
+      routes:
+      - to: 1.2.3.4
+        via: 192.168.1.2''')
+
+        self.assert_nm({'dm0': '''[connection]
+id=netplan-dm0
+type={}
+interface-name=dm0
+
+[ipv4]
+method=manual
+address1=192.168.1.2/24
+route1=1.2.3.4,192.168.1.2
+
+[ipv6]
+method=ignore
+'''.format(('dummy'))})      # wokeignore:rule=dummy
+
+
+class TestNetworkd(TestBase):
+
+    def test_basic(self):
+        self.generate('''network:
+  version: 2
+  dummy-devices:            # wokeignore:rule=dummy
+    dm0:
+      addresses:
+        - 192.168.1.2/24
+      routes:
+      - to: 1.2.3.4
+        via: 192.168.1.2''')
+
+        self.assert_networkd({'dm0.network': ND_WITHIP % ('dm0', '192.168.1.2/24') + '''
+[Route]
+Destination=1.2.3.4
+Gateway=192.168.1.2
+''',
+                              'dm0.netdev': ND_DUMMY % ('dm0')})    # wokeignore:rule=dummy
+
+
+class TestNetplanYAMLv2(TestBase):
+    '''No asserts are needed.
+
+    The generate() method implicitly checks the (re-)generated YAML.
+    '''
+
+    def test_basic(self):
+        self.generate('''network:
+  version: 2
+  dummy-devices:            # wokeignore:rule=dummy
+    dm0: {}''')
+
+    def test_interface_ipv4(self):
+        self.generate('''network:
+  version: 2
+  dummy-devices:            # wokeignore:rule=dummy
+    dm0:
+      addresses:
+        - 192.168.1.2/24
+      routes:
+      - to: 1.2.3.4
+        via: 192.168.1.2''')

--- a/tests/integration/dummies.py
+++ b/tests/integration/dummies.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python3
+# Dummy devices integration tests.          wokeignore:rule=dummy
+#
+# These need to be run in a VM and do change the system
+# configuration.
+#
+# Copyright (C) 2023 Canonical, Ltd.
+# Author: Danilo Egea Gondolfo <danilo.egea.gondolfo@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import subprocess
+import unittest
+
+from base import IntegrationTestsBase, test_backends
+
+
+class _CommonTests():
+
+    def test_create_single_interface(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dm0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:        # wokeignore:rule=dummy
+    dm0: {}
+''' % {'r': self.backend})
+        self.generate_and_settle(['dm0'])
+        self.assert_iface('dm0')
+
+    def test_create_multiple_interfaces(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dm0'], stderr=subprocess.DEVNULL)
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dm1'], stderr=subprocess.DEVNULL)
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dm2'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:        # wokeignore:rule=dummy
+    dm0: {}
+    dm1: {}
+    dm2: {}
+''' % {'r': self.backend})
+        self.generate_and_settle(['dm0', 'dm1', 'dm2'])
+        self.assert_iface('dm0')
+        self.assert_iface('dm1')
+        self.assert_iface('dm2')
+
+    def test_interface_with_ip_addresses(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dm0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:            # wokeignore:rule=dummy
+    dm0:
+      addresses:
+        - 192.168.123.123/24
+        - 1234:FFFF::42/64
+''' % {'r': self.backend})
+        self.generate_and_settle(['dm0'])
+        self.assert_iface('dm0', ['inet 192.168.123.123/24', 'inet6 1234:ffff::42/64'])
+
+
+@unittest.skipIf("networkd" not in test_backends,
+                 "skipping as networkd backend tests are disabled")
+class TestNetworkd(IntegrationTestsBase, _CommonTests):
+    backend = 'networkd'
+
+
+@unittest.skipIf("NetworkManager" not in test_backends,
+                 "skipping as NetworkManager backend tests are disabled")
+class TestNetworkManager(IntegrationTestsBase, _CommonTests):
+    backend = 'NetworkManager'
+
+
+unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -340,6 +340,28 @@ route2=4:5:6:7:8:9:0:1/63,,5
           proxy._: ""
 '''.format(UUID, UUID)})
 
+    def test_keyfile_dummy(self):       # wokeignore:rule=dummy
+        self.generate_from_keyfile('''[connection]
+id=Test
+uuid={}
+type={}
+
+[ipv4]
+method=manual
+address1=192.168.123.123/24
+'''.format(UUID, 'dummy'))      # wokeignore:rule=dummy
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  dummy-devices:            # wokeignore:rule=dummy
+    NM-{}:
+      renderer: NetworkManager
+      addresses:
+      - "192.168.123.123/24"
+      networkmanager:
+        uuid: "{}"
+        name: "Test"
+'''.format(UUID, UUID)})
+
     def _template_keyfile_type(self, nd_type, nm_type, supported=True):
         self.maxDiff = None
         file = os.path.join(self.workdir.name, 'tmp/some.keyfile')
@@ -383,9 +405,6 @@ route2=4:5:6:7:8:9:0:1/63,,5
 
     def test_keyfile_type_tunnel(self):
         self._template_keyfile_type('tunnels', 'ip-tunnel', False)
-
-    def test_keyfile_type_other(self):
-        self._template_keyfile_type('nm-devices', 'dummy', False)  # wokeignore:rule=dummy
 
     def test_keyfile_type_wifi(self):
         self.generate_from_keyfile('''[connection]


### PR DESCRIPTION
## Description

This is a resurrection of #115. I didn't reuse the PR because it's old and incomplete.

It implements support for parsing YAMLs and Keyfiles so it works with netplan-everywhere (Network Manager + Netplan).

Related LP bug: https://bugs.launchpad.net/netplan/+bug/1774203

Unfortunately the Linux kernel name for this type of interface conflicts with our sensitive-wording  policy so I had to add some annotations in the code to ignore the errors from Woke. Our words list doesn't catch the word 'dummies' though (flaw I exploited to not insert the wokeignore annotation on some places), so I don't know, maybe we could just drop "dummy" from our denylist...

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1774203

