### PR TITLE
parse: Downgrade NM passthrough warning to debug

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3103,7 +3103,7 @@ handle_network_type(NetplanParser* npp, yaml_node_t* node, const char* key_prefi
             case NETPLAN_DEF_TYPE_WIFI: handlers = wifi_def_handlers; break;
             case NETPLAN_DEF_TYPE_DUMMY: handlers = dummy_def_handlers; break;      /* wokeignore:rule=dummy */
             case NETPLAN_DEF_TYPE_NM:
-                g_warning("netplan: %s: handling NetworkManager passthrough device, settings are not fully supported.", npp->current.netdef->id);
+                g_debug("netplan: %s: handling NetworkManager passthrough device, settings are not fully supported.", npp->current.netdef->id);
                 handlers = ethernet_def_handlers;
                 if (npp->current.netdef->backend != NETPLAN_BACKEND_NM) {
                     g_warning("nm-device: %s: the renderer for nm-devices must be NetworkManager, it will be used instead of the defined one.",


### PR DESCRIPTION
## Description
With the NetworkManager integration in place there will be many more cases where "nm-devices" are used, and we don't want to spam system logs with our warnings.

## Checklist

- [X] Runs `make check` successfully.
- [X] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

