### PR TITLE
NetworkManager: Wireguard private key flag support

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1642,6 +1642,39 @@ The specific settings for tunnels are defined below.
     > `systemd-networkd` backend (v242+) is used, this can also be an
     > absolute path to a file containing the private key.
 
+  - **private-key-flags** (sequence of scalars) – since **0.107**
+
+    > Private key flags used by Network Manager. Possible values are:
+    > `agent-owned`, `not-saved` and `not-required`.
+    >
+    > `agent-owned`: a user-session secret agent is responsible for
+    > providing and storing this secret.
+    >
+    > `not-saved`: this secret should not be saved but should be
+    > requested from the user each time it is required.
+    >
+    > `not-required`: this flag hints that the secret is not required
+    > and should not be requested from the user.
+
+    Example:
+
+    ```yaml
+    network:
+      renderer: NetworkManager
+      tunnels:
+        wg0:
+          mode: wireguard
+          port: 5182
+          key:
+            private-key-flags:
+              - agent-owned
+          peers:
+            - keys:
+                public: rlbInAj0qV69CysWPQY7KEBnKxpYCpaWqOs/dLevdWc=
+              allowed-ips: [0.0.0.0/0, "2001:fe:ad:de:ad:be:ef:1/24"]
+              keepalive: 23
+              endpoint: 1.2.3.4:5
+      ```
 - **keys** (scalar or mapping)
 
   > Alternate name for the `key` field. See above.

--- a/src/abi.h
+++ b/src/abi.h
@@ -132,6 +132,14 @@ typedef struct authentication_settings {
     char* phase2_auth;  /* netplan-feature: auth-phase2 */
 } NetplanAuthenticationSettings;
 
+typedef enum {
+    NETPLAN_KEY_FLAG_NONE           = 0,
+    NETPLAN_KEY_FLAG_AGENT_OWNED    = 1<<0,
+    NETPLAN_KEY_FLAG_NOT_SAVED      = 1<<1,
+    NETPLAN_KEY_FLAG_NOT_REQUIRED   = 1<<2,
+    NETPLAN_KEY_FLAG_MAX_
+} NetplanKeyFlags;
+
 typedef struct ovs_controller {
     char* connection_mode;
     GArray* addresses;
@@ -383,4 +391,6 @@ struct netplan_net_definition {
 
     /* True if "networkmanager" settings are present */
     gboolean has_backend_settings_nm;
+
+    guint tunnel_private_key_flags;
 };

--- a/src/names.c
+++ b/src/names.c
@@ -103,6 +103,14 @@ netplan_infiniband_mode_to_str[NETPLAN_IB_MODE_MAX_] = {
     [NETPLAN_IB_MODE_CONNECTED] = "connected"
 };
 
+static const char* const
+netplan_key_flags_to_str[NETPLAN_KEY_FLAG_MAX_] = {
+    [NETPLAN_KEY_FLAG_NONE] = NULL,
+    [NETPLAN_KEY_FLAG_AGENT_OWNED] = "agent-owned",
+    [NETPLAN_KEY_FLAG_NOT_SAVED] = "not-saved",
+    [NETPLAN_KEY_FLAG_NOT_REQUIRED] = "not-required",
+};
+
 #define NAME_FUNCTION(_radical, _type) const char *netplan_ ## _radical ## _name( _type val) \
 { \
     return (val < sizeof(netplan_ ## _radical ## _to_str) / sizeof(char *)) ?  netplan_ ## _radical ## _to_str [val] : NULL; \
@@ -124,6 +132,7 @@ NAME_FUNCTION(tunnel_mode, NetplanTunnelMode);
 NAME_FUNCTION(addr_gen_mode, NetplanAddrGenMode);
 NAME_FUNCTION(wifi_mode, NetplanWifiMode);
 NAME_FUNCTION(infiniband_mode, NetplanInfinibandMode);
+NAME_FUNCTION(key_flags, NetplanKeyFlags);
 NAME_FUNCTION_FLAGS(vxlan_notification);
 NAME_FUNCTION_FLAGS(vxlan_checksum);
 NAME_FUNCTION_FLAGS(vxlan_extension);

--- a/src/names.h
+++ b/src/names.h
@@ -45,6 +45,9 @@ const char*
 netplan_infiniband_mode_name(NetplanInfinibandMode val);
 
 const char*
+netplan_key_flags_name(NetplanKeyFlags val);
+
+const char*
 netplan_vxlan_notification_name(int val);
 
 const char*

--- a/src/nm.c
+++ b/src/nm.c
@@ -344,6 +344,9 @@ write_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError** e
             g_key_file_set_string(kf, "wireguard", "private-key", def->tunnel.private_key);
     }
 
+    if (def->tunnel_private_key_flags != NETPLAN_KEY_FLAG_NONE)
+        g_key_file_set_uint64(kf, "wireguard", "private-key-flags", def->tunnel_private_key_flags);
+
     if (def->tunnel.port)
         g_key_file_set_uint64(kf, "wireguard", "listen-port", def->tunnel.port);
     if (def->tunnel.fwmark)

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -498,6 +498,9 @@ parse_tunnels(GKeyFile* kf, NetplanNetDefinition* nd)
         nd->tunnel.port = g_key_file_get_uint64(kf, "wireguard", "listen-port", NULL);
         _kf_clear_key(kf, "wireguard", "listen-port");
 
+        nd->tunnel_private_key_flags = g_key_file_get_integer(kf, "wireguard", "private-key-flags", NULL);
+        _kf_clear_key(kf, "wireguard", "private-key-flags");
+
         gchar** keyfile_groups = g_key_file_get_groups(kf, NULL);
 
         /* Handling peers

--- a/src/types.c
+++ b/src/types.c
@@ -366,6 +366,8 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     netdef->large_receive_offload = NETPLAN_TRISTATE_UNSET;
 
     netdef->ib_mode = NETPLAN_IB_MODE_KERNEL;
+
+    netdef->tunnel_private_key_flags = NETPLAN_KEY_FLAG_NONE;
 }
 
 void

--- a/src/validation.c
+++ b/src/validation.c
@@ -202,7 +202,7 @@ validate_tunnel_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
         return yaml_error(npp, node, error, "%s: missing or invalid 'mode' property for tunnel", nd->id);
 
     if (nd->tunnel.mode == NETPLAN_TUNNEL_MODE_WIREGUARD) {
-        if (!nd->tunnel.private_key)
+        if (!nd->tunnel.private_key && nd->tunnel_private_key_flags == NETPLAN_KEY_FLAG_NONE)
             g_warning("%s: missing 'key' property (private key) for wireguard", nd->id);
         if (nd->tunnel.private_key && nd->tunnel.private_key[0] != '/' && !is_wireguard_key(nd->tunnel.private_key))
             return yaml_error(npp, node, error, "%s: invalid wireguard private key", nd->id);

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1632,6 +1632,90 @@ method=auto\n'''.format(UUID), regenerate=False)
           connection.interface-name: "wg0"
 '''.format(UUID, UUID)})
 
+    def test_wireguard_with_key_flags(self):
+        self.generate_from_keyfile('''[connection]
+id=wg0
+type=wireguard
+uuid={}
+interface-name=wg0
+
+[wireguard]
+listen-port=51820
+private-key-flags=1
+
+[wireguard-peer.M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=]
+endpoint=10.20.30.40:51820
+allowed-ips=0.0.0.0/0;
+
+[ipv4]
+method=auto\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "wireguard"
+      port: 51820
+      keys:
+        private-key-flags:
+        - agent-owned
+      peers:
+      - endpoint: "10.20.30.40:51820"
+        keys:
+          public: "M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4="
+        allowed-ips:
+        - "0.0.0.0/0"
+      networkmanager:
+        uuid: "{}"
+        name: "wg0"
+        passthrough:
+          connection.interface-name: "wg0"
+'''.format(UUID, UUID)})
+
+    def test_wireguard_with_key_all_flags_enabled(self):
+        self.generate_from_keyfile('''[connection]
+id=wg0
+type=wireguard
+uuid={}
+interface-name=wg0
+
+[wireguard]
+listen-port=51820
+private-key-flags=7
+
+[wireguard-peer.M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=]
+endpoint=10.20.30.40:51820
+allowed-ips=0.0.0.0/0;
+
+[ipv4]
+method=auto\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "wireguard"
+      port: 51820
+      keys:
+        private-key-flags:
+        - agent-owned
+        - not-saved
+        - not-required
+      peers:
+      - endpoint: "10.20.30.40:51820"
+        keys:
+          public: "M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4="
+        allowed-ips:
+        - "0.0.0.0/0"
+      networkmanager:
+        uuid: "{}"
+        name: "wg0"
+        passthrough:
+          connection.interface-name: "wg0"
+'''.format(UUID, UUID)})
+
     def test_wireguard_with_key_and_peer_without_allowed_ips(self):
         self.generate_from_keyfile('''[connection]
 id=wg0


### PR DESCRIPTION
## Description

Network Manager supports storing the Wireguard private key in an external keychain agent, like the kdewallet. In this cases, it will emit the following configuration in the keyfile: `wireguard.private-key-flags=1` and omit the private key, which will be stored somewhere else.

The new key will look like this:

```yaml
network:
  version: 2
  tunnels:
    wg-tunnel:
      renderer: NetworkManager
      addresses:
      - "10.20.30.1/24"
      mode: "wireguard"
      port: 51820
      keys:
        private-key-flags:
        - agent-owned
```

Adding this options is one way of solving the issue described here https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2024661

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

