### PR TITLE
Fix keyfile parsing of wireguard config when the prefix of allowed IPs is omited

### DIFF
--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -511,7 +511,18 @@ parse_tunnels(GKeyFile* kf, NetplanNetDefinition* nd)
                     for (int i = 0; allowed_ips_split[i] != NULL; i++) {
                         gchar* ip = allowed_ips_split[i];
                         if (g_strcmp0(ip, "")) {
-                            gchar* address = g_strdup(ip);
+                            gchar* address = NULL;
+                            /*
+                             * NM doesn't care if the prefix was omitted.
+                             * Even though the WG manual says it requires the prefix,
+                             * if it's omitted in its config file it will default to /32
+                             * so we should do the same here and append a /32 if it's not present,
+                             * otherwise we will generate a YAML that will fail validation.
+                             */
+                            if (!g_strrstr(ip, "/"))
+                                address = g_strdup_printf("%s/32", ip);
+                            else
+                                address = g_strdup(ip);
                             g_array_append_val(wireguard_peer->allowed_ips, address);
                         }
                     }

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -76,7 +76,7 @@ class TestKeyfileBase(unittest.TestCase):
         shutil.rmtree(self.workdir.name)
         super().tearDown()
 
-    def generate_from_keyfile(self, keyfile, netdef_id=None, expect_fail=False, filename=None):
+    def generate_from_keyfile(self, keyfile, netdef_id=None, expect_fail=False, filename=None, regenerate=True):
         '''Call libnetplan with given keyfile string as configuration'''
         err = ctypes.POINTER(_NetplanError)()
         # Autodetect default 'NM-<UUID>' netdef-id
@@ -121,7 +121,8 @@ class TestKeyfileBase(unittest.TestCase):
                 lib._write_netplan_conf(netdef_id.encode(), self.workdir.name.encode())
                 lib.netplan_clear_netdefs()
                 # check re-generated keyfile
-                self.assert_nm_regenerate({generated_file: keyfile})
+                if regenerate:
+                    self.assert_nm_regenerate({generated_file: keyfile})
             with open(outf.name, 'r') as f:
                 output = f.read().strip()  # output from stderr (fd=2) on C/library level
                 return output

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1578,6 +1578,47 @@ method=auto\n'''.format(UUID))
           connection.interface-name: "wg0"
 '''.format(UUID, UUID)})
 
+    def test_wireguard_allowed_ips_without_prefix(self):
+        '''
+        When the IP prefix is not present we should default to /32
+        '''
+        self.generate_from_keyfile('''[connection]
+id=wg0
+type=wireguard
+uuid={}
+interface-name=wg0
+
+[wireguard]
+private-key=aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A=
+
+[wireguard-peer.cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI=]
+endpoint=1.2.3.4:12345
+allowed-ips=192.168.0.10
+
+[ipv4]
+method=auto\n'''.format(UUID), regenerate=False)
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "wireguard"
+      keys:
+        private: "aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A="
+      peers:
+      - endpoint: "1.2.3.4:12345"
+        keys:
+          public: "cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI="
+        allowed-ips:
+        - "192.168.0.10/32"
+      networkmanager:
+        uuid: "{}"
+        name: "wg0"
+        passthrough:
+          connection.interface-name: "wg0"
+'''.format(UUID, UUID)})
+
     def test_wireguard_with_key_and_peer_without_allowed_ips(self):
         self.generate_from_keyfile('''[connection]
 id=wg0


### PR DESCRIPTION
## Description

Network Manager allows entering IPs without prefixes. Although WG docs says the format a.b.c.d/prefix should be used, it will accept only the IP address and default the prefix to /32. This change will append a /32 to the allowed IPs that don't have a prefix found in the keyfile.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

