### PR TITLE
Support for VETH interfaces

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -16,6 +16,7 @@ network:
   ethernets: MAPPING
   modems: MAPPING
   tunnels: MAPPING
+  virtual-ethernets: MAPPING
   vlans: MAPPING
   vrfs: MAPPING
   wifis: MAPPING
@@ -53,6 +54,10 @@ network:
 - [**tunnels**](#properties-for-device-type-tunnels) (mapping)
 
   > Creates and configures different types of virtual tunnels.
+
+- [**virtual-ethernets**](#properties-for-device-type-virtual-ethernets) (mapping)
+
+  > Creates and configures Virtual Ethernet (veth) devices.
 
 - [**vlans**](#properties-for-device-type-vlans) (mapping)
 
@@ -1883,6 +1888,63 @@ VXLAN specific keys:
 
   > Allows setting the IPv4 Do not Fragment (DF) bit in outgoing packets.
   > Takes a boolean value. When unset, the kernel's default will be used.
+
+## Properties for device type `virtual-ethernets:`
+
+**Status**: Optional.
+
+**Purpose**: Use the `virtual-ethernets` key to create virtual Ethernet interfaces.
+
+**Structure**: The key consists of a mapping of virtual-ethernet interface names. Each
+`virtual-ethernet` requires a `peer`. In order to have a fully working `virtual-ethernet` pair,
+both devices must be defined, i.e., only setting the `peer` key with the peer
+name is not enough, the peer interface must also be defined and set the first one
+as its peer.
+The general configuration structure for Virtual Ethernets is shown below.
+
+```yaml
+network:
+  virtual-ethernets:
+    veth0:
+      peer: veth1
+    veth1:
+      peer: veth0
+```
+
+When applied, two virtual interfaces called `veth0` and `veth1` will be created in the system.
+
+Virtual Ethernets acts as tunnels forwarding traffic from one interface to the other.
+They can be used to connect two separate virtual networks such as network namespaces and
+bridges. It's not possible to move `virtual-ethernets` to different namespaces through Netplan at the
+present moment.
+
+The specific settings for virtual-ethernets are defined below.
+
+- **peer** (scalar)
+
+  > Defines the virtual-ethernet peer. The peer interface must also be a virtual-ethernet device.
+
+Below is a complete example that uses a pair of virtual Ethernet devices to create a link between two
+bridges:
+
+```yaml
+network:
+  version: 2
+  renderer: networkd
+  virtual-ethernets:
+    veth0-peer1:
+      peer: veth0-peer2
+    veth0-peer2:
+      peer: veth0-peer1
+
+  bridges:
+    br0:
+      interfaces:
+        - veth0-peer1
+    br1:
+      interfaces:
+        - veth0-peer2
+```
 
 ## Properties for device type `vlans:`
 

--- a/examples/virtual-ethernet.yaml
+++ b/examples/virtual-ethernet.yaml
@@ -1,0 +1,16 @@
+network:
+  version: 2
+  renderer: networkd
+  virtual-ethernets:
+    veth0-peer1:
+      peer: veth0-peer2
+    veth0-peer2:
+      peer: veth0-peer1
+
+  bridges:
+    br0:
+      interfaces:
+        - veth0-peer1
+    br1:
+      interfaces:
+        - veth0-peer2

--- a/include/types.h
+++ b/include/types.h
@@ -49,6 +49,7 @@ typedef enum {
     /* Type fallback/passthrough */
     NETPLAN_DEF_TYPE_NM,
     NETPLAN_DEF_TYPE_DUMMY,     /* wokeignore:rule=dummy */
+    NETPLAN_DEF_TYPE_VETH,
     /* Place holder type used to fill gaps when a netdef
      * requires links to another netdef (such as vlan_link)
      * but it's not strictly mandatory

--- a/src/abi.h
+++ b/src/abi.h
@@ -393,4 +393,8 @@ struct netplan_net_definition {
     gboolean has_backend_settings_nm;
 
     guint tunnel_private_key_flags;
+
+    /* virtual-ethernet */
+    /* netplan-feature: virtual-ethernet */
+    NetplanNetDefinition* veth_peer_link;
 };

--- a/src/names.c
+++ b/src/names.c
@@ -50,6 +50,7 @@ netplan_def_type_to_str[NETPLAN_DEF_TYPE_MAX_] = {
     [NETPLAN_DEF_TYPE_VRF] = "vrfs",
     [NETPLAN_DEF_TYPE_TUNNEL] = "tunnels",
     [NETPLAN_DEF_TYPE_DUMMY] = "dummy-devices",       /* wokeignore:rule=dummy */
+    [NETPLAN_DEF_TYPE_VETH] = "virtual-ethernets",
     [NETPLAN_DEF_TYPE_PORT] = "_ovs-ports",
     [NETPLAN_DEF_TYPE_NM] = "nm-devices",
 };

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -791,6 +791,9 @@ _serialize_yaml(
     YAML_BOOL_TRUE(def, event, emitter, "delay-virtual-functions-rebind",
                    def->sriov_delay_virtual_functions_rebind);
 
+    if (def->type == NETPLAN_DEF_TYPE_VETH && def->veth_peer_link)
+        YAML_STRING(def, event, emitter, "peer", def->veth_peer_link->id);
+
     /* Search interfaces */
     if (def->type == NETPLAN_DEF_TYPE_BRIDGE || def->type == NETPLAN_DEF_TYPE_BOND || def->type == NETPLAN_DEF_TYPE_VRF) {
         tmp_arr = g_array_new(FALSE, FALSE, sizeof(NetplanNetDefinition*));

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -524,6 +524,21 @@ write_netdev_file(const NetplanNetDefinition* def, const char* rootdir, const ch
             g_string_append_printf(s, "Kind=dummy\n");      /* wokeignore:rule=dummy */
             break;
 
+        case NETPLAN_DEF_TYPE_VETH:
+            /*
+             * Only one .netdev file is required to create the veth pair.
+             * To select what netdef we are going to use, we sort both names, get the first one,
+             * and, if the selected name is the name of the netdef being written, we generate
+             * the .netdev file. Otherwise we skip the netdef.
+             */
+            gchar* first = g_strcmp0(def->id, def->veth_peer_link->id) < 0 ? def->id : def->veth_peer_link->id;
+            if (first != def->id) {
+                g_string_free(s, TRUE);
+                return;
+            }
+            g_string_append_printf(s, "Kind=veth\n\n[Peer]\nName=%s\n", def->veth_peer_link->id);
+            break;
+
         case NETPLAN_DEF_TYPE_TUNNEL:
             switch(def->tunnel.mode) {
                 case NETPLAN_TUNNEL_MODE_GRE:

--- a/src/types.c
+++ b/src/types.c
@@ -368,6 +368,8 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     netdef->ib_mode = NETPLAN_IB_MODE_KERNEL;
 
     netdef->tunnel_private_key_flags = NETPLAN_KEY_FLAG_NONE;
+
+    netdef->veth_peer_link = NULL;
 }
 
 void

--- a/src/validation.h
+++ b/src/validation.h
@@ -44,3 +44,6 @@ validate_default_route_consistency(const NetplanParser* npp, GHashTable* netdefs
 
 gboolean
 adopt_and_validate_vrf_routes(const NetplanParser* npp, GHashTable* netdefs, GError** error);
+
+gboolean
+validate_veth_pair(const NetplanState* np_state, const NetplanNetDefinition* netdef, GError** error);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -84,6 +84,7 @@ ND_VLAN = '[NetDev]\nName=%s\nKind=vlan\n\n[VLAN]\nId=%d\n'
 ND_VXLAN = '[NetDev]\nName=%s\nKind=vxlan\n\n[VXLAN]\nVNI=%d\n'
 ND_VRF = '[NetDev]\nName=%s\nKind=vrf\n\n[VRF]\nTable=%d\n'
 ND_DUMMY = '[NetDev]\nName=%s\nKind=dummy\n'        # wokeignore:rule=dummy
+ND_VETH = '[NetDev]\nName=%s\nKind=veth\n\n[Peer]\nName=%s\n'
 SD_WPA = '''[Unit]
 Description=WPA supplicant for netplan %(iface)s
 DefaultDependencies=no

--- a/tests/generator/test_veths.py
+++ b/tests/generator/test_veths.py
@@ -1,0 +1,199 @@
+#
+# Tests for Virtual Ethernet (veth) devices config generated via netplan
+#
+# Copyright (C) 2023 Canonical, Ltd.
+# Author: Danilo Egea Gondolfo <danilo.egea.gondolfo@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from .base import ND_VETH, ND_EMPTY, TestBase
+
+
+class _CommonTests():
+    def test_missing_peer_key_should_fail(self):
+        out = self.generate('''network:
+  version: 2
+  renderer: %(r)s
+  virtual-ethernets:
+    veth0: {}''' % {'r': self.backend}, expect_fail=True)
+
+        self.assertIn('virtual-ethernet missing \'peer\' property', out)
+
+    def test_veth_peer_is_not_a_veth_interface(self):
+        out = self.generate('''network:
+  version: 2
+  renderer: %(r)s
+  virtual-ethernets:
+    veth0:
+      peer: eth0
+  ethernets:
+    eth0: {}
+      ''' % {'r': self.backend}, expect_fail=True)
+
+        self.assertIn('\'eth0\' is not a virtual-ethernet interface', out)
+
+    def test_veth_peer_is_anothers_interface_peer_already(self):
+        out = self.generate('''network:
+  version: 2
+  renderer: %(r)s
+  virtual-ethernets:
+    veth2:
+      peer: veth1
+    veth0:
+      peer: veth1
+    veth1:
+      peer: veth2''' % {'r': self.backend}, expect_fail=True)
+
+        self.assertIn('virtual-ethernet peer \'veth1\' is another virtual-ethernet\'s (veth2) peer already', out)
+
+    def test_veth_peer_is_itself(self):
+        out = self.generate('''network:
+  version: 2
+  renderer: %(r)s
+  virtual-ethernets:
+    veth1:
+      peer: veth1''' % {'r': self.backend}, expect_fail=True)
+
+        self.assertIn('virtual-ethernet peer cannot be itself', out)
+
+    def test_basic(self):
+        self.generate('''network:
+  version: 2
+  renderer: %(r)s
+  virtual-ethernets:
+    veth0:
+      peer: veth1
+    veth1:
+      peer: veth0''' % {'r': self.backend})
+
+        if self.backend == 'NetworkManager':
+            self.assert_nm({'veth0': '''[connection]
+id=netplan-veth0
+type={}
+interface-name=veth0
+
+[veth]
+peer=veth1
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''.format(('veth')), 'veth1': '''[connection]
+id=netplan-veth1
+type={}
+interface-name=veth1
+
+[veth]
+peer=veth0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''.format(('veth'))})
+
+        if self.backend == 'networkd':
+            self.assert_networkd({'veth0.network': ND_EMPTY % ('veth0', 'ipv6'),
+                                  'veth1.network': ND_EMPTY % ('veth1', 'ipv6'),
+                                  'veth0.netdev': ND_VETH % ('veth0', 'veth1')})
+
+
+class NetworkManager(TestBase, _CommonTests):
+    backend = 'NetworkManager'
+
+    def test_veth_peer_is_not_a_veth_interface_validation_stage(self):
+        out = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  virtual-ethernets:
+    veth0:
+      peer: eth0''', confs={'b': '''network:
+  renderer: NetworkManager
+  ethernets:
+    eth0: {}'''}, expect_fail=True)
+
+        self.assertIn('\'eth0\' is not a virtual-ethernet interface', out)
+
+    def test_veth_peer_has_no_peer_itself(self):
+        out = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  virtual-ethernets:
+    veth0:
+      peer: veth1
+    veth1:
+      peer: abc''', expect_fail=True)
+
+        self.assertIn('virtual-ethernet peer \'veth1\' does not have a peer itself', out)
+
+    def test_veth_peer_has_no_peer_itself_validation_stage(self):
+        out = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  virtual-ethernets:
+    veth0:
+      peer: veth1''', confs={'b': '''network:
+  version: 2
+  renderer: NetworkManager
+  virtual-ethernets:
+    veth1:
+      peer: asd'''}, expect_fail=True)
+
+        self.assertIn('virtual-ethernet peer \'veth1\' does not have a peer itself', out)
+
+    def test_veth_peer_is_anothers_interface_peer_already_validation_stage(self):
+        out = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  virtual-ethernets:
+    veth0:
+      peer: veth1
+      ''', confs={'b': '''network:
+  renderer: NetworkManager
+  virtual-ethernets:
+    veth1:
+      peer: veth2
+    veth2:
+      peer: veth1'''}, expect_fail=True)
+
+        self.assertIn('virtual-ethernet peer \'veth1\' is another virtual-ethernet\'s (veth2) peer already', out)
+
+
+class TestNetworkd(TestBase, _CommonTests):
+    backend = 'networkd'
+
+    def test_basic_missing_peer(self):
+        ''' When networkd is the renderer, both peers are required '''
+        out = self.generate('''network:
+  version: 2
+  virtual-ethernets:
+    veth0:
+      peer: veth1''', expect_fail=True)
+
+        self.assertIn('veth0: interface \'veth1\' is not defined', out)
+
+    def test_veth_peer_of_a_peer_was_not_defined(self):
+        out = self.generate('''network:
+  version: 2
+  renderer: networkd
+  virtual-ethernets:
+    veth0:
+      peer: veth1
+    veth1:
+      peer: abc''', expect_fail=True)
+
+        self.assertIn('veth1: interface \'abc\' is not defined', out)

--- a/tests/integration/veths.py
+++ b/tests/integration/veths.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python3
+# Veths integration tests.
+#
+# These need to be run in a VM and do change the system
+# configuration.
+#
+# Copyright (C) 2023 Canonical, Ltd.
+# Author: Danilo Egea Gondolfo <danilo.egea.gondolfo@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import subprocess
+import unittest
+
+from base import IntegrationTestsBase, test_backends
+
+
+class _CommonTests():
+
+    def test_create_veth_pair(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'veth0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  virtual-ethernets:
+    veth0:
+      dhcp4: false
+      dhcp6: false
+      peer: veth1
+    veth1:
+      dhcp4: false
+      dhcp6: false
+      peer: veth0''' % {'r': self.backend})
+        self.generate_and_settle(['veth0', 'veth1'])
+        self.assert_iface_up('veth0')
+        self.assert_iface_up('veth1')
+
+    def test_create_veth_pair_with_ip_address(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'veth0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  virtual-ethernets:
+    veth0:
+      dhcp4: false
+      dhcp6: false
+      peer: veth1
+      addresses:
+        - 192.168.123.123/24
+        - 1234:FFFF::42/64
+    veth1:
+      dhcp4: false
+      dhcp6: false
+      peer: veth0''' % {'r': self.backend})
+        self.generate_and_settle(['veth0', 'veth1'])
+        self.assert_iface_up('veth0')
+        self.assert_iface_up('veth1')
+
+        expected_ips = {'192.168.123.123', '1234:ffff::42'}
+        json = self.iface_json('veth0')
+        data = json.get('addr_info', {})
+        ips = {ip.get('local') for ip in data}
+        self.assertTrue(expected_ips.issubset(ips))
+
+
+@unittest.skipIf("networkd" not in test_backends,
+                 "skipping as networkd backend tests are disabled")
+class TestNetworkd(IntegrationTestsBase, _CommonTests):
+    backend = 'networkd'
+
+
+@unittest.skipIf("NetworkManager" not in test_backends,
+                 "skipping as NetworkManager backend tests are disabled")
+class TestNetworkManager(IntegrationTestsBase, _CommonTests):
+    backend = 'NetworkManager'
+
+
+unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1894,3 +1894,39 @@ dns-search='''.format(UUID))
           ethernet.cloned-mac-address: "random"
           ipv4.dns-search: ""
 '''.format(UUID, UUID)})
+
+    def test_veth_pair(self):
+        self.generate_from_keyfile('''[connection]
+id=veth-peer1
+uuid={}
+type=veth
+interface-name=veth-peer1
+
+[veth]
+peer=veth-peer2
+
+[ipv4]
+method=auto\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  virtual-ethernets:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      peer: "veth-peer2"
+      networkmanager:
+        uuid: "{}"
+        name: "veth-peer1"
+        passthrough:
+          connection.interface-name: "veth-peer1"
+'''.format(UUID, UUID)})
+
+    def test_veth_without_peer(self):
+        self.generate_from_keyfile('''[connection]
+id=veth-peer1
+uuid={}
+type=veth
+interface-name=veth-peer1
+
+[ipv4]
+method=auto\n'''.format(UUID), expect_fail=True)


### PR DESCRIPTION
# Design: Netplan support for VETH

## Rationale 

Veths are Virtual Ethernet interfaces that are commonly used to
connect bridges or network namespaces. They act like a link between
two networks, simply bypassing traffic from one veth peer to the other.

Veths work in peers, meaning that users will always create two of them.

This implementation allows users to create peers of veths, configure them with
IPs, routes and etc, change their MAC addresses and use them as member
interfaces for bridges and bonds for example. It doesn't support adding veths
to different network namespaces, although it could be done by an external tool.


## Changes in the schema

As both peers are configurable with IPs and etc, they must be defined in
separate stanzas.

A new type of network called `virtual-ethernets` was created and one extra key called 
`peer` was introduced.

```yaml
network:
  version: 2
  renderer: networkd
  virtual-ethernets:
    veth0-peer1:
      peer: veth0-peer2
    veth0-peer2:
      peer: veth0-peer1

  bridges:
    br0:
      interfaces:
        - veth0-peer1
    br1:
      interfaces:
        - veth0-peer2
```

Even though `veth` only work in pairs, it's not mandatory to define the peer
stanza (the `peer` key is mandatory) when using NetworkManager as renderer. The `peer` interface is not required
because Network Manager requires the creation of two connections, one for each
peer. As our keyfile parser maps a keyfile to a YAML file (a 1:1 mapping), if
we forced the creation of both peers, we'd had problems with the
Netplan-NetworkManager integration.

## systemd-networkd backend

Networkd requires a single `.netdev` file to create both veths.
So the configuration above will generate the `.netdev` file below:

```ini
[NetDev]
Name=veth0-peer1
Kind=veth

[Peer]
Name=veth0-peer2
```

If further configuration is required, one `.network` file per veth peer must be
created.

As only one `.netdev` is needed, we sort both peer names and use the first one.
If the peer stanza is not defined, it will not generate any files.

## Network Manager backend

On Network Manager, one keyfile per peer is required. So, creating a `veth` pair
requires 2 connections.

`veth-peer1.nmconnection`:
```ini
[connection]
id=veth-peer1
uuid=64cec75d-1f76-4379-bd82-684bc77484b9
type=veth
interface-name=veth-peer1

[veth]
peer=veth-peer2
```

`veth-peer2.nmconnection`:
```ini
[connection]
id=veth-peer2
uuid=a5d3f350-15f7-4e21-a2d4-be549531fba3
type=veth
interface-name=veth-peer2

[veth]
peer=veth-peer1
```

## Netplan Everywhere
One of the implications of these changes is that Network Manager will
create YAML files for `virtual-ethernets` automatically.

`veth` devices will be seen as unmanaged by Network Manager until the file
`/var/run/NetworkManager/conf.d/10-globally-managed-devices.conf` is
created by the generator and Network Manager is restarted. The implication
is that, `veth` pairs created with NM on a system that is not already
managed by NM will not come up online until the user either calls
`netplan apply` or restart NM.

### Keyfile parser

The keyfile parser will create a 1:1 mapping between the keyfile 
and the interface in the YAML file it generates. That's the main
reason why it's not mandatory to defined both peers at once.

That approach enable Netplan Everywhere to work out of the box
with `virtual-ethernets`.

## Alternative solution

$NOTE$: this was the original approach implemented. But due to complications
with the integration with Network Manager, we used the approach described
above.

We could make it mandatory to define both peers at once. It makes sense
because `virtual-ethernets` only work in pairs.

When creating the `veth` interface from the keyfile, a stanza for the peer
is also created and linked to the `veth`. That basically means that a keyfile
for a `veth` interface will generate 2 interfaces in the YAML file, the
interface itself and its peer. The same will happen when the second `veth`
(the peer) is created in a second API call to Network Manager. In the end,
2 Netplan YAML files will be created. When the generator is called, it will
merge both files, creating the full `veth` configuration.

This approach will require some changes in the Network Manager integration with Netplan.
Currently, Network Manager assumes a single netdef is present in the
Netplan state, but now we will have 2 netdefs. Both netdefs must be part of
the same YAML file so, instead of writing the netdef to the file, we will
need to write the entire netplan state (which will contain 2 netdefs).

After some changes to the Network Manager's integration patch, 
that's the results:

Adding the first `veth` interface:

```
nmcli con add \
  con-name veth-nm-peer1 \
  type veth \
  peer veth-nm-peer2 \
  connection.interface-name veth-nm-peer1
```

This will create the file
`/etc/netplan/90-NM-d4afd034-9634-4a67-a3ee-0c52154eefa3.yaml` with the
following content:

```yaml
network:
  version: 2
  virtual-ethernets:
    veth-nm-peer1:
      renderer: NetworkManager
      dhcp4: true
      dhcp6: true
      peer: "veth-nm-peer2"
      networkmanager:
        uuid: "d4afd034-9634-4a67-a3ee-0c52154eefa3"
        name: "veth-nm-peer1"
        passthrough:
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
    veth-nm-peer2:
      renderer: NetworkManager
      peer: "veth-nm-peer1"
```

Now, adding the `veth` peer with the following command:

```
nmcli con add \
  con-name veth-nm-peer2 \
  type veth \
  peer veth-nm-peer1 \
  connection.interface-name veth-nm-peer2
```

This will create the file
`/etc/netplan/90-NM-505fc532-a910-4346-8bd8-19e849b696e6.yaml` with the
following content:

```yaml
network:
  version: 2
  virtual-ethernets:
    veth-nm-peer2:
      renderer: NetworkManager
      dhcp4: true
      dhcp6: true
      peer: "veth-nm-peer1"
      networkmanager:
        uuid: "505fc532-a910-4346-8bd8-19e849b696e6"
        name: "veth-nm-peer2"
        passthrough:
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
    veth-nm-peer1:
      renderer: NetworkManager
      peer: "veth-nm-peer2"
```

Network Manager now has both connections:

```
NAME           UUID                                  TYPE  DEVICE
veth-nm-peer1  d4afd034-9634-4a67-a3ee-0c52154eefa3  veth  --
veth-nm-peer2  505fc532-a910-4346-8bd8-19e849b696e6  veth  --
```

`netplan get` will then produce the following result:

```yaml
network:
  version: 2
  virtual-ethernets:
    veth-nm-peer2:
      renderer: NetworkManager
      dhcp4: true
      dhcp6: true
      peer: "veth-nm-peer1"
      networkmanager:
        uuid: "505fc532-a910-4346-8bd8-19e849b696e6"
        name: "veth-nm-peer2"
        passthrough:
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
    veth-nm-peer1:
      renderer: NetworkManager
      dhcp4: true
      dhcp6: true
      peer: "veth-nm-peer2"
      networkmanager:
        uuid: "d4afd034-9634-4a67-a3ee-0c52154eefa3"
        name: "veth-nm-peer1"
        passthrough:
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
```
### Deleting connections

Netplan's `netplan_delete_connection()` will try to remove one of the peers
from the Netplan's state. As a `veth` peer cannot exist without the other,
`netplan_delete_connection()` will need to remove both connections when
any one of them is deleted.

The problem with this approach is that, after deleting one of the veths,
both of them will disappear from the YAML files but one connection will be kept
in the Network Manager's state.

So, deleting an interface, would require the deletion of both of them. If
we delete a single interface, Netplan will fail to parse the one that's left.
If we delete both of them from netplan, after running `nmcli con del`, one would
still be in the Network Manager's state so it would be out of sync with netplan.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

