### PR TITLE
routes: fix metric rendering (LP: #2023681)

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -591,7 +591,7 @@ write_route(NetplanIPRoute* r, GString* s)
     if (r->onlink)
         g_string_append_printf(s, "GatewayOnLink=true\n");
     if (r->metric != NETPLAN_METRIC_UNSPEC)
-        g_string_append_printf(s, "Metric=%d\n", r->metric);
+        g_string_append_printf(s, "Metric=%u\n", r->metric);
     if (r->table != NETPLAN_ROUTE_TABLE_UNSPEC)
         g_string_append_printf(s, "Table=%d\n", r->table);
     if (r->mtubytes != NETPLAN_MTU_UNSPEC)

--- a/src/nm.c
+++ b/src/nm.c
@@ -210,7 +210,7 @@ write_routes(const NetplanNetDefinition* def, GKeyFile *kf, int family, GError**
             tmp_key = g_strdup_printf("route%d", j);
             tmp_val = g_string_new(destination);
             if (cur_route->metric != NETPLAN_METRIC_UNSPEC)
-                g_string_append_printf(tmp_val, ",%s,%d", is_global ? cur_route->via : "",
+                g_string_append_printf(tmp_val, ",%s,%u", is_global ? cur_route->via : "",
                                        cur_route->metric);
             else if (is_global) // no metric, but global gateway
                 g_string_append_printf(tmp_val, ",%s", cur_route->via);

--- a/src/validation.c
+++ b/src/validation.c
@@ -555,7 +555,7 @@ defroute_err(struct _defroute_entry *entry, const char *new_netdef_id, GError **
     if (entry->metric == NETPLAN_METRIC_UNSPEC)
         strncpy(metric_name, "metric: default", sizeof(metric_name) - 1);
     else
-        snprintf(metric_name, sizeof(metric_name) - 1, "metric: %d", entry->metric);
+        snprintf(metric_name, sizeof(metric_name) - 1, "metric: %u", entry->metric);
 
     g_set_error(error, NETPLAN_VALIDATION_ERROR, NETPLAN_ERROR_CONFIG_GENERIC,
             "Conflicting default route declarations for %s (%s, %s), first declared in %s but also in %s",


### PR DESCRIPTION
Routes metric are rendered as signed integer instead of unsigned integer. This means all metric > 2147483647 is rendered as negative and is breaking the generated configuration.


## Description

https://bugs.launchpad.net/netplan/+bug/2023681

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [-] New/changed keys in YAML format are documented.
- [-] \(Optional\) Adds example YAML for new feature.
- [-] \(Optional\) Closes an open bug in Launchpad.

