### PR TITLE
Improve autopkgtest stability with systemd 253 & iproute 6.4

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -31,6 +31,7 @@ import unittest
 import shutil
 import gi
 import glob
+import json
 
 # make sure we point to libnetplan properly.
 os.environ.update({'LD_LIBRARY_PATH': '.:{}'.format(os.environ.get('LD_LIBRARY_PATH'))})
@@ -277,6 +278,15 @@ class IntegrationTestsBase(unittest.TestCase):
             self.poll_text(dnsmasq_log, 'IPv6 router advertisement enabled')
         else:
             self.poll_text(dnsmasq_log, 'DHCP, IP range')
+
+    def iface_json(self, iface: str) -> dict:
+        '''Return iproute2's (detailed) JSON representation'''
+        out = subprocess.check_output(['ip', '-j', '-d', 'a', 'show', 'dev', iface],
+                                      text=True)
+        json_dict = json.loads(out)
+        if json_dict:
+            return json_dict[0]
+        return {}
 
     def assert_iface(self, iface, expected_ip_a=None, unexpected_ip_a=None):
         '''Assert that client interface has been created'''

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -76,6 +76,9 @@ class IntegrationTestsBase(unittest.TestCase):
             f.write('[keyfile]\nunmanaged-devices=interface-name:en*,eth0,nptestsrv')
         subprocess.check_call(['netplan', 'apply'])
         subprocess.call(['/lib/systemd/systemd-networkd-wait-online', '--quiet', '--timeout=30'])
+        if klass.is_active('NetworkManager.service'):
+            subprocess.check_call(['nm-online', '-s'])
+            subprocess.check_call(['nmcli', 'general', 'reload'])
 
     @classmethod
     def tearDownClass(klass):
@@ -115,19 +118,29 @@ class IntegrationTestsBase(unittest.TestCase):
         if os.path.exists('/sys/class/net/eth42'):
             raise SystemError('eth42 interface already exists')
 
-        # create virtual ethernet devs
-        subprocess.check_call(['ip', 'link', 'add', 'name', 'eth42', 'type',
-                               'veth', 'peer', 'name', 'veth42'])
         klass.dev_e_ap = 'veth42'
         klass.dev_e_client = 'eth42'
         klass.dev_e_ap_ip4 = '192.168.5.1/24'
         klass.dev_e_ap_ip6 = '2600::1/64'
-        subprocess.check_call(['ip', 'link', 'add', 'name', 'eth43', 'type',
-                               'veth', 'peer', 'name', 'veth43'])
+
         klass.dev_e2_ap = 'veth43'
         klass.dev_e2_client = 'eth43'
         klass.dev_e2_ap_ip4 = '192.168.6.1/24'
         klass.dev_e2_ap_ip6 = '2601::1/64'
+
+        # don't let NM trample over our test routers
+        with open('/etc/NetworkManager/conf.d/99-test-denylist.conf', 'w') as f:
+            f.write('[keyfile]\nunmanaged-devices+=%s,%s\n' % (klass.dev_e_ap, klass.dev_e2_ap))
+        if klass.is_active('NetworkManager.service'):
+            subprocess.check_call(['nm-online', '-s'])
+            subprocess.check_call(['nmcli', 'general', 'reload'])
+
+        # create virtual ethernet devs
+        subprocess.check_call(['ip', 'link', 'add', 'name', 'eth42', 'type',
+                               'veth', 'peer', 'name', 'veth42'])
+        subprocess.check_call(['ip', 'link', 'add', 'name', 'eth43', 'type',
+                               'veth', 'peer', 'name', 'veth43'])
+
         # Creation of the veths introduces a race with newer versions of
         # systemd, as it  will change the initial MAC address after the device
         # was created and networkd took control. Give it some time, so we read
@@ -139,10 +152,6 @@ class IntegrationTestsBase(unittest.TestCase):
         out = subprocess.check_output(['ip', '-br', 'link', 'show', 'dev', 'eth43'],
                                       text=True)
         klass.dev_e2_client_mac = out.split()[2]
-
-        # don't let NM trample over our test routers
-        with open('/etc/NetworkManager/conf.d/99-test-denylist.conf', 'w') as f:
-            f.write('[keyfile]\nunmanaged-devices+=%s,%s\n' % (klass.dev_e_ap, klass.dev_e2_ap))
 
     @classmethod
     def shutdown_devices(klass):
@@ -322,7 +331,10 @@ class IntegrationTestsBase(unittest.TestCase):
         if 'Run \'systemctl daemon-reload\' to reload units.' in out:
             self.fail('systemd units changed without reload')
         # start NM so that we can verify that it does not manage anything
-        subprocess.check_call(['systemctl', 'start', 'NetworkManager.service'])
+        subprocess.call(['nm-online', '-sxq'])  # Wait for NM startup, from 'netplan apply'
+        if not self.is_active('NetworkManager.service'):
+            subprocess.check_call(['systemctl', 'start', 'NetworkManager.service'])
+            subprocess.call(['nm-online', '-sq'])
 
         # Debugging output
         # out = subprocess.check_output(['NetworkManager', '--print-config'], text=True)

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -94,14 +94,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(2)
         p.send_signal(signal.SIGUSR1)
-        out, err = p.communicate()
-        p.wait(10)
+        out, err = p.communicate(timeout=10)
         self.assertEqual('', err)
         self.assertNotIn('An error occurred:', out)
-        self.assertRegex(out.strip(), r'Do you want to keep these settings\?\n\n\n'
-                         r'Press ENTER before the timeout to accept the new configuration\n\n\n'
-                         r'(Changes will revert in \d+ seconds\n)+'
-                         r'Configuration accepted\.')
+        self.assertIn('Configuration accepted.', out)
 
     def test_try_reject_lp1949095(self):
         with open(self.config, 'w') as f:
@@ -113,14 +109,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(2)
         p.send_signal(signal.SIGINT)
-        out, err = p.communicate()
-        p.wait(10)
+        out, err = p.communicate(timeout=10)
         self.assertEqual('', err)
         self.assertNotIn('An error occurred:', out)
-        self.assertRegex(out.strip(), r'Do you want to keep these settings\?\n\n\n'
-                         r'Press ENTER before the timeout to accept the new configuration\n\n\n'
-                         r'(Changes will revert in \d+ seconds\n)+'
-                         r'Reverting\.')
+        self.assertIn('Reverting.', out)
 
     def test_apply_networkd_inactive_lp1962095(self):
         self.setup_eth(None)

--- a/tests/integration/tunnels.py
+++ b/tests/integration/tunnels.py
@@ -229,9 +229,13 @@ class _CommonTests():
                                   ' l3miss ', ' ttl 64 ', ' ageing 100 '])
         if self.backend == 'networkd':
             # checksums are not supported on the NetworkManager backend
-            self.assert_iface('vx0', [' udpcsum ', ' udp6zerocsumtx ',
-                                      ' udp6zerocsumrx ', ' remcsumtx ',
-                                      ' remcsumrx '])
+            json = self.iface_json('vx0')
+            data = json.get('linkinfo', {}).get('info_data', {})
+            self.assertTrue(data.get('udp_csum'))
+            self.assertTrue(data.get('udp_zero_csum6_tx'))
+            self.assertTrue(data.get('udp_zero_csum6_rx'))
+            self.assertTrue(data.get('remcsum_tx'))
+            self.assertTrue(data.get('remcsum_rx'))
 
 
 @unittest.skipIf("networkd" not in test_backends,


### PR DESCRIPTION
## Description
    Starting with the systemd v253 update NetworkManager started taking
    implicit control of certain interfaces, blocking itself (after a restart)
    from managing those interface through its configure netplan-* connection
    profile.

https://bugs.debian.org/1039071

    iproute2 v6.4 changed its CLI output, the JSON output is expected to
    stay stable, so we should migrate to using iface_json() over time.

https://bugs.debian.org/1040004

Also, resolves a race condition where the following text is already gone from the buffer at the time when we check the assertions. We see such failures a lot in the Ubuntu autopkgtests:
```
Do you want to keep these settings?
Press ENTER before the timeout to accept the new configuration
Changes will revert in {} seconds
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

