### PR TITLE
Improve the coverage of the memory leak tests

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2969,10 +2969,14 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
             return yaml_error(npp, peer, error, "Open vSwitch port '%s' is already assigned to peer '%s'",
                               component2->id, component2->peer);
 
-        component1->peer = g_strdup(scalar(peer));
-        component2->peer = g_strdup(scalar(port));
-        component1->peer_link = component2;
-        component2->peer_link = component1;
+        if (!component1->peer) {
+            component1->peer = g_strdup(scalar(peer));
+            component1->peer_link = component2;
+        }
+        if (!component2->peer) {
+            component2->peer = g_strdup(scalar(port));
+            component2->peer_link = component1;
+        }
     }
     return TRUE;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -1479,8 +1479,10 @@ handle_bond_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data, 
             if (component->bond && g_strcmp0(component->bond, npp->current.netdef->id) != 0)
                 return yaml_error(npp, node, error, "%s: interface '%s' is already assigned to bond %s",
                                   npp->current.netdef->id, scalar(entry), component->bond);
-            component->bond = g_strdup(npp->current.netdef->id);
-            component->bond_link = npp->current.netdef;
+            if (!component->bond) {
+                component->bond = g_strdup(npp->current.netdef->id);
+                component->bond_link = npp->current.netdef;
+            }
             if (component->backend == NETPLAN_BACKEND_OVS) {
                 g_debug("%s: Bond contains Open vSwitch interface, choosing OVS backend", npp->current.netdef->id);
                 npp->current.netdef->backend = NETPLAN_BACKEND_OVS;

--- a/tools/keyfile_to_yaml.c
+++ b/tools/keyfile_to_yaml.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+
+#include <types.h>
+#include <netplan.h>
+#include <parse-nm.h>
+#include <parse.h>
+#include <util.h>
+
+
+int main(int argc, char** argv) {
+    NetplanParser *npp;
+    NetplanState *np_state;
+    NetplanError* error = NULL;
+
+    if (argc < 2) return 1;
+
+    npp = netplan_parser_new();
+
+    netplan_parser_load_keyfile(npp, argv[1], &error);
+    if (error) goto exit_parser;
+
+    np_state = netplan_state_new();
+
+    netplan_state_import_parser_results(np_state, npp, &error);
+    if (!error) printf("keyfile %s loaded\n", argv[1]);
+
+    netplan_state_clear(&np_state);
+
+exit_parser:
+    netplan_parser_clear(&npp);
+    if (error) netplan_error_clear(&error);
+
+    return 0;
+}

--- a/tools/run_asan.sh
+++ b/tools/run_asan.sh
@@ -4,9 +4,15 @@ set -e
 set -x
 
 BUILDDIR="_leakcheckbuild"
+CC=gcc
 
 meson setup ${BUILDDIR} -Db_sanitize=address,undefined
 meson compile -C ${BUILDDIR} --verbose
+
+${CC} tools/keyfile_to_yaml.c -o tools/keyfile_to_yaml \
+    -lnetplan $(pkg-config --cflags --libs glib-2.0) \
+    -Iinclude -L${BUILDDIR}/src \
+    -fsanitize=address,undefined -g
 
 TESTS=$(find ${BUILDDIR}/tests/ctests/ -executable -type f)
 for test in ${TESTS}
@@ -15,12 +21,36 @@ do
 done
 
 mkdir -p ${BUILDDIR}/fakeroot/{etc/netplan,run}
-export LD_LIBRARY_PATH="${BUILDDIR}/src"
 
 for yaml in examples/*.yaml
 do
+    filepath=${BUILDDIR}/fakeroot/etc/netplan/${yaml##*/}
+    filename=$(basename ${filepath})
     cp ${yaml} ${BUILDDIR}/fakeroot/etc/netplan/
-    chmod 600 ${BUILDDIR}/fakeroot/etc/netplan/${yaml##*/}
-    ./${BUILDDIR}/src/generate --root-dir ${BUILDDIR}/fakeroot
-    rm ${BUILDDIR}/fakeroot/etc/netplan/${yaml##*/}
+    chmod 600 ${filepath}
+
+    # Set the renderer and check if the new file can be parsed with the new renderer
+    # We use the system's netplan because it will not fail if there's a memory leak
+    netplan set --root-dir ${BUILDDIR}/fakeroot --origin-hint ${filename/.yaml/} network.renderer=networkd
+    if netplan generate --root-dir ${BUILDDIR}/fakeroot > /dev/null 2>&1
+    then
+        LD_LIBRARY_PATH="${BUILDDIR}/src" ./${BUILDDIR}/src/generate --root-dir ${BUILDDIR}/fakeroot
+    else
+        echo "File ${filename} can't be parsed with renderer = networkd"
+    fi
+
+    netplan set --root-dir ${BUILDDIR}/fakeroot --origin-hint ${filename/.yaml/} network.renderer=NetworkManager
+    if netplan generate --root-dir ${BUILDDIR}/fakeroot > /dev/null 2>&1
+    then
+        LD_LIBRARY_PATH="${BUILDDIR}/src" ./${BUILDDIR}/src/generate --root-dir ${BUILDDIR}/fakeroot
+        for keyfile in $(find ${BUILDDIR}/fakeroot/run/NetworkManager/system-connections/ -type f)
+        do
+            sed -i 's/\[connection\]/\[connection\]\nuuid=c87fb5fc-f607-45f3-8fcd-720b83a742e4/' "${keyfile}"
+            LD_LIBRARY_PATH="${BUILDDIR}/src" ./tools/keyfile_to_yaml "${keyfile}"
+        done
+    else
+        echo "File ${filename} can't be parsed with renderer = NetworkManager"
+    fi
+
+    rm ${filepath}
 done


### PR DESCRIPTION
## Description

Now the run_asan.sh script will call the generator twice for each yaml file, once with renderer=networkd and again with renderer=NetworkManager.

When the renderer is set to NetworkManager, it will also call a new tool (keyfile_to_yaml.c) to load the keyfile.

Also, plug two memory leaks :)

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

