### PR TITLE
doc: Explanation about 00-network-manager-all.yaml

### DIFF
--- a/doc/explanation.md
+++ b/doc/explanation.md
@@ -5,6 +5,11 @@
 structure-id
 ```
 
+## NetworkManager
+```{toctree}
+nm-all
+```
+
 ## Design
 Network configuration abstraction via systemd-generator
 ```{toctree}

--- a/doc/nm-all.md
+++ b/doc/nm-all.md
@@ -1,0 +1,26 @@
+## NetworkManager default configuration
+
+Without configuration, Netplan will not do anything. Therefore, on Desktop
+systems, a useful configuration snippet to just bring up networking via DHCP is
+as follows:
+
+```yaml
+network:
+  version: 2
+  renderer: NetworkManager
+```
+
+This will make NetworkManager manage all devices and by default. Any ethernet
+device will come up with DHCP, once carrier is detected. This is basically
+Netplan passing control over to NetworkManager at boot time.
+
+You can still define any more specific IDs in you Netplan configuration, to
+configure interfaces individually, according to Netplan's [YAML reference](/netplan-yaml/).
+
+When NetworkManager's [Netplan desktop integration}(/netplan-everywhere/) is
+activated, NetworkManager will automatically create specific Netplan IDs for
+each of its connection profiles.
+
+This configuration snippet is shipped by default on Ubuntu Desktop systems
+through the [ubuntu-settings](https://launchpad.net/ubuntu/+source/ubuntu-settings)
+package as `/usr/lib/netplan/00-network-manager-all.yaml`.


### PR DESCRIPTION
## Description

This adds an explanation section to Netplan's docs, about the `/usr/lib/netplan/00-network-manager-all.yaml` default configuration:
```yaml
network:
  version: 2
  renderer: NetworkManager
```

Replaces: https://github.com/canonical/netplan/pull/373

See also: https://github.com/canonical/netplan.io/pull/273

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

