### PR TITLE
Provide frequency to wpa_supplicant when in adhoc mode (LP: #2020754)

### DIFF
--- a/examples/wireless_adhoc.yaml
+++ b/examples/wireless_adhoc.yaml
@@ -1,0 +1,23 @@
+network:
+  version: 2
+  wifis:
+    wl0:
+      link-local: [ ipv4 ]
+      access-points:
+        "test":
+          mode: adhoc
+          band: 2.4GHz
+          channel: 7
+          password: "********"
+
+    wl1:
+      addresses: [192.168.2.12/24]
+      routes:
+        - to: default
+          via: 192.168.2.1
+      access-points:
+        "test":
+          mode: adhoc
+          band: 2.4GHz
+          channel: 7
+          password: "********"

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1164,6 +1164,8 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir, GError** er
         NetplanWifiAccessPoint* ap;
         g_hash_table_iter_init(&iter, def->access_points);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer) &ap)) {
+            gchar* freq_config_str = ap->mode == NETPLAN_WIFI_MODE_ADHOC ? "frequency" : "freq_list";
+
             g_string_append_printf(s, "network={\n  ssid=\"%s\"\n", ap->ssid);
             if (ap->bssid) {
                 g_string_append_printf(s, "  bssid=%s\n", ap->bssid);
@@ -1176,8 +1178,8 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir, GError** er
                 if(!wifi_frequency_24)
                     wifi_get_freq24(1);
                 if (ap->channel) {
-                    g_string_append_printf(s, "  freq_list=%d\n", wifi_get_freq24(ap->channel));
-                } else {
+                    g_string_append_printf(s, "  %s=%d\n", freq_config_str, wifi_get_freq24(ap->channel));
+                } else if (ap->mode != NETPLAN_WIFI_MODE_ADHOC) {
                     g_string_append_printf(s, "  freq_list=");
                     g_hash_table_foreach(wifi_frequency_24, wifi_append_freq, s);
                     // overwrite last whitespace with newline
@@ -1188,8 +1190,8 @@ write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir, GError** er
                 if(!wifi_frequency_5)
                     wifi_get_freq5(7);
                 if (ap->channel) {
-                    g_string_append_printf(s, "  freq_list=%d\n", wifi_get_freq5(ap->channel));
-                } else {
+                    g_string_append_printf(s, "  %s=%d\n", freq_config_str, wifi_get_freq5(ap->channel));
+                } else if (ap->mode != NETPLAN_WIFI_MODE_ADHOC) {
                     g_string_append_printf(s, "  freq_list=");
                     g_hash_table_foreach(wifi_frequency_5, wifi_append_freq, s);
                     // overwrite last whitespace with newline

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -411,6 +411,11 @@ class TestBase(unittest.TestCase):
                 r.add(line[len(prefix):])
         return r
 
+    def assert_wpa_supplicant(self, iface, content):
+        conf_path = os.path.join(self.workdir.name, 'run', 'netplan', "wpa-" + iface + ".conf")
+        with open(conf_path) as f:
+            self.assertEqual(f.read(), content)
+
     def assert_nm(self, connections_map=None, conf=None):
         # check config
         conf_path = os.path.join(self.workdir.name, 'run', 'NetworkManager', 'conf.d', 'netplan.conf')

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -604,6 +604,52 @@ ssid=homenet
 mode=adhoc
 '''})
 
+    def test_wifi_adhoc_wpa_24ghz(self):
+        self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      access-points:
+        homenet:
+          mode: adhoc
+          band: 2.4GHz
+          channel: 7
+          password: "********"''')
+
+        self.assert_wpa_supplicant("wl0", """ctrl_interface=/run/wpa_supplicant
+
+network={
+  ssid="homenet"
+  frequency=2442
+  mode=1
+  key_mgmt=WPA-PSK
+  psk="********"
+}
+""")
+
+    def test_wifi_adhoc_wpa_5ghz(self):
+        self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      access-points:
+        homenet:
+          mode: adhoc
+          band: 5GHz
+          channel: 7
+          password: "********"''')
+
+        self.assert_wpa_supplicant("wl0", """ctrl_interface=/run/wpa_supplicant
+
+network={
+  ssid="homenet"
+  frequency=5035
+  mode=1
+  key_mgmt=WPA-PSK
+  psk="********"
+}
+""")
+
     def test_wifi_wowlan(self):
         self.generate('''network:
   version: 2


### PR DESCRIPTION
## Description
generated configuration for wpa_supplicant is missing "frequency", when in adhoc mode.

here is the corresponding bug report:
https://bugs.launchpad.net/netplan/+bug/2020754
