### PR TITLE
Vlan keyfile parser support

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -49,6 +49,12 @@ typedef enum {
     /* Type fallback/passthrough */
     NETPLAN_DEF_TYPE_NM,
     NETPLAN_DEF_TYPE_DUMMY,     /* wokeignore:rule=dummy */
+    /* Place holder type used to fill gaps when a netdef
+     * requires links to another netdef (such as vlan_link)
+     * but it's not strictly mandatory
+     * It's intended to be used only when renderer is NetworkManager
+     */
+    NETPLAN_DEF_TYPE_NM_PLACEHOLDER_,
     NETPLAN_DEF_TYPE_MAX_
 } NetplanDefType;
 

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -1042,6 +1042,7 @@ netplan_netdef_list_write_yaml(const NetplanState* np_state, GList* netdefs, int
 
     /* Go through the netdefs type-by-type */
     for (unsigned i = 0; i < NETPLAN_DEF_TYPE_MAX_; ++i) {
+        if (i == NETPLAN_DEF_TYPE_NM_PLACEHOLDER_) continue;
         /* Per-netdef config */
         if (g_list_find_custom(netdefs, &i, contains_netdef_type)) {
             if (i == NETPLAN_DEF_TYPE_PORT) {

--- a/src/nm.c
+++ b/src/nm.c
@@ -957,6 +957,10 @@ netplan_netdef_write_nm(
 {
     gboolean no_error = TRUE;
 
+    /* Placeholder interfaces are not supposed to be rendered */
+    if (netdef->type == NETPLAN_DEF_TYPE_NM_PLACEHOLDER_)
+        return TRUE;
+
     SET_OPT_OUT_PTR(has_been_written, FALSE);
     if (netdef->backend != NETPLAN_BACKEND_NM) {
         g_debug("NetworkManager: definition %s is not for us (backend %i)", netdef->id, netdef->backend);

--- a/src/parse.c
+++ b/src/parse.c
@@ -3071,8 +3071,13 @@ handle_network_type(NetplanParser* npp, yaml_node_t* node, const char* key_prefi
         npp->current.netdef = npp->parsed_defs ? g_hash_table_lookup(npp->parsed_defs, scalar(key)) : NULL;
         if (npp->current.netdef) {
             /* already exists, overriding/amending previous definition */
-            if (npp->current.netdef->type != GPOINTER_TO_UINT(data))
-                return yaml_error(npp, key, error, "Updated definition '%s' changes device type", scalar(key));
+            if (npp->current.netdef->type != GPOINTER_TO_UINT(data)) {
+                /* If the existing netdef is a place holder, we just repurpose it */
+                if (npp->current.netdef->type == NETPLAN_DEF_TYPE_NM_PLACEHOLDER_)
+                    npp->current.netdef->type = GPOINTER_TO_UINT(data);
+                else
+                    return yaml_error(npp, key, error, "Updated definition '%s' changes device type", scalar(key));
+            }
         } else {
             npp->current.netdef = netplan_netdef_new(npp, scalar(key), GPOINTER_TO_UINT(data), npp->current.backend);
         }

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -400,9 +400,6 @@ address1=192.168.123.123/24
     def test_keyfile_type_bond(self):
         self._template_keyfile_type('bonds', 'bond')
 
-    def test_keyfile_type_vlan(self):
-        self._template_keyfile_type('nm-devices', 'vlan', False)
-
     def test_keyfile_type_tunnel(self):
         self._template_keyfile_type('tunnels', 'ip-tunnel', False)
 
@@ -824,20 +821,18 @@ method=ignore
 '''.format(UUID))
         self.assert_netplan({UUID: '''network:
   version: 2
-  nm-devices:
+  vlans:
     NM-{}:
       renderer: NetworkManager
+      addresses:
+      - "1.2.3.4/24"
+      id: 1
+      link: "en1"
       networkmanager:
         uuid: "{}"
         name: "netplan-enblue"
         passthrough:
-          connection.type: "vlan"
           connection.interface-name: "enblue"
-          vlan.id: "1"
-          vlan.parent: "en1"
-          ipv4.method: "manual"
-          ipv4.address1: "1.2.3.4/24"
-          ipv6.method: "ignore"
 '''.format(UUID, UUID)})
 
     def test_keyfile_bridge(self):


### PR DESCRIPTION
## Description

Support for reading VLAN keyfiles.

One problem found during the implementation is that Netplan requires the existence of the `link` interface in the YAML configuration. Although Network Manager can create a vlan connection even if the parent interface doesn't exist.

The approach used here basically makes netplan to behave the same way: when the renderer is NetworkManager, it will ignore the fact that the parent doesn't exist and point to whatever interface was used by NM. In order to continue passing the VLAN validation rules, the netdef type `NETPLAN_DEF_TYPE_NM_PLACEHOLDER_` was introduced. It will be used in cases where a required dependency can't be satisfied but it's still required by Netplan but not by Network Manager. So its use is basically to fill this gap and allow the backend renderer to retrieve the VLAN link ID from the place holder netdef.

For example, the command `nmcli con add con-name vlan-123 type vlan dev enp5s0 id 123` will generate the following keyfile:

```ini
[connection]
id=vlan-123
uuid=7f329164-8206-4937-9f8e-11e51767af89
type=vlan

[ethernet]

[vlan]
flags=1
id=123
parent=enp5s0

[ipv4]
method=auto

[ipv6]
addr-gen-mode=default
method=auto

[proxy]
```

The keyfile parser will produce the following YAML. The value in the key `link` will point to a name that might not be an existing netplan interface ID (netdef).

```yaml
network:
  version: 2
  vlans:
    NM-7f329164-8206-4937-9f8e-11e51767af89:
      renderer: NetworkManager
      dhcp4: true
      dhcp6: true
      id: 123
      link: "enp5s0"
      networkmanager:
        uuid: "7f329164-8206-4937-9f8e-11e51767af89"
        name: "vlan-123"
        passthrough:
          ethernet._: ""
          vlan.flags: "1"
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
```

This is unfortunately required due to the way we import keyfiles at the moment.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

