### PR TITLE
CI: fix dch after adding the new 0.106.1 tag

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -42,7 +42,7 @@ jobs:
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
-          dch -v $(git describe --tags) "Autopkgtest CI testing (Jammy)"
+          dch -v $(git describe --long --tags $(git rev-list --tags --max-count=1)) "Autopkgtest CI testing (Jammy)"
       - name: Run autopkgtest (incl. build)
         run: |
           # using --setup-commands temporarily to install:


### PR DESCRIPTION
After adding the new tag from the stable/0.106 branch, dch is failing with:

  New version specified (0.106-78-g3074070) is less than
  the current version number (0.106.1-0ubuntu1)!  Use -b to force.

Basically, git describe is still describing the tag 0.106 and not 0.106.1.
With this change, we'll first find the lastest tag before calling describe.


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

