### PR TITLE
Fixes for minor issues

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('netplan', 'c',
         license: 'GPL3',
         default_options: [
             'c_std=c99',
-            'warning_level=1',
+            'warning_level=2',
             'werror=true',
         ],
         meson_version: '>= 0.61.0',

--- a/src/abi.h
+++ b/src/abi.h
@@ -252,7 +252,7 @@ struct netplan_net_definition {
     } match;
     gboolean has_match;
     gboolean wake_on_lan;
-    NetplanWifiWowlanFlag wowlan;
+    gint wowlan;
     gboolean emit_lldp;
 
     /* these properties are only valid for NETPLAN_DEF_TYPE_WIFI */

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -273,7 +273,7 @@ method_apply(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 }
 
 static int
-method_generate(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
+method_generate(sd_bus_message *m, __unused void *userdata, sd_bus_error *ret_error)
 {
     g_autoptr(GError) err = NULL;
     g_autofree gchar *stdout = NULL;
@@ -306,7 +306,7 @@ method_generate(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 }
 
 static int
-method_info(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
+method_info(sd_bus_message *m, __unused void *userdata, __unused sd_bus_error *ret_error)
 {
     sd_bus_message *reply = NULL;
     gint exit_status = 0;
@@ -434,7 +434,7 @@ method_set(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
 }
 
 static int
-netplan_try_cancelled_cb(sd_event_source *es, const siginfo_t *si, void* userdata)
+netplan_try_cancelled_cb(__unused sd_event_source *es, const siginfo_t *si, void* userdata)
 {
     NetplanData *d = userdata;
     g_autofree gchar *state_dir = NULL;
@@ -778,7 +778,7 @@ static const sd_bus_vtable netplan_vtable[] = {
  */
 
 static int
-terminate_mainloop_cb(sd_event_source *es, const struct signalfd_siginfo *si, void* userdata) {
+terminate_mainloop_cb(__unused sd_event_source *es, __unused const struct signalfd_siginfo *si, void* userdata) {
     sd_event *event = userdata;
     /* Gracefully terminate the mainloop, to write GCOV output */
     sd_event_exit(event, 0);
@@ -786,7 +786,7 @@ terminate_mainloop_cb(sd_event_source *es, const struct signalfd_siginfo *si, vo
 }
 
 int
-main(int argc, char *argv[])
+main(__unused int argc, __unused char *argv[])
 {
     sd_bus_slot *slot = NULL;
     sd_bus *bus = NULL;

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -518,7 +518,7 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     if (seconds > 0)
         poll_timeout = seconds * 100;
     /* Timeout after up to 10 sec of waiting for the stamp file */
-    for (int i = 0; i < poll_timeout; i++) {
+    for (guint i = 0; i < poll_timeout; i++) {
         struct timespec timeout = {
             .tv_sec = 0,
             .tv_nsec = 1000 * 1000 * 10, // 10 ms

--- a/src/error.c
+++ b/src/error.c
@@ -73,7 +73,7 @@ get_syntax_error_context(const NetplanParser* npp, const int line_num, const int
 }
 
 static char *
-get_parser_error_context(const yaml_parser_t *parser, GError **error)
+get_parser_error_context(const yaml_parser_t *parser, __unused GError **error)
 {
     GString *message = NULL;
     unsigned char* line = parser->buffer.pointer;

--- a/src/generate.c
+++ b/src/generate.c
@@ -43,9 +43,9 @@ static gboolean any_nm = FALSE;
 static gchar* mapping_iface;
 
 static GOptionEntry options[] = {
-    {"root-dir", 'r', 0, G_OPTION_ARG_FILENAME, &rootdir, "Search for and generate configuration files in this root directory instead of /"},
+    {"root-dir", 'r', 0, G_OPTION_ARG_FILENAME, &rootdir, "Search for and generate configuration files in this root directory instead of /", NULL},
     {G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &files, "Read configuration from this/these file(s) instead of /etc/netplan/*.yaml", "[config file ..]"},
-    {"mapping", 0, 0, G_OPTION_ARG_STRING, &mapping_iface, "Only show the device to backend mapping for the specified interface."},
+    {"mapping", 0, 0, G_OPTION_ARG_STRING, &mapping_iface, "Only show the device to backend mapping for the specified interface.", NULL},
     {NULL}
 };
 

--- a/src/names.c
+++ b/src/names.c
@@ -134,7 +134,7 @@ NAME_FUNCTION_FLAGS(vxlan_extension);
         if (g_strcmp0(val, netplan_ ## _radical ## _to_str[i]) == 0) \
             return i; \
     } \
-    return -1; \
+    return NETPLAN_DEF_TYPE_NONE; \
 }
 
 ENUM_FUNCTION(def_type, NetplanDefType);

--- a/src/names.c
+++ b/src/names.c
@@ -130,7 +130,7 @@ NAME_FUNCTION_FLAGS(vxlan_extension);
 
 #define ENUM_FUNCTION(_radical, _type) _type netplan_ ## _radical ## _from_name(const char* val) \
 { \
-    for (int i = 0; i < sizeof(netplan_ ## _radical ## _to_str); ++i) { \
+    for (size_t i = 0; i < sizeof(netplan_ ## _radical ## _to_str); ++i) { \
         if (g_strcmp0(val, netplan_ ## _radical ## _to_str[i]) == 0) \
             return i; \
     } \

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -37,7 +37,7 @@
  * Append WiFi frequencies to wpa_supplicant's freq_list=
  */
 static void
-wifi_append_freq(gpointer key, gpointer value, gpointer user_data)
+wifi_append_freq(__unused gpointer key, gpointer value, gpointer user_data)
 {
     GString* s = user_data;
     g_string_append_printf(s, "%d ", GPOINTER_TO_INT(value));

--- a/src/nm.c
+++ b/src/nm.c
@@ -949,7 +949,7 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
  */
 gboolean
 netplan_netdef_write_nm(
-        const NetplanState* np_state,
+        __unused const NetplanState* np_state,
         const NetplanNetDefinition* netdef,
         const char* rootdir,
         gboolean* has_been_written,
@@ -997,7 +997,7 @@ gboolean
 netplan_state_finish_nm_write(
         const NetplanState* np_state,
         const char* rootdir,
-        GError** error)
+        __unused GError** error)
 {
     GString* udev_rules = g_string_new(NULL);
     GString *nm_conf = g_string_new(NULL);

--- a/src/nm.c
+++ b/src/nm.c
@@ -42,7 +42,7 @@
  * This is done by checking for certain modem_params, which are only
  * applicable to GSM connections.
  */
-static const gboolean
+static gboolean
 modem_is_gsm(const NetplanNetDefinition* def)
 {
     if (   def->modem_params.apn

--- a/src/nm.c
+++ b/src/nm.c
@@ -174,7 +174,7 @@ write_search_domains(const NetplanNetDefinition* def, const char* group, GKeyFil
 }
 
 static gboolean
-write_routes(const NetplanNetDefinition* def, GKeyFile *kf, int family, GError** error)
+write_routes(const NetplanNetDefinition* def, GKeyFile *kf, gint family, GError** error)
 {
     const gchar* group = NULL;
     gchar* tmp_key = NULL;

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -34,7 +34,7 @@
  * https://bugzilla.gnome.org/show_bug.cgi?id=696940
  * https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/c36200a225aefb2a3919618e75682646899b82c0
  */
-static const NetplanDefType
+static NetplanDefType
 type_from_str(const char* type_str)
 {
     if (!g_strcmp0(type_str, "ethernet") || !g_strcmp0(type_str, "802-3-ethernet"))
@@ -59,7 +59,7 @@ type_from_str(const char* type_str)
     return NETPLAN_DEF_TYPE_NM;
 }
 
-static const NetplanWifiMode
+static NetplanWifiMode
 ap_type_from_str(const char* type_str)
 {
     if (!g_strcmp0(type_str, "infrastructure"))
@@ -72,7 +72,7 @@ ap_type_from_str(const char* type_str)
     return NETPLAN_WIFI_MODE_OTHER;
 }
 
-static const NetplanTunnelMode
+static NetplanTunnelMode
 tunnel_mode_from_str(const char* type_str)
 {
     if (!g_strcmp0(type_str, "wireguard"))

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -244,7 +244,7 @@ parse_routes(GKeyFile* kf, const gchar* group, GArray** routes_arr)
             *routes_arr = g_array_new(FALSE, TRUE, sizeof(NetplanIPRoute*));
         route = g_new0(NetplanIPRoute, 1);
         route->type = g_strdup("unicast");
-        route->family = G_MAXUINT; /* 0 is a valid family ID */
+        route->family = -1; /* 0 is a valid family ID */
         route->metric = NETPLAN_METRIC_UNSPEC; /* 0 is a valid metric */
         g_debug("%s: adding new route (kf)", key);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -356,7 +356,7 @@ handle_generic_guint(NetplanParser* npp, yaml_node_t* node, const void* entryptr
  *        located
  */
 static gboolean
-handle_generic_str(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
+handle_generic_str(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, __unused GError** error)
 {
     g_assert(entryptr);
     guint offset = GPOINTER_TO_UINT(data);
@@ -569,7 +569,7 @@ handle_embedded_switch_mode(NetplanParser* npp, yaml_node_t* node, const void* d
 }
 
 static gboolean
-handle_ib_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_ib_mode(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     if (g_strcmp0(scalar(node), "datagram") == 0)
         npp->current.netdef->ib_mode = NETPLAN_IB_MODE_DATAGRAM;
@@ -589,7 +589,7 @@ handle_ib_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError**
  *        located
  */
 static gboolean
-handle_netdef_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_netdef_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, __unused GError** error)
 {
     guint offset = GPOINTER_TO_UINT(data);
     NetplanNetDefinition* ref = NULL;
@@ -618,7 +618,7 @@ handle_netdef_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, GE
  *        write is located
  */
 static gboolean
-handle_vxlan_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_vxlan_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, __unused GError** error)
 {
     guint offset = GPOINTER_TO_UINT(data);
     NetplanNetDefinition* ref = NULL;
@@ -739,7 +739,7 @@ handle_netdef_ip6(NetplanParser* npp, yaml_node_t* node, const void* data, GErro
 }
 
 static gboolean
-handle_netdef_addrgen(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_netdef_addrgen(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     g_assert(npp->current.netdef);
     if (strcmp(scalar(node), "eui64") == 0)
@@ -780,7 +780,7 @@ handle_netdef_backend_settings_str(NetplanParser* npp, yaml_node_t* node, const 
  * user_data is expected to contain a pointer to the GData list.
  */
 static void
-validate_kf_group_key(GQuark key_id, gpointer value, gpointer user_data)
+validate_kf_group_key(GQuark key_id, __unused gpointer value, gpointer user_data)
 {
     GData** list = user_data;
     const gchar* key = g_quark_to_string(key_id);
@@ -815,7 +815,7 @@ handle_netdef_passthrough_datalist(NetplanParser* npp, yaml_node_t* node, const 
  ****************************************************/
 
 static gboolean
-handle_match_driver(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_match_driver(NetplanParser* npp, yaml_node_t* node, __unused const char* key_prefix, __unused const void* _, GError** error)
 {
     gboolean ret = FALSE;
     yaml_node_t *elem = NULL;
@@ -865,7 +865,7 @@ static const mapping_entry_handler match_handlers[] = {
  ****************************************************/
 
 static gboolean
-handle_auth_str(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_auth_str(NetplanParser* npp, yaml_node_t* node, const void* data, __unused GError** error)
 {
     g_assert(npp->current.auth);
     guint offset = GPOINTER_TO_UINT(data);
@@ -877,7 +877,7 @@ handle_auth_str(NetplanParser* npp, yaml_node_t* node, const void* data, GError*
 }
 
 static gboolean
-handle_auth_key_management(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_auth_key_management(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanAuthenticationSettings* auth = npp->current.auth;
     g_assert(auth);
@@ -897,7 +897,7 @@ handle_auth_key_management(NetplanParser* npp, yaml_node_t* node, const void* _,
 }
 
 static gboolean
-handle_auth_method(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_auth_method(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanAuthenticationSettings* auth = npp->current.auth;
     g_assert(auth);
@@ -931,7 +931,7 @@ static const mapping_entry_handler auth_handlers[] = {
  ****************************************************/
 
 NetplanBackend
-get_default_backend_for_type(NetplanBackend global_backend, NetplanDefType type)
+get_default_backend_for_type(NetplanBackend global_backend, __unused NetplanDefType type)
 {
     if (global_backend != NETPLAN_BACKEND_NONE)
         return global_backend;
@@ -985,7 +985,7 @@ handle_access_point_bool(NetplanParser* npp, yaml_node_t* node, const void* data
 }
 
 static gboolean
-handle_access_point_password(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_access_point_password(NetplanParser* npp, yaml_node_t* node, __unused const void* _, __unused GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
     g_assert(access_point);
@@ -998,7 +998,7 @@ handle_access_point_password(NetplanParser* npp, yaml_node_t* node, const void* 
 }
 
 static gboolean
-handle_access_point_auth(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_access_point_auth(NetplanParser* npp, yaml_node_t* node, __unused const char* key_prefix, __unused const void* _, GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
     gboolean ret;
@@ -1014,7 +1014,7 @@ handle_access_point_auth(NetplanParser* npp, yaml_node_t* node, const char* key_
 }
 
 static gboolean
-handle_access_point_mode(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_access_point_mode(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
     g_assert(access_point);
@@ -1030,7 +1030,7 @@ handle_access_point_mode(NetplanParser* npp, yaml_node_t* node, const void* _, G
 }
 
 static gboolean
-handle_access_point_band(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_access_point_band(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
     g_assert(access_point);
@@ -1095,7 +1095,7 @@ parse_renderer(NetplanParser* npp, yaml_node_t* node, NetplanBackend* backend, G
 }
 
 static gboolean
-handle_netdef_renderer(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_netdef_renderer(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (npp->current.netdef->type == NETPLAN_DEF_TYPE_VLAN) {
         if (strcmp(scalar(node), "sriov") == 0) {
@@ -1128,7 +1128,7 @@ handle_activation_mode(NetplanParser* npp, yaml_node_t* node, const void* data, 
 }
 
 static gboolean
-handle_match(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_match(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     npp->current.netdef->has_match = TRUE;
     return process_mapping(npp, node, key_prefix, match_handlers, NULL, error);
@@ -1149,7 +1149,7 @@ NETPLAN_WIFI_WOWLAN_TYPES[] = {
 };
 
 static gboolean
-handle_wowlan(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_wowlan(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         yaml_node_t *entry = yaml_document_get_node(&npp->doc, *i);
@@ -1172,7 +1172,7 @@ handle_wowlan(NetplanParser* npp, yaml_node_t* node, const void* _, GError** err
 }
 
 static gboolean
-handle_auth(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_auth(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     gboolean ret;
 
@@ -1317,13 +1317,13 @@ skip_ip6:
 }
 
 static gboolean
-handle_addresses(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_addresses(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     return handle_generic_addresses(npp, node, TRUE, &(npp->current.netdef->ip4_addresses), &(npp->current.netdef->ip6_addresses), error);
 }
 
 static gboolean
-handle_gateway4(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_gateway4(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!is_ip4_address(scalar(node)))
         return yaml_error(npp, node, error, "invalid IPv4 address '%s'", scalar(node));
@@ -1335,7 +1335,7 @@ handle_gateway4(NetplanParser* npp, yaml_node_t* node, const void* _, GError** e
 }
 
 static gboolean
-handle_gateway6(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_gateway6(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!is_ip6_address(scalar(node)))
         return yaml_error(npp, node, error, "invalid IPv6 address '%s'", scalar(node));
@@ -1347,7 +1347,7 @@ handle_gateway6(NetplanParser* npp, yaml_node_t* node, const void* _, GError** e
 }
 
 static gboolean
-handle_wifi_access_points(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* data, GError** error)
+handle_wifi_access_points(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* data, GError** error)
 {
     for (yaml_node_pair_t* entry = node->data.mapping.pairs.start; entry < node->data.mapping.pairs.top; entry++) {
         NetplanWifiAccessPoint *access_point = NULL;
@@ -1398,7 +1398,7 @@ handle_wifi_access_points(NetplanParser* npp, yaml_node_t* node, const char* key
  * @data: ignored
  */
 static gboolean
-handle_bridge_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_bridge_interfaces(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     /* all entries must refer to already defined IDs */
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
@@ -1463,7 +1463,7 @@ handle_bond_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError
  * @data: ignored
  */
 static gboolean
-handle_bond_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_bond_interfaces(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     /* all entries must refer to already defined IDs */
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
@@ -1496,7 +1496,7 @@ handle_bond_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data, 
 }
 
 static gboolean
-handle_nameservers_search(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_nameservers_search(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         yaml_node_t *entry = yaml_document_get_node(&npp->doc, *i);
@@ -1517,7 +1517,7 @@ handle_nameservers_search(NetplanParser* npp, yaml_node_t* node, const void* _, 
 }
 
 static gboolean
-handle_nameservers_addresses(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_nameservers_addresses(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         GArray **nameservers = NULL;
@@ -1549,7 +1549,7 @@ handle_nameservers_addresses(NetplanParser* npp, yaml_node_t* node, const void* 
 }
 
 static gboolean
-handle_link_local(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_link_local(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     gboolean ipv4 = FALSE;
     gboolean ipv6 = FALSE;
@@ -1586,7 +1586,7 @@ NETPLAN_OPTIONAL_ADDRESS_TYPES[] = {
 };
 
 static gboolean
-handle_optional_addresses(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_optional_addresses(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         yaml_node_t *entry = yaml_document_get_node(&npp->doc, *i);
@@ -1719,7 +1719,7 @@ handle_routes_bool(NetplanParser* npp, yaml_node_t* node, const void* data, GErr
 }
 
 static gboolean
-handle_routes_scope(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_routes_scope(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     NetplanIPRoute* route = npp->current.route;
     if (route->scope)
@@ -1735,7 +1735,7 @@ handle_routes_scope(NetplanParser* npp, yaml_node_t* node, const void* data, GEr
 }
 
 static gboolean
-handle_routes_type(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_routes_type(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     NetplanIPRoute* route = npp->current.route;
     if (route->type)
@@ -1783,7 +1783,7 @@ handle_routes_ip(NetplanParser* npp, yaml_node_t* node, const void* data, GError
 }
 
 static gboolean
-handle_routes_destination(NetplanParser *npp, yaml_node_t *node, const void *data, GError **error)
+handle_routes_destination(NetplanParser *npp, yaml_node_t *node, __unused const void *data, GError **error)
 {
     const char *addr = scalar(node);
     if (g_strcmp0(addr, "default") != 0) /* netplan-feature: default-routes */
@@ -1944,7 +1944,7 @@ static const mapping_entry_handler bridge_params_handlers[] = {
 };
 
 static gboolean
-handle_bridge(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_bridge(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     npp->current.netdef->custom_bridging = TRUE;
     npp->current.netdef->bridge_params.stp = TRUE;
@@ -1971,7 +1971,7 @@ static const mapping_entry_handler routes_handlers[] = {
 };
 
 static gboolean
-handle_routes(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_routes(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!npp->current.netdef->routes)
         npp->current.netdef->routes = g_array_new(FALSE, TRUE, sizeof(NetplanIPRoute*));
@@ -2060,7 +2060,7 @@ static const mapping_entry_handler ip_rules_handlers[] = {
 };
 
 static gboolean
-handle_ip_rules(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_ip_rules(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         yaml_node_t *entry = yaml_document_get_node(&npp->doc, *i);
@@ -2106,7 +2106,7 @@ handle_ip_rules(NetplanParser* npp, yaml_node_t* node, const void* _, GError** e
  ****************************************************/
 
 static gboolean
-handle_arp_ip_targets(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_arp_ip_targets(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!npp->current.netdef->bond_params.arp_ip_targets) {
         npp->current.netdef->bond_params.arp_ip_targets = g_array_new(FALSE, FALSE, sizeof(char *));
@@ -2208,7 +2208,7 @@ static const mapping_entry_handler bond_params_handlers[] = {
 };
 
 static gboolean
-handle_vrf_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_vrf_interfaces(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     /* all entries must refer to already defined IDs */
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
@@ -2231,7 +2231,7 @@ handle_vrf_interfaces(NetplanParser* npp, yaml_node_t* node, const void* data, G
 }
 
 static gboolean
-handle_vxlan_source_port(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_vxlan_source_port(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     assert_type(npp, node, YAML_SEQUENCE_NODE);
     if (node->data.sequence.items.top - node->data.sequence.items.start != 2)
@@ -2258,13 +2258,13 @@ handle_vxlan_source_port(NetplanParser* npp, yaml_node_t* node, const void* _, G
 }
 
 static gboolean
-handle_bonding(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_bonding(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     return process_mapping(npp, node, key_prefix, bond_params_handlers, NULL, error);
 }
 
 static gboolean
-handle_dhcp_identifier(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_dhcp_identifier(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     g_free(npp->current.netdef->dhcp_identifier);
     /* "duid" is the default case, so we don't store it. */
@@ -2308,7 +2308,7 @@ handle_tunnel_addr(NetplanParser* npp, yaml_node_t* node, const void* data, GErr
 }
 
 static gboolean
-handle_tunnel_mode(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_tunnel_mode(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     const char *key = scalar(node);
     NetplanTunnelMode i;
@@ -2332,7 +2332,7 @@ static const mapping_entry_handler tunnel_keys_handlers[] = {
 };
 
 static gboolean
-handle_tunnel_key_mapping(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_tunnel_key_mapping(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     gboolean ret = FALSE;
 
@@ -2376,14 +2376,14 @@ handle_wireguard_peer_guint(NetplanParser* npp, yaml_node_t* node, const void* d
 }
 
 static gboolean
-handle_wireguard_allowed_ips(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_wireguard_allowed_ips(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     return handle_generic_addresses(npp, node, FALSE, &(npp->current.wireguard_peer->allowed_ips),
                                     &(npp->current.wireguard_peer->allowed_ips), error);
 }
 
 static gboolean
-handle_wireguard_endpoint(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_wireguard_endpoint(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     g_autofree char* endpoint = NULL;
     char* port;
@@ -2428,7 +2428,7 @@ static const mapping_entry_handler wireguard_peer_keys_handlers[] = {
 };
 
 static gboolean
-handle_wireguard_peer_key_mapping(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_wireguard_peer_key_mapping(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     return process_mapping(npp, node, key_prefix, wireguard_peer_keys_handlers, NULL, error);
 }
@@ -2442,7 +2442,7 @@ const mapping_entry_handler wireguard_peer_handlers[] = {
 };
 
 static gboolean
-handle_wireguard_peers(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_wireguard_peers(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!npp->current.netdef->wireguard_peers)
         npp->current.netdef->wireguard_peers = g_array_new(FALSE, TRUE, sizeof(NetplanWireguardPeer*));
@@ -2573,7 +2573,7 @@ handle_ovs_bridge_controller_connection_mode(NetplanParser* npp, yaml_node_t* no
 }
 
 static gboolean
-handle_ovs_bridge_controller_addresses(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_ovs_bridge_controller_addresses(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
         return yaml_error(npp, node, error, "Key 'controller.addresses' is only valid for interface type 'Open vSwitch bridge'");
@@ -2651,7 +2651,7 @@ static const mapping_entry_handler ovs_backend_settings_handlers[] = {
 };
 
 static gboolean
-handle_ovs_backend(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_ovs_backend(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     GList* values = NULL;
     gboolean ret = process_mapping(npp, node, key_prefix, ovs_backend_settings_handlers, &values, error);
@@ -2874,7 +2874,7 @@ static const mapping_entry_handler tunnel_def_handlers[] = {
  ****************************************************/
 
 static gboolean
-handle_network_version(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_network_version(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     long mangled_version;
 
@@ -2886,7 +2886,7 @@ handle_network_version(NetplanParser* npp, yaml_node_t* node, const void* _, GEr
 }
 
 static gboolean
-handle_network_renderer(NetplanParser* npp, yaml_node_t* node, const void* _, GError** error)
+handle_network_renderer(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     gboolean res = parse_renderer(npp, node, &npp->global_backend, error);
     if (!npp->global_renderer)
@@ -2912,7 +2912,7 @@ handle_network_ovs_settings_global_protocol(NetplanParser* npp, yaml_node_t* nod
 }
 
 static gboolean
-handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     yaml_node_t* port = NULL;
     yaml_node_t* peer = NULL;
@@ -3160,7 +3160,7 @@ static const mapping_entry_handler ovs_global_ssl_handlers[] = {
 };
 
 static gboolean
-handle_ovs_global_ssl(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* _, GError** error)
+handle_ovs_global_ssl(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     gboolean ret;
 
@@ -3211,7 +3211,7 @@ static const mapping_entry_handler root_handlers[] = {
  * to exist but are needed in order to generate backend configuration.
  */
 static void
-process_missing_ids(NetplanParser* npp, GError** error)
+process_missing_ids(NetplanParser* npp, __unused GError** error)
 {
     GHashTableIter iter;
     gpointer key, value;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1699,7 +1699,7 @@ get_ip_family(const char* address)
 }
 
 static gboolean
-check_and_set_family(int family, guint* dest)
+check_and_set_family(gint family, gint* dest)
 {
     if (*dest != -1 && *dest != family)
         return FALSE;
@@ -1986,7 +1986,7 @@ handle_routes(NetplanParser* npp, yaml_node_t* node, const void* _, GError** err
         route = g_new0(NetplanIPRoute, 1);
         route->type = g_strdup("unicast");
         route->scope = NULL;
-        route->family = G_MAXUINT; /* 0 is a valid family ID */
+        route->family = -1; /* 0 is a valid family ID */
         route->metric = NETPLAN_METRIC_UNSPEC; /* 0 is a valid metric */
         route->table = NETPLAN_ROUTE_TABLE_UNSPEC;
         g_debug("%s: adding new route", npp->current.netdef->id);

--- a/src/parse.c
+++ b/src/parse.c
@@ -854,7 +854,7 @@ handle_match_driver(NetplanParser* npp, yaml_node_t* node, const char* key_prefi
 }
 
 static const mapping_entry_handler match_handlers[] = {
-    {"driver", YAML_NO_NODE, {.variable=handle_match_driver}},
+    {"driver", YAML_NO_NODE, {.variable=handle_match_driver}, NULL},
     {"macaddress", YAML_SCALAR_NODE, {.generic=handle_netdef_mac}, netdef_offset(match.mac)},
     {"name", YAML_SCALAR_NODE, {.generic=handle_netdef_id}, netdef_offset(match.original_name)},
     {NULL}
@@ -913,8 +913,8 @@ handle_auth_method(NetplanParser* npp, yaml_node_t* node, const void* _, GError*
 }
 
 static const mapping_entry_handler auth_handlers[] = {
-    {"key-management", YAML_SCALAR_NODE, {.generic=handle_auth_key_management}},
-    {"method", YAML_SCALAR_NODE, {.generic=handle_auth_method}},
+    {"key-management", YAML_SCALAR_NODE, {.generic=handle_auth_key_management}, NULL},
+    {"method", YAML_SCALAR_NODE, {.generic=handle_auth_method}, NULL},
     {"identity", YAML_SCALAR_NODE, {.generic=handle_auth_str}, auth_offset(identity)},
     {"anonymous-identity", YAML_SCALAR_NODE, {.generic=handle_auth_str}, auth_offset(anonymous_identity)},
     {"password", YAML_SCALAR_NODE, {.generic=handle_auth_str}, auth_offset(password)},
@@ -1067,14 +1067,14 @@ static const mapping_entry_handler ap_nm_backend_settings_handlers[] = {
 
 
 static const mapping_entry_handler wifi_access_point_handlers[] = {
-    {"band", YAML_SCALAR_NODE, {.generic=handle_access_point_band}},
+    {"band", YAML_SCALAR_NODE, {.generic=handle_access_point_band}, NULL},
     {"bssid", YAML_SCALAR_NODE, {.generic=handle_access_point_mac}, access_point_offset(bssid)},
     {"hidden", YAML_SCALAR_NODE, {.generic=handle_access_point_bool}, access_point_offset(hidden)},
     {"channel", YAML_SCALAR_NODE, {.generic=handle_access_point_guint}, access_point_offset(channel)},
-    {"mode", YAML_SCALAR_NODE, {.generic=handle_access_point_mode}},
-    {"password", YAML_SCALAR_NODE, {.generic=handle_access_point_password}},
-    {"auth", YAML_MAPPING_NODE, {.map={.custom=handle_access_point_auth}}},
-    {"networkmanager", YAML_MAPPING_NODE, {.map={.handlers=ap_nm_backend_settings_handlers}}},
+    {"mode", YAML_SCALAR_NODE, {.generic=handle_access_point_mode}, NULL},
+    {"password", YAML_SCALAR_NODE, {.generic=handle_access_point_password}, NULL},
+    {"auth", YAML_MAPPING_NODE, {.map={.custom=handle_access_point_auth}}, NULL},
+    {"networkmanager", YAML_MAPPING_NODE, {.map={.handlers=ap_nm_backend_settings_handlers}}, NULL},
     {NULL}
 };
 
@@ -1958,10 +1958,10 @@ handle_bridge(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, con
 static const mapping_entry_handler routes_handlers[] = {
     {"from", YAML_SCALAR_NODE, {.generic=handle_routes_ip}, route_offset(from)},
     {"on-link", YAML_SCALAR_NODE, {.generic=handle_routes_bool}, route_offset(onlink)},
-    {"scope", YAML_SCALAR_NODE, {.generic=handle_routes_scope}},
+    {"scope", YAML_SCALAR_NODE, {.generic=handle_routes_scope}, NULL},
     {"table", YAML_SCALAR_NODE, {.generic=handle_routes_guint}, route_offset(table)},
-    {"to", YAML_SCALAR_NODE, {.generic=handle_routes_destination}},
-    {"type", YAML_SCALAR_NODE, {.generic=handle_routes_type}},
+    {"to", YAML_SCALAR_NODE, {.generic=handle_routes_destination}, NULL},
+    {"type", YAML_SCALAR_NODE, {.generic=handle_routes_type}, NULL},
     {"via", YAML_SCALAR_NODE, {.generic=handle_routes_ip}, route_offset(via)},
     {"metric", YAML_SCALAR_NODE, {.generic=handle_routes_guint}, route_offset(metric)},
     {"mtu", YAML_SCALAR_NODE, {.generic=handle_routes_guint}, route_offset(mtubytes)},
@@ -2188,7 +2188,7 @@ static const mapping_entry_handler bond_params_handlers[] = {
     {"all-members-active", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(bond_params.all_members_active)},
     {"arp-interval", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.arp_interval)},
     /* TODO: arp_ip_targets */
-    {"arp-ip-targets", YAML_SEQUENCE_NODE, {.generic=handle_arp_ip_targets}},
+    {"arp-ip-targets", YAML_SEQUENCE_NODE, {.generic=handle_arp_ip_targets}, NULL},
     {"arp-validate", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.arp_validate)},
     {"arp-all-targets", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.arp_all_targets)},
     {"up-delay", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(bond_params.up_delay)},
@@ -2434,10 +2434,10 @@ handle_wireguard_peer_key_mapping(NetplanParser* npp, yaml_node_t* node, const c
 }
 
 const mapping_entry_handler wireguard_peer_handlers[] = {
-    {"keys", YAML_MAPPING_NODE, {.map={.custom=handle_wireguard_peer_key_mapping}}},
+    {"keys", YAML_MAPPING_NODE, {.map={.custom=handle_wireguard_peer_key_mapping}}, NULL},
     {"keepalive", YAML_SCALAR_NODE, {.generic=handle_wireguard_peer_guint}, wireguard_peer_offset(keepalive)},
-    {"endpoint", YAML_SCALAR_NODE, {.generic=handle_wireguard_endpoint}},
-    {"allowed-ips", YAML_SEQUENCE_NODE, {.generic=handle_wireguard_allowed_ips}},
+    {"endpoint", YAML_SCALAR_NODE, {.generic=handle_wireguard_endpoint}, NULL},
+    {"allowed-ips", YAML_SEQUENCE_NODE, {.generic=handle_wireguard_allowed_ips}, NULL},
     {NULL}
 };
 
@@ -2646,7 +2646,7 @@ static const mapping_entry_handler ovs_backend_settings_handlers[] = {
     {"mcast-snooping", YAML_SCALAR_NODE, {.generic=handle_ovs_bridge_bool}, netdef_offset(ovs_settings.mcast_snooping)},
     {"rstp", YAML_SCALAR_NODE, {.generic=handle_ovs_bridge_bool}, netdef_offset(ovs_settings.rstp)},
     {"protocols", YAML_SEQUENCE_NODE, {.generic=handle_ovs_bridge_protocol}, netdef_offset(ovs_settings.protocols)},
-    {"controller", YAML_MAPPING_NODE, {.map={.handlers=ovs_controller_handlers}}},
+    {"controller", YAML_MAPPING_NODE, {.map={.handlers=ovs_controller_handlers}}, NULL},
     {NULL}
 };
 
@@ -2677,8 +2677,8 @@ cleanup:
 }
 
 static const mapping_entry_handler nameservers_handlers[] = {
-    {"search", YAML_SEQUENCE_NODE, {.generic=handle_nameservers_search}},
-    {"addresses", YAML_SEQUENCE_NODE, {.generic=handle_nameservers_addresses}},
+    {"search", YAML_SEQUENCE_NODE, {.generic=handle_nameservers_search}, NULL},
+    {"addresses", YAML_SEQUENCE_NODE, {.generic=handle_nameservers_addresses}, NULL},
     {NULL}
 };
 
@@ -2708,38 +2708,38 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
 #define COMMON_LINK_HANDLERS \
     {"accept-ra", YAML_SCALAR_NODE, {.generic=handle_accept_ra}, netdef_offset(accept_ra)}, \
     {"activation-mode", YAML_SCALAR_NODE, {.generic=handle_activation_mode}, netdef_offset(activation_mode)}, \
-    {"addresses", YAML_SEQUENCE_NODE, {.generic=handle_addresses}}, \
+    {"addresses", YAML_SEQUENCE_NODE, {.generic=handle_addresses}, NULL}, \
     {"critical", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(critical)}, \
     {"ignore-carrier", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(ignore_carrier)}, \
     {"dhcp4", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(dhcp4)}, \
     {"dhcp6", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(dhcp6)}, \
-    {"dhcp-identifier", YAML_SCALAR_NODE, {.generic=handle_dhcp_identifier}}, \
-    {"dhcp4-overrides", YAML_MAPPING_NODE, {.map={.handlers=dhcp4_overrides_handlers}}}, \
-    {"dhcp6-overrides", YAML_MAPPING_NODE, {.map={.handlers=dhcp6_overrides_handlers}}}, \
-    {"gateway4", YAML_SCALAR_NODE, {.generic=handle_gateway4}}, \
-    {"gateway6", YAML_SCALAR_NODE, {.generic=handle_gateway6}}, \
-    {"ipv6-address-generation", YAML_SCALAR_NODE, {.generic=handle_netdef_addrgen}}, \
+    {"dhcp-identifier", YAML_SCALAR_NODE, {.generic=handle_dhcp_identifier}, NULL}, \
+    {"dhcp4-overrides", YAML_MAPPING_NODE, {.map={.handlers=dhcp4_overrides_handlers}}, NULL}, \
+    {"dhcp6-overrides", YAML_MAPPING_NODE, {.map={.handlers=dhcp6_overrides_handlers}}, NULL}, \
+    {"gateway4", YAML_SCALAR_NODE, {.generic=handle_gateway4}, NULL}, \
+    {"gateway6", YAML_SCALAR_NODE, {.generic=handle_gateway6}, NULL}, \
+    {"ipv6-address-generation", YAML_SCALAR_NODE, {.generic=handle_netdef_addrgen}, NULL}, \
     {"ipv6-address-token", YAML_SCALAR_NODE, {.generic=handle_netdef_addrtok}, netdef_offset(ip6_addr_gen_token)}, \
     {"ipv6-mtu", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(ipv6_mtubytes)}, \
     {"ipv6-privacy", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(ip6_privacy)}, \
-    {"link-local", YAML_SEQUENCE_NODE, {.generic=handle_link_local}}, \
+    {"link-local", YAML_SEQUENCE_NODE, {.generic=handle_link_local}, NULL}, \
     {"macaddress", YAML_SCALAR_NODE, {.generic=handle_netdef_mac}, netdef_offset(set_mac)}, \
     {"mtu", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(mtubytes)}, \
-    {"nameservers", YAML_MAPPING_NODE, {.map={.handlers=nameservers_handlers}}}, \
+    {"nameservers", YAML_MAPPING_NODE, {.map={.handlers=nameservers_handlers}}, NULL}, \
     {"optional", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(optional)}, \
-    {"optional-addresses", YAML_SEQUENCE_NODE, {.generic=handle_optional_addresses}}, \
-    {"renderer", YAML_SCALAR_NODE, {.generic=handle_netdef_renderer}}, \
-    {"routes", YAML_SEQUENCE_NODE, {.generic=handle_routes}}, \
-    {"routing-policy", YAML_SEQUENCE_NODE, {.generic=handle_ip_rules}}, \
+    {"optional-addresses", YAML_SEQUENCE_NODE, {.generic=handle_optional_addresses}, NULL}, \
+    {"renderer", YAML_SCALAR_NODE, {.generic=handle_netdef_renderer}, NULL}, \
+    {"routes", YAML_SEQUENCE_NODE, {.generic=handle_routes}, NULL}, \
+    {"routing-policy", YAML_SEQUENCE_NODE, {.generic=handle_ip_rules}, NULL}, \
     {"neigh-suppress", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(bridge_neigh_suppress)}
 
 #define COMMON_BACKEND_HANDLERS \
-    {"networkmanager", YAML_MAPPING_NODE, {.map={.handlers=nm_backend_settings_handlers}}}, \
-    {"openvswitch", YAML_MAPPING_NODE, {.map={.custom=handle_ovs_backend}}}
+    {"networkmanager", YAML_MAPPING_NODE, {.map={.handlers=nm_backend_settings_handlers}}, NULL}, \
+    {"openvswitch", YAML_MAPPING_NODE, {.map={.custom=handle_ovs_backend}}, NULL}
 
 /* Handlers for physical links */
 #define PHYSICAL_LINK_HANDLERS \
-    {"match", YAML_MAPPING_NODE, {.map={.custom=handle_match}}}, \
+    {"match", YAML_MAPPING_NODE, {.map={.custom=handle_match}}, NULL}, \
     {"set-name", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(set_name)}, \
     {"wakeonlan", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(wake_on_lan)}, \
     {"wakeonwlan", YAML_SEQUENCE_NODE, {.generic=handle_wowlan}, netdef_offset(wowlan)}, \
@@ -2756,7 +2756,7 @@ static const mapping_entry_handler ethernet_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     COMMON_BACKEND_HANDLERS,
     PHYSICAL_LINK_HANDLERS,
-    {"auth", YAML_MAPPING_NODE, {.map={.custom=handle_auth}}},
+    {"auth", YAML_MAPPING_NODE, {.map={.custom=handle_auth}}, NULL},
     {"link", YAML_SCALAR_NODE, {.generic=handle_netdef_id_ref}, netdef_offset(sriov_link)},
     {"virtual-function-count", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(sriov_explicit_vf_count)},
     {"embedded-switch-mode", YAML_SCALAR_NODE, {.generic=handle_embedded_switch_mode}, netdef_offset(embedded_switch_mode)},
@@ -2769,8 +2769,8 @@ static const mapping_entry_handler wifi_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     COMMON_BACKEND_HANDLERS,
     PHYSICAL_LINK_HANDLERS,
-    {"access-points", YAML_MAPPING_NODE, {.map={.custom=handle_wifi_access_points}}},
-    {"auth", YAML_MAPPING_NODE, {.map={.custom=handle_auth}}},
+    {"access-points", YAML_MAPPING_NODE, {.map={.custom=handle_wifi_access_points}}, NULL},
+    {"auth", YAML_MAPPING_NODE, {.map={.custom=handle_auth}}, NULL},
     {"regulatory-domain", YAML_SCALAR_NODE, {.generic=handle_netdef_str}, netdef_offset(regulatory_domain)},
     {NULL}
 };
@@ -2779,7 +2779,7 @@ static const mapping_entry_handler bridge_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     COMMON_BACKEND_HANDLERS,
     {"interfaces", YAML_SEQUENCE_NODE, {.generic=handle_bridge_interfaces}, NULL},
-    {"parameters", YAML_MAPPING_NODE, {.map={.custom=handle_bridge}}},
+    {"parameters", YAML_MAPPING_NODE, {.map={.custom=handle_bridge}}, NULL},
     {NULL}
 };
 
@@ -2787,7 +2787,7 @@ static const mapping_entry_handler bond_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     COMMON_BACKEND_HANDLERS,
     {"interfaces", YAML_SEQUENCE_NODE, {.generic=handle_bond_interfaces}, NULL},
-    {"parameters", YAML_MAPPING_NODE, {.map={.custom=handle_bonding}}},
+    {"parameters", YAML_MAPPING_NODE, {.map={.custom=handle_bonding}}, NULL},
     {NULL}
 };
 
@@ -2801,11 +2801,11 @@ static const mapping_entry_handler vlan_def_handlers[] = {
 
 static const mapping_entry_handler vrf_def_handlers[] = {
     COMMON_BACKEND_HANDLERS,
-    {"renderer", YAML_SCALAR_NODE, {.generic=handle_netdef_renderer}},
+    {"renderer", YAML_SCALAR_NODE, {.generic=handle_netdef_renderer}, NULL},
     {"interfaces", YAML_SEQUENCE_NODE, {.generic=handle_vrf_interfaces}, NULL},
     {"table", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(vrf_table)},
-    {"routes", YAML_SEQUENCE_NODE, {.generic=handle_routes}},
-    {"routing-policy", YAML_SEQUENCE_NODE, {.generic=handle_ip_rules}},
+    {"routes", YAML_SEQUENCE_NODE, {.generic=handle_routes}, NULL},
+    {"routing-policy", YAML_SEQUENCE_NODE, {.generic=handle_ip_rules}, NULL},
     {NULL}
 };
 
@@ -2834,7 +2834,7 @@ static const mapping_entry_handler dummy_def_handlers[] = {     /* wokeignore:ru
 static const mapping_entry_handler tunnel_def_handlers[] = {
     COMMON_LINK_HANDLERS,
     COMMON_BACKEND_HANDLERS,
-    {"mode", YAML_SCALAR_NODE, {.generic=handle_tunnel_mode}},
+    {"mode", YAML_SCALAR_NODE, {.generic=handle_tunnel_mode}, NULL},
     {"local", YAML_SCALAR_NODE, {.generic=handle_tunnel_addr}, netdef_offset(tunnel.local_ip)},
     {"remote", YAML_SCALAR_NODE, {.generic=handle_tunnel_addr}, netdef_offset(tunnel.remote_ip)},
     {"ttl", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(tunnel_ttl)},
@@ -2842,13 +2842,13 @@ static const mapping_entry_handler tunnel_def_handlers[] = {
     /* Handle key/keys for clarity in config: this can be either a scalar or
      * mapping of multiple keys (input and output)
      */
-    {"key", YAML_NO_NODE, {.variable=handle_tunnel_key_mapping}},
-    {"keys", YAML_NO_NODE, {.variable=handle_tunnel_key_mapping}},
+    {"key", YAML_NO_NODE, {.variable=handle_tunnel_key_mapping}, NULL},
+    {"keys", YAML_NO_NODE, {.variable=handle_tunnel_key_mapping}, NULL},
 
     /* wireguard */
     {"mark", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(tunnel.fwmark)},
     {"port", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(tunnel.port)},
-    {"peers", YAML_SEQUENCE_NODE, {.generic=handle_wireguard_peers}},
+    {"peers", YAML_SEQUENCE_NODE, {.generic=handle_wireguard_peers}, NULL},
 
     /* vxlan */
     {"link", YAML_SCALAR_NODE, {.generic=handle_vxlan_id_ref}, vxlan_offset(link)},
@@ -2865,7 +2865,7 @@ static const mapping_entry_handler tunnel_def_handlers[] = {
     {"notifications", YAML_SEQUENCE_NODE, {.generic=handle_vxlan_flags}, vxlan_offset(notifications)},
     {"checksums", YAML_SEQUENCE_NODE, {.generic=handle_vxlan_flags}, vxlan_offset(checksums)},
     {"extensions", YAML_SEQUENCE_NODE, {.generic=handle_vxlan_flags}, vxlan_offset(extensions)},
-    {"port-range", YAML_SEQUENCE_NODE, {.generic=handle_vxlan_source_port}},
+    {"port-range", YAML_SEQUENCE_NODE, {.generic=handle_vxlan_source_port}, NULL},
     {NULL}
 };
 
@@ -3175,8 +3175,8 @@ static const mapping_entry_handler ovs_network_settings_handlers[] = {
     {"external-ids", YAML_MAPPING_NODE, {.map={.custom=handle_network_ovs_settings_global}}, ovs_settings_offset(external_ids)},
     {"other-config", YAML_MAPPING_NODE, {.map={.custom=handle_network_ovs_settings_global}}, ovs_settings_offset(other_config)},
     {"protocols", YAML_SEQUENCE_NODE, {.generic=handle_network_ovs_settings_global_protocol}, ovs_settings_offset(protocols)},
-    {"ports", YAML_SEQUENCE_NODE, {.generic=handle_network_ovs_settings_global_ports}},
-    {"ssl", YAML_MAPPING_NODE, {.map={.custom=handle_ovs_global_ssl}}},
+    {"ports", YAML_SEQUENCE_NODE, {.generic=handle_network_ovs_settings_global_ports}, NULL},
+    {"ssl", YAML_MAPPING_NODE, {.map={.custom=handle_ovs_global_ssl}}, NULL},
     {NULL}
 };
 
@@ -3184,16 +3184,16 @@ static const mapping_entry_handler network_handlers[] = {
     {"bonds", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_BOND)},
     {"bridges", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_BRIDGE)},
     {"ethernets", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_ETHERNET)},
-    {"renderer", YAML_SCALAR_NODE, {.generic=handle_network_renderer}},
+    {"renderer", YAML_SCALAR_NODE, {.generic=handle_network_renderer}, NULL},
     {"tunnels", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_TUNNEL)},
-    {"version", YAML_SCALAR_NODE, {.generic=handle_network_version}},
+    {"version", YAML_SCALAR_NODE, {.generic=handle_network_version}, NULL},
     {"vlans", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_VLAN)},
     {"vrfs", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_VRF)},
     {"wifis", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_WIFI)},
     {"modems", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_MODEM)},
     {"dummy-devices", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_DUMMY)},    /* wokeignore:rule=dummy */
     {"nm-devices", YAML_MAPPING_NODE, {.map={.custom=handle_network_type}}, GUINT_TO_POINTER(NETPLAN_DEF_TYPE_NM)},
-    {"openvswitch", YAML_MAPPING_NODE, {.map={.handlers=ovs_network_settings_handlers}}},
+    {"openvswitch", YAML_MAPPING_NODE, {.map={.handlers=ovs_network_settings_handlers}}, NULL},
     {NULL}
 };
 
@@ -3202,7 +3202,7 @@ static const mapping_entry_handler network_handlers[] = {
  ****************************************************/
 
 static const mapping_entry_handler root_handlers[] = {
-    {"network", YAML_MAPPING_NODE, {.map={.handlers=network_handlers}}},
+    {"network", YAML_MAPPING_NODE, {.map={.handlers=network_handlers}}, NULL},
     {NULL}
 };
 

--- a/src/sriov.c
+++ b/src/sriov.c
@@ -128,7 +128,7 @@ _netplan_state_get_vf_count_for_def(const NetplanState* np_state, const NetplanN
 {
     GHashTableIter iter;
     gpointer key, value;
-    int count = 0;
+    guint count = 0;
 
     g_hash_table_iter_init(&iter, np_state->netdefs);
     while (g_hash_table_iter_next (&iter, &key, &value)) {

--- a/src/sriov.c
+++ b/src/sriov.c
@@ -65,7 +65,7 @@ write_sriov_rebind_systemd_unit(const GString* pfs, const char* rootdir, GError*
  * Finalize the SR-IOV configuration (global config)
  */
 gboolean
-netplan_state_finish_sriov_write(const NetplanState* np_state, const char* rootdir, GError** error)
+netplan_state_finish_sriov_write(const NetplanState* np_state, const char* rootdir, __unused GError** error)
 {
     NetplanNetDefinition* def = NULL;
     NetplanNetDefinition* pf = NULL;

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -114,7 +114,7 @@ typedef struct {
 } NetplanWifiAccessPoint;
 
 typedef struct {
-    guint family;
+    gint family;
     char* type;
     char* scope;
     guint table;
@@ -135,7 +135,7 @@ typedef struct {
 } NetplanIPRoute;
 
 typedef struct {
-    guint family;
+    gint family;
 
     char* from;
     char* to;

--- a/src/types.c
+++ b/src/types.c
@@ -201,7 +201,7 @@ reset_vxlan(NetplanVxlan* vxlan)
  *        to interpret the processed object, especially regarding the backend settings
  */
 static void
-free_access_point(void* key, void* value, void* data)
+free_access_point(__unused void* key, void* value, __unused void* data)
 {
     NetplanWifiAccessPoint* ap = value;
     g_free(ap->ssid);

--- a/src/types.c
+++ b/src/types.c
@@ -152,7 +152,7 @@ reset_dhcp_overrides(NetplanDHCPOverrides* overrides)
 void
 reset_ip_rule(NetplanIPRule* ip_rule)
 {
-    ip_rule->family = G_MAXUINT; /* 0 is a valid family ID */
+    ip_rule->family = -1; /* 0 is a valid family ID */
     ip_rule->priority = NETPLAN_IP_RULE_PRIO_UNSPEC;
     ip_rule->table = NETPLAN_ROUTE_TABLE_UNSPEC;
     ip_rule->tos = NETPLAN_IP_RULE_TOS_UNSPEC;

--- a/src/types.c
+++ b/src/types.c
@@ -354,14 +354,6 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     FREE_AND_NULLIFY(netdef->activation_mode);
     netdef->ignore_carrier = FALSE;
 
-    netdef->receive_checksum_offload = FALSE;
-    netdef->transmit_checksum_offload = FALSE;
-    netdef->tcp_segmentation_offload = FALSE;
-    netdef->tcp6_segmentation_offload = FALSE;
-    netdef->generic_segmentation_offload = FALSE;
-    netdef->generic_receive_offload = FALSE;
-    netdef->large_receive_offload = FALSE;
-
     reset_private_netdef_data(netdef->_private);
     FREE_AND_NULLIFY(netdef->_private);
 

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -26,6 +26,8 @@
 
 #define SET_OPT_OUT_PTR(ptr,val) { if (ptr) *ptr = val; }
 
+#define __unused __attribute__((unused))
+
 extern GHashTable*
 wifi_frequency_24;
 

--- a/src/util.c
+++ b/src/util.c
@@ -939,7 +939,7 @@ is_route_present(const NetplanNetDefinition* netdef, const NetplanIPRoute* route
 {
     const GArray* routes = netdef->routes;
 
-    for (int i = 0; i < routes->len; i++) {
+    for (guint i = 0; i < routes->len; i++) {
         const NetplanIPRoute* entry = g_array_index(routes, NetplanIPRoute*, i);
         if (
                 entry->family == route->family &&
@@ -963,7 +963,7 @@ is_route_rule_present(const NetplanNetDefinition* netdef, const NetplanIPRule* r
 {
     const GArray* rules = netdef->ip_rules;
 
-    for (int i = 0; i < rules->len; i++) {
+    for (guint i = 0; i < rules->len; i++) {
         const NetplanIPRule* entry = g_array_index(rules, NetplanIPRule*, i);
         if (
                 entry->family == rule->family &&

--- a/src/util.c
+++ b/src/util.c
@@ -818,7 +818,8 @@ netplan_copy_string(const char* input, char* out_buffer, size_t out_size)
     char* end = stpncpy(out_buffer, input, out_size);
     // If it point to the first byte past the buffer, we don't have enough
     // space in the buffer.
-    if (end - out_buffer == out_size)
+    size_t len = end - out_buffer;
+    if (len == out_size)
         return NETPLAN_BUFFER_TOO_SMALL;
     return end - out_buffer + 1;
 }

--- a/src/validation.c
+++ b/src/validation.c
@@ -533,9 +533,9 @@ adopt_and_validate_vrf_routes(const NetplanParser *npp, GHashTable *netdefs, GEr
 }
 
 struct _defroute_entry {
-    int family;
-    int table;
-    int metric;
+    gint family;
+    guint table;
+    guint metric;
     const char *netdef_id;
 };
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -480,7 +480,7 @@ sriov_rules_error:
 }
 
 gboolean
-adopt_and_validate_vrf_routes(const NetplanParser *npp, GHashTable *netdefs, GError **error)
+adopt_and_validate_vrf_routes(__unused const NetplanParser *npp, GHashTable *netdefs, GError **error)
 {
     gpointer key, value;
     GHashTableIter iter;
@@ -594,7 +594,7 @@ check_defroute(struct _defroute_entry *candidate,
 }
 
 gboolean
-validate_default_route_consistency(const NetplanParser* npp, GHashTable *netdefs, GError ** error)
+validate_default_route_consistency(__unused const NetplanParser* npp, GHashTable *netdefs, GError ** error)
 {
     struct _defroute_entry candidate = {};
     GSList *defroutes = NULL;

--- a/tests/ctests/test_netplan_deprecated.c
+++ b/tests/ctests/test_netplan_deprecated.c
@@ -20,7 +20,7 @@
 
 // LCOV_EXCL_START
 gboolean
-netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, NetplanError** error)
+netplan_parser_load_keyfile(__unused NetplanParser* npp, __unused const char* filename, __unused NetplanError** error)
 {
     return 1; //
 }
@@ -31,7 +31,7 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, NetplanErr
 #include "test_utils.h"
 
 void
-test_netplan_get_id_from_nm_filename_no_ssid(void **state)
+test_netplan_get_id_from_nm_filename_no_ssid(__unused void **state)
 {
     const char* filename = "/some/rootdir/run/NetworkManager/system-connections/netplan-some-id.nmconnection";
     char* id = netplan_get_id_from_nm_filename(filename, NULL);
@@ -40,7 +40,7 @@ test_netplan_get_id_from_nm_filename_no_ssid(void **state)
 }
 
 void
-test_netplan_get_id_from_nm_filename_with_ssid(void **state)
+test_netplan_get_id_from_nm_filename_with_ssid(__unused void **state)
 {
     const char* filename = "/some/rootdir/run/NetworkManager/system-connections/netplan-some-id-SOME-SSID.nmconnection";
     char* id = netplan_get_id_from_nm_filename(filename, "SOME-SSID");
@@ -49,7 +49,7 @@ test_netplan_get_id_from_nm_filename_with_ssid(void **state)
 }
 
 void
-test_netplan_get_id_from_nm_filename_filename_is_malformed(void **state)
+test_netplan_get_id_from_nm_filename_filename_is_malformed(__unused void **state)
 {
     const char* filename = "INVALID/netplan-some-id.nmconnection";
     char* id = netplan_get_id_from_nm_filename(filename, NULL);
@@ -58,13 +58,13 @@ test_netplan_get_id_from_nm_filename_filename_is_malformed(void **state)
 
 
 int
-setup(void** state)
+setup(__unused void** state)
 {
     return 0;
 }
 
 int
-tear_down(void** state)
+tear_down(__unused void** state)
 {
     return 0;
 }

--- a/tests/ctests/test_netplan_error.c
+++ b/tests/ctests/test_netplan_error.c
@@ -17,7 +17,7 @@
 #include "parse.c"
 
 void
-test_netplan_error_message(void** state)
+test_netplan_error_message(__unused void** state)
 {
     const gchar* message = "it failed";
     char error_message[100] = {0};
@@ -28,7 +28,7 @@ test_netplan_error_message(void** state)
 }
 
 void
-test_netplan_error_code(void** state)
+test_netplan_error_code(__unused void** state)
 {
     GError *gerror = g_error_new(1234, 5678, "%s: error message", "it failed");
     uint64_t error_code = netplan_error_code(gerror);
@@ -41,13 +41,13 @@ test_netplan_error_code(void** state)
 }
 
 int
-setup(void** state)
+setup(__unused void** state)
 {
     return 0;
 }
 
 int
-tear_down(void** state)
+tear_down(__unused void** state)
 {
     return 0;
 }

--- a/tests/ctests/test_netplan_keyfile.c
+++ b/tests/ctests/test_netplan_keyfile.c
@@ -22,7 +22,7 @@
 #include "test_utils_keyfile.h"
 
 void
-test_load_keyfile_wifi_wpa_eap(void** state)
+test_load_keyfile_wifi_wpa_eap(__unused void** state)
 {
     NetplanState *np_state = NULL;
     NetplanStateIterator iter;
@@ -66,7 +66,7 @@ test_load_keyfile_wifi_wpa_eap(void** state)
 
 
 void
-test_load_keyfile_simple_wireguard(void** state)
+test_load_keyfile_simple_wireguard(__unused void** state)
 {
     NetplanState *np_state = NULL;
     NetplanStateIterator iter;
@@ -93,7 +93,7 @@ test_load_keyfile_simple_wireguard(void** state)
 }
 
 void
-test_load_keyfile_wireguard_with_key_and_peer(void** state)
+test_load_keyfile_wireguard_with_key_and_peer(__unused void** state)
 {
     NetplanState *np_state = NULL;
     NetplanStateIterator iter;
@@ -132,7 +132,7 @@ test_load_keyfile_wireguard_with_key_and_peer(void** state)
 }
 
 void
-test_load_keyfile_wireguard_with_bad_peer_key(void** state)
+test_load_keyfile_wireguard_with_bad_peer_key(__unused void** state)
 {
     NetplanState *np_state = NULL;
     NetplanStateIterator iter;
@@ -163,7 +163,7 @@ test_load_keyfile_wireguard_with_bad_peer_key(void** state)
 }
 
 void
-test_load_keyfile_vxlan(void** state)
+test_load_keyfile_vxlan(__unused void** state)
 {
     NetplanState *np_state = NULL;
     NetplanStateIterator iter;
@@ -196,7 +196,7 @@ test_load_keyfile_vxlan(void** state)
 }
 
 void
-test_load_keyfile_multiple_addresses_and_routes(void** state)
+test_load_keyfile_multiple_addresses_and_routes(__unused void** state)
 {
     NetplanState *np_state = NULL;
     NetplanStateIterator iter;
@@ -232,13 +232,13 @@ test_load_keyfile_multiple_addresses_and_routes(void** state)
 }
 
 int
-setup(void** state)
+setup(__unused void** state)
 {
     return 0;
 }
 
 int
-tear_down(void** state)
+tear_down(__unused void** state)
 {
     return 0;
 }

--- a/tests/ctests/test_netplan_misc.c
+++ b/tests/ctests/test_netplan_misc.c
@@ -21,7 +21,7 @@
 #include "test_utils.h"
 
 void
-test_netplan_get_optional(void** state)
+test_netplan_get_optional(__unused void** state)
 {
 
     NetplanState* np_state = load_fixture_to_netplan_state("optional.yaml");
@@ -35,7 +35,7 @@ test_netplan_get_optional(void** state)
 }
 
 void
-test_netplan_get_id_from_nm_filepath_no_ssid(void **state)
+test_netplan_get_id_from_nm_filepath_no_ssid(__unused void **state)
 {
 
     const char* filename = "/some/rootdir/run/NetworkManager/system-connections/netplan-some-id.nmconnection";
@@ -48,7 +48,7 @@ test_netplan_get_id_from_nm_filepath_no_ssid(void **state)
 }
 
 void
-test_netplan_get_id_from_nm_filepath_with_ssid(void **state)
+test_netplan_get_id_from_nm_filepath_with_ssid(__unused void **state)
 {
 
     const char* filename = "/run/NetworkManager/system-connections/netplan-some-id-SOME-SSID.nmconnection";
@@ -61,7 +61,7 @@ test_netplan_get_id_from_nm_filepath_with_ssid(void **state)
 }
 
 void
-test_netplan_get_id_from_nm_filepath_buffer_is_too_small(void **state)
+test_netplan_get_id_from_nm_filepath_buffer_is_too_small(__unused void **state)
 {
 
     const char* filename = "/run/NetworkManager/system-connections/netplan-some-id-SOME-SSID.nmconnection";
@@ -73,7 +73,7 @@ test_netplan_get_id_from_nm_filepath_buffer_is_too_small(void **state)
 }
 
 void
-test_netplan_get_id_from_nm_filepath_buffer_is_the_exact_size(void **state)
+test_netplan_get_id_from_nm_filepath_buffer_is_the_exact_size(__unused void **state)
 {
 
     const char* filename = "/run/NetworkManager/system-connections/netplan-some-id-SOME-SSID.nmconnection";
@@ -86,7 +86,7 @@ test_netplan_get_id_from_nm_filepath_buffer_is_the_exact_size(void **state)
 }
 
 void
-test_netplan_get_id_from_nm_filepath_filename_is_malformed(void **state)
+test_netplan_get_id_from_nm_filepath_filename_is_malformed(__unused void **state)
 {
 
     const char* filename = "INVALID/netplan-some-id.nmconnection";
@@ -98,7 +98,7 @@ test_netplan_get_id_from_nm_filepath_filename_is_malformed(void **state)
 }
 
 void
-test_netplan_netdef_get_output_filename_nm_with_ssid(void** state)
+test_netplan_netdef_get_output_filename_nm_with_ssid(__unused void** state)
 {
     NetplanNetDefinition netdef;
     const char* expected = "/run/NetworkManager/system-connections/netplan-enlol3s0-home-network.nmconnection";
@@ -116,7 +116,7 @@ test_netplan_netdef_get_output_filename_nm_with_ssid(void** state)
 }
 
 void
-test_netplan_netdef_get_output_filename_nm_without_ssid(void** state)
+test_netplan_netdef_get_output_filename_nm_without_ssid(__unused void** state)
 {
     NetplanNetDefinition netdef;
     const char* expected = "/run/NetworkManager/system-connections/netplan-enlol3s0.nmconnection";
@@ -133,7 +133,7 @@ test_netplan_netdef_get_output_filename_nm_without_ssid(void** state)
 }
 
 void
-test_netplan_netdef_get_output_filename_networkd(void** state)
+test_netplan_netdef_get_output_filename_networkd(__unused void** state)
 {
     NetplanNetDefinition netdef;
     const char* expected = "/run/systemd/network/10-netplan-enlol3s0.network";
@@ -150,7 +150,7 @@ test_netplan_netdef_get_output_filename_networkd(void** state)
 }
 
 void
-test_netplan_netdef_get_output_filename_buffer_is_too_small(void** state)
+test_netplan_netdef_get_output_filename_buffer_is_too_small(__unused void** state)
 {
     NetplanNetDefinition netdef;
     char out_buffer[16] = { 0 };
@@ -164,7 +164,7 @@ test_netplan_netdef_get_output_filename_buffer_is_too_small(void** state)
 }
 
 void
-test_netplan_netdef_get_output_filename_invalid_backend(void** state)
+test_netplan_netdef_get_output_filename_invalid_backend(__unused void** state)
 {
     NetplanNetDefinition netdef;
     char out_buffer[16] = { 0 };
@@ -178,7 +178,7 @@ test_netplan_netdef_get_output_filename_invalid_backend(void** state)
 }
 
 void
-test_util_is_route_present(void** state)
+test_util_is_route_present(__unused void** state)
 {
     const char* yaml =
         "network:\n"
@@ -278,7 +278,7 @@ test_util_is_route_present(void** state)
 }
 
 void
-test_util_is_route_rule_present(void** state)
+test_util_is_route_rule_present(__unused void** state)
 {
     const char* yaml =
         "network:\n"
@@ -316,7 +316,7 @@ test_util_is_route_rule_present(void** state)
 }
 
 void
-test_util_is_string_in_array(void** state)
+test_util_is_string_in_array(__unused void** state)
 {
     const char* yaml =
         "network:\n"
@@ -341,7 +341,7 @@ test_util_is_string_in_array(void** state)
 
 
 void
-test_normalize_ip_address(void** state)
+test_normalize_ip_address(__unused void** state)
 {
     assert_string_equal(normalize_ip_address("default", AF_INET), "0.0.0.0/0");
     assert_string_equal(normalize_ip_address("default", AF_INET6), "::/0");
@@ -349,13 +349,13 @@ test_normalize_ip_address(void** state)
 }
 
 int
-setup(void** state)
+setup(__unused void** state)
 {
     return 0;
 }
 
 int
-tear_down(void** state)
+tear_down(__unused void** state)
 {
     return 0;
 }

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -21,7 +21,7 @@
 #include "test_utils.h"
 
 void
-test_netplan_parser_new_parser(void** state)
+test_netplan_parser_new_parser(__unused void** state)
 {
     NetplanParser* npp = netplan_parser_new();
     assert_non_null(npp);
@@ -29,7 +29,7 @@ test_netplan_parser_new_parser(void** state)
 }
 
 void
-test_netplan_parser_load_yaml(void** state)
+test_netplan_parser_load_yaml(__unused void** state)
 {
     const char* filename = FIXTURESDIR "/ovs.yaml";
     GError *error = NULL;
@@ -43,7 +43,7 @@ test_netplan_parser_load_yaml(void** state)
 }
 
 void
-test_netplan_parser_load_yaml_from_fd(void** state)
+test_netplan_parser_load_yaml_from_fd(__unused void** state)
 {
     const char* filename = FIXTURESDIR "/ovs.yaml";
     FILE* f = fopen(filename, "r");
@@ -59,7 +59,7 @@ test_netplan_parser_load_yaml_from_fd(void** state)
 }
 
 void
-test_netplan_parser_load_nullable_fields(void** state)
+test_netplan_parser_load_nullable_fields(__unused void** state)
 {
     const char* filename = FIXTURESDIR "/nullable.yaml";
     FILE* f = fopen(filename, "r");
@@ -78,7 +78,7 @@ test_netplan_parser_load_nullable_fields(void** state)
 }
 
 void
-test_netplan_parser_load_nullable_overrides(void** state)
+test_netplan_parser_load_nullable_overrides(__unused void** state)
 {
     const char* filename = FIXTURESDIR "/optional.yaml";
     FILE* f = fopen(filename, "r");
@@ -98,7 +98,7 @@ test_netplan_parser_load_nullable_overrides(void** state)
 }
 
 void
-test_netplan_parser_interface_has_bridge_netdef(void** state)
+test_netplan_parser_interface_has_bridge_netdef(__unused void** state)
 {
 
     NetplanState *np_state = load_fixture_to_netplan_state("bridge.yaml");
@@ -117,7 +117,7 @@ test_netplan_parser_interface_has_bridge_netdef(void** state)
 }
 
 void
-test_netplan_parser_interface_has_bond_netdef(void** state)
+test_netplan_parser_interface_has_bond_netdef(__unused void** state)
 {
 
     NetplanState* np_state = load_fixture_to_netplan_state("bond.yaml");
@@ -136,7 +136,7 @@ test_netplan_parser_interface_has_bond_netdef(void** state)
 }
 
 void
-test_netplan_parser_interface_has_peer_netdef(void** state)
+test_netplan_parser_interface_has_peer_netdef(__unused void** state)
 {
 
     NetplanState* np_state = load_fixture_to_netplan_state("ovs.yaml");
@@ -156,7 +156,7 @@ test_netplan_parser_interface_has_peer_netdef(void** state)
 }
 
 void
-test_netplan_parser_sriov_embedded_switch(void** state)
+test_netplan_parser_sriov_embedded_switch(__unused void** state)
 {
 
     char embedded_switch[16];
@@ -176,7 +176,7 @@ test_netplan_parser_sriov_embedded_switch(void** state)
  * LP#2000324
  */
 void
-test_netplan_parser_process_document_proper_error(void** state)
+test_netplan_parser_process_document_proper_error(__unused void** state)
 {
 
     NetplanParser *npp = netplan_parser_new();
@@ -207,7 +207,7 @@ test_netplan_parser_process_document_proper_error(void** state)
 }
 
 void
-test_netplan_parser_process_document_missing_interface_error(void** state)
+test_netplan_parser_process_document_missing_interface_error(__unused void** state)
 {
 
     NetplanParser *npp = netplan_parser_new();
@@ -237,7 +237,7 @@ test_netplan_parser_process_document_missing_interface_error(void** state)
 }
 
 void
-test_nm_device_backend_is_nm_by_default(void** state)
+test_nm_device_backend_is_nm_by_default(__unused void** state)
 {
     const char* yaml =
         "network:\n"
@@ -263,13 +263,13 @@ test_nm_device_backend_is_nm_by_default(void** state)
 }
 
 int
-setup(void** state)
+setup(__unused void** state)
 {
     return 0;
 }
 
 int
-tear_down(void** state)
+tear_down(__unused void** state)
 {
     return 0;
 }

--- a/tests/ctests/test_netplan_state.c
+++ b/tests/ctests/test_netplan_state.c
@@ -19,7 +19,7 @@
 #include "test_utils.h"
 
 void
-test_netplan_state_new_state(void** state)
+test_netplan_state_new_state(__unused void** state)
 {
     NetplanState* np_state = netplan_state_new();
     assert_non_null(np_state);
@@ -27,7 +27,7 @@ test_netplan_state_new_state(void** state)
 }
 
 void
-test_netplan_state_iterator(void** state)
+test_netplan_state_iterator(__unused void** state)
 {
     NetplanState* np_state = load_fixture_to_netplan_state("bond.yaml");
     NetplanStateIterator iter;
@@ -50,7 +50,7 @@ test_netplan_state_iterator(void** state)
 }
 
 void
-test_netplan_state_iterator_empty(void** state)
+test_netplan_state_iterator_empty(__unused void** state)
 {
     NetplanStateIterator iter = { 0 };
     NetplanNetDefinition* netdef = NULL;
@@ -60,7 +60,7 @@ test_netplan_state_iterator_empty(void** state)
 }
 
 void
-test_netplan_state_iterator_null(void** state)
+test_netplan_state_iterator_null(__unused void** state)
 {
     NetplanStateIterator *iter = NULL;
     NetplanNetDefinition* netdef = NULL;
@@ -70,20 +70,20 @@ test_netplan_state_iterator_null(void** state)
 }
 
 void
-test_netplan_state_iterator_null_has_next(void** state)
+test_netplan_state_iterator_null_has_next(__unused void** state)
 {
     assert_false(netplan_state_iterator_has_next(NULL));
 }
 
 
 int
-setup(void** state)
+setup(__unused void** state)
 {
     return 0;
 }
 
 int
-tear_down(void** state)
+tear_down(__unused void** state)
 {
     return 0;
 }

--- a/tests/ctests/test_netplan_validation.c
+++ b/tests/ctests/test_netplan_validation.c
@@ -19,7 +19,7 @@
 #include "test_utils.h"
 
 void
-test_validate_interface_name_length(void** state)
+test_validate_interface_name_length(__unused void** state)
 {
     const char* yaml =
         "network:\n"
@@ -41,7 +41,7 @@ test_validate_interface_name_length(void** state)
 }
 
 void
-test_validate_interface_name_length_set_name(void** state)
+test_validate_interface_name_length_set_name(__unused void** state)
 {
     const char* yaml =
         "network:\n"
@@ -65,7 +65,7 @@ test_validate_interface_name_length_set_name(void** state)
 }
 
 void
-test_validate_interface_name_length_too_long(void** state)
+test_validate_interface_name_length_too_long(__unused void** state)
 {
     const char* yaml =
         "network:\n"
@@ -87,7 +87,7 @@ test_validate_interface_name_length_too_long(void** state)
 }
 
 void
-test_validate_interface_name_length_set_name_too_long(void** state)
+test_validate_interface_name_length_set_name_too_long(__unused void** state)
 {
     const char* yaml =
         "network:\n"
@@ -111,13 +111,13 @@ test_validate_interface_name_length_set_name_too_long(void** state)
 }
 
 int
-setup(void** state)
+setup(__unused void** state)
 {
     return 0;
 }
 
 int
-tear_down(void** state)
+tear_down(__unused void** state)
 {
     return 0;
 }


### PR DESCRIPTION
## Description

Some of this issues were found when I tried to compile netplan as c++, some were found by increasing the warning level with `-Wextra` and some were found by me while fixing the issues found by the compiler.

Some changes might seem unnecessary, specially the one annotating unused parameters with `__unused`. But I think they add some value.

My motivation to increase the warning_level to 2 is to avoid problems like this:

```c
int main() {
    int a = -1;
    unsigned int b = 1;
    if(a > b) {
        printf("According to my calculations %d IS greater than %d\n", a, b);
    }
}
```
```
$ cc main.c
$ ./a.out
According to my calculations -1 IS greater than 1
``` 

It's unfortunate that it's only caught by the compiler by using `-Wextra` or explicitly using `-Wsign-compare` (which is enabled by `-Wextra`).

Annotating the unused parameters with `__unused` at least makes us aware about the big number of function parameters we never use and, because it's annoying having this annotations, we might decide to get rid of them in the future.

Some changes were made to improve consistency, for example, the g++ compiler found a couple of instances of the code below (which is accepted by a C compiler):

```c
enum Values {
    V1, V2, V3,
};
int main() {
    enum Values v = V1 | V2 | V3;
}
```
As the result of the expression is not a variant of the Values enum, it seems to me it doesn't make sense to store it in a variable of type enum Values.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

