### PR TITLE
parse-nm:wg: add support for reading the listen-port property

### DIFF
--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -477,6 +477,10 @@ parse_tunnels(GKeyFile* kf, NetplanNetDefinition* nd)
         nd->tunnel.private_key = g_key_file_get_string(kf, "wireguard", "private-key", NULL);
         _kf_clear_key(kf, "wireguard", "private-key");
 
+        /* Reading the listen port */
+        nd->tunnel.port = g_key_file_get_uint64(kf, "wireguard", "listen-port", NULL);
+        _kf_clear_key(kf, "wireguard", "listen-port");
+
         gchar** keyfile_groups = g_key_file_get_groups(kf, NULL);
 
         /* Handling peers


### PR DESCRIPTION
## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

