### PR TITLE
tests:integration: Adopt for systemd v254 (Closes: #1041310)

### DIFF
--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -346,7 +346,7 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
 
     # TODO: implement link-local handling in NetworkManager backend and move this test into CommonTests()
     def test_link_local_ipv6(self):
-        self.setup_eth(None)
+        self.setup_eth('ra-only')
         with open(self.config, 'w') as f:
             f.write('''network:
   renderer: %(r)s

--- a/tests/integration/scenarios.py
+++ b/tests/integration/scenarios.py
@@ -35,7 +35,7 @@ from base import IntegrationTestsBase, test_backends
 class _CommonTests():
 
     def test_mix_bridge_on_bond(self):
-        self.setup_eth(None)
+        self.setup_eth('ra-only')
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'bond0'], stderr=subprocess.DEVNULL)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'br0'], stderr=subprocess.DEVNULL)
         with open(self.config, 'w') as f:
@@ -65,7 +65,7 @@ class _CommonTests():
             self.assertIn(self.dev_e2_client, result)
 
     def test_mix_vlan_on_bridge_on_bond(self):
-        self.setup_eth(None, False)
+        self.setup_eth('ra-only')
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'bond0'], stderr=subprocess.DEVNULL)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'br0'], stderr=subprocess.DEVNULL)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'br1'], stderr=subprocess.DEVNULL)

--- a/tests/integration/vlans.py
+++ b/tests/integration/vlans.py
@@ -68,7 +68,7 @@ class _CommonTests():
                       subprocess.check_output(['ip', 'route', 'show', 'dev', 'nptesttwo']))
 
     def test_vlan_mac_address(self):
-        self.setup_eth(None)
+        self.setup_eth('ra-only')
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'myvlan'], stderr=subprocess.DEVNULL)
         with open(self.config, 'w') as f:
             f.write('''network:


### PR DESCRIPTION
## Description
systemd-networkd v245 seems to be more picky about moving an interface from "configuring" to "configured" state. It waits for an IPv6 RA to be received. So we need to define "accept-ra: false" in Netplan tests to ignore that, or make our test environment (dnsmasq) to actually provide RAs. I went with the latter.

We still see weird error messages from 'networkctl', which seems new, but they do not fail tests. E.g.: Failed to query link bit rates: Invalid argument
Failed to query link DHCP leases: Invalid argument

I have the impression that those error messages are thrown while the interface is still in "configuring" state, i.e. while waiting for the RA to be received/processed. We're calling 'networkctl status IFACE' in a loop and the error message vanishes when calling the command after a few seconds.

https://bugs.debian.org/1041310

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

