### PR TITLE
Netplan state diff

### DIFF
--- a/netplan_cli/cli/state.py
+++ b/netplan_cli/cli/state.py
@@ -509,6 +509,7 @@ class NetplanConfigState():
 
         np_state = netplan.State()
         np_state.import_parser_results(parser)
+        self.netdefs = np_state.netdefs
 
         self.state = StringIO()
 

--- a/netplan_cli/cli/state_diff.py
+++ b/netplan_cli/cli/state_diff.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2023 Canonical, Ltd.
+# Authors: Danilo Egea Gondolfo <danilo.egea.gondolfo@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from netplan.netdef import NetplanRoute
+from netplan_cli.cli.state import SystemConfigState, NetplanConfigState, DEVICE_TYPES
+
+
+class NetplanDiffState():
+    '''
+    DiffState is mainly responsible for getting both system's and Netplan's configuration
+    state, compare them and provide a data-structure containing the differences it found.
+    '''
+
+    def __init__(self, system_state: SystemConfigState, netplan_state: NetplanConfigState):
+        self.system_state = system_state
+        self.netplan_state = netplan_state
+
+    def get_full_state(self) -> dict:
+        '''
+        Return the states of both the system and Netplan in a common representation
+        that makes it easier to compare them.
+        '''
+
+        full_state = {
+            'interfaces': {}
+        }
+
+        system_interfaces = self._get_system_interfaces()
+        netplan_interfaces = self._get_netplan_interfaces()
+
+        # Merge all the interfaces in the same data structure
+        all_interfaces = set(list(system_interfaces.keys()) + list(netplan_interfaces.keys()))
+        for interface in all_interfaces:
+            full_state['interfaces'][interface] = {}
+
+        for interface, config in system_interfaces.items():
+            full_state['interfaces'][interface].update(config)
+
+        for interface, config in netplan_interfaces.items():
+            full_state['interfaces'][interface].update(config)
+
+        return full_state
+
+    def _get_netplan_interfaces(self) -> dict:
+        system_interfaces = self.system_state.get_data()
+        interfaces = {}
+        for interface, config in self.netplan_state.netdefs.items():
+
+            iface = {}
+            iface[interface] = {'netplan_state': {'id': interface}}
+            iface_ref = iface[interface]['netplan_state']
+
+            iface_ref['type'] = DEVICE_TYPES.get(config.type, 'unknown')
+
+            iface_ref['dhcp4'] = config.dhcp4
+            iface_ref['dhcp6'] = config.dhcp6
+
+            addresses = [addr for addr in config.addresses]
+            if addresses:
+                iface_ref['addresses'] = {}
+                for addr in addresses:
+                    flags = {}
+                    if addr.label:
+                        flags['label'] = addr.label
+                    if addr.lifetime:
+                        flags['lifetime'] = addr.lifetime
+                    iface_ref['addresses'][str(addr)] = {'flags': flags}
+
+            if nameservers := list(config.nameserver_addresses):
+                iface_ref['nameservers_addresses'] = nameservers
+
+            if search := list(config.nameserver_search):
+                iface_ref['nameservers_search'] = search
+
+            if routes := list(config.routes):
+                iface_ref['routes'] = routes
+
+            if mac := config.macaddress:
+                iface_ref['macaddress'] = mac
+
+            if interface not in system_interfaces:
+                # If the netdef ID doesn't correspond to any interface name in the system,
+                # it might be associated with multiple system interfaces, such as when the 'match' key is used,
+                # or the interface name is set in the passthrough section, such as when we create a connection via
+                # Network Manager and the netdef ID is the UUID of the connetion.
+                # In these cases, we need to look for all the system's interfaces
+                # pointing to this netdef and add one netdef entry per device.
+                found_some = False
+                for key, value in system_interfaces.items():
+                    if netdef_id := value.get('id'):
+                        if netdef_id == interface:
+                            found_some = True
+                            interfaces[key] = iface[interface]
+
+                # If we don't find any system interface associated with the netdef
+                # that's because it's not matching any device. In this case, we add the
+                # netdef ID to the list anyway.
+                if not found_some:
+                    interfaces.update(iface)
+            else:
+                interfaces.update(iface)
+
+        return interfaces
+
+    def _get_system_interfaces(self) -> dict:
+        interfaces = {}
+
+        for interface, config in self.system_state.get_data().items():
+            if interface == 'netplan-global-state':
+                continue
+
+            device_type = config.get('type')
+            interfaces[interface] = {'system_state': {'type': device_type}}
+
+            if netdef_id := config.get('id'):
+                interfaces[interface]['system_state']['id'] = netdef_id
+
+            iface_ref = interfaces[interface]['system_state']
+
+            if index := config.get('index'):
+                iface_ref['index'] = index
+
+            addresses = {}
+            for addr in config.get('addresses', []):
+                ip = list(addr.keys())[0]
+                prefix = addr.get(ip).get('prefix')
+                full_addr = f'{ip}/{prefix}'
+
+                addresses[full_addr] = {'flags': addr.get(ip).get('flags', [])}
+            if addresses:
+                iface_ref['addresses'] = addresses
+
+            if nameservers := config.get('dns_addresses'):
+                iface_ref['nameservers_addresses'] = nameservers
+
+            if search := config.get('dns_search'):
+                iface_ref['nameservers_search'] = search
+
+            if routes := config.get('routes'):
+                iface_ref['routes'] = [self._system_route_to_netplan(route) for route in routes]
+
+            if mac := config.get('macaddress'):
+                iface_ref['macaddress'] = mac
+
+        return interfaces
+
+    def _system_route_to_netplan(self, system_route: dict) -> NetplanRoute:
+        route = {}
+
+        if family := system_route.get('family'):
+            route['family'] = family
+        if to := system_route.get('to'):
+            route['to'] = to
+        if via := system_route.get('via'):
+            route['via'] = via
+        if from_addr := system_route.get('from'):
+            route['from_addr'] = from_addr
+        if metric := system_route.get('metric'):
+            route['metric'] = metric
+        if scope := system_route.get('scope'):
+            route['scope'] = scope
+        if route_type := system_route.get('type'):
+            route['type'] = route_type
+        if protocol := system_route.get('protocol'):
+            route['protocol'] = protocol
+        if table := system_route.get('table'):
+            route['table'] = self._default_route_tables_name_to_number(table)
+
+        return NetplanRoute(**route)
+
+    def _default_route_tables_name_to_number(self, name: str) -> int:
+        value = 0
+        # Mapped in /etc/iproute2/rt_tables
+        if name == 'default':
+            value = 253
+        elif name == 'main':
+            value = 254
+        elif name == 'local':
+            value = 255
+        else:
+            try:
+                value = int(name)
+            except ValueError:
+                value = 0
+
+        return value

--- a/netplan_cli/cli/state_diff.py
+++ b/netplan_cli/cli/state_diff.py
@@ -86,6 +86,7 @@ class NetplanDiffState():
             self._analyze_ip_addresses(config, iface)
             self._analyze_nameservers(config, iface)
             self._analyze_search_domains(config, iface)
+            self._analyze_mac_addresses(config, iface)
 
             report['interfaces'].update(iface)
 
@@ -261,6 +262,20 @@ class NetplanDiffState():
             iface[name]['system_state'].update({
                 'missing_nameservers_search': list(present_only_in_netplan),
             })
+
+    def _analyze_mac_addresses(self, config: dict, iface: dict) -> None:
+        name = list(iface.keys())[0]
+        system_macaddress = config.get('system_state', {}).get('macaddress')
+        netplan_macaddress = config.get('netplan_state', {}).get('macaddress')
+
+        if system_macaddress and netplan_macaddress:
+            if system_macaddress != netplan_macaddress:
+                iface[name]['system_state'].update({
+                    'missing_macaddress': netplan_macaddress
+                })
+                iface[name]['netplan_state'].update({
+                    'missing_macaddress': system_macaddress
+                })
 
     def _analyze_missing_interfaces(self, report: dict) -> None:
         netplan_interfaces = {iface for iface in self.netplan_state.netdefs}

--- a/netplan_cli/cli/state_diff.py
+++ b/netplan_cli/cli/state_diff.py
@@ -16,10 +16,20 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import ipaddress
+import json
 from typing import AbstractSet
 
 from netplan.netdef import NetplanRoute
 from netplan_cli.cli.state import SystemConfigState, NetplanConfigState, DEVICE_TYPES
+
+
+class DiffJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, NetplanRoute):
+            return obj.to_dict()
+
+        # Shouldn't be reached as the only non-serializable type we have at the moment is NetplanRoute
+        return json.JSONEncoder.default(self, obj)  # pragma: nocover (only NetplanRoute requires the encoder)
 
 
 class NetplanDiffState():

--- a/netplan_cli/cli/state_diff.py
+++ b/netplan_cli/cli/state_diff.py
@@ -102,6 +102,8 @@ class NetplanDiffState():
 
             report['interfaces'].update(iface)
 
+        # Sort the list of interfaces according to their indices.
+        report['interfaces'] = dict(sorted(report['interfaces'].items(), key=lambda iface: iface[1].get('index')))
         return report
 
     def _create_new_report(self) -> dict:

--- a/netplan_cli/cli/state_diff.py
+++ b/netplan_cli/cli/state_diff.py
@@ -326,8 +326,22 @@ class NetplanDiffState():
             if iface.netdef_id not in netplan_interfaces:
                 system_only.append(iface.name)
 
-        report['missing_interfaces_system'] = sorted(netplan_only)
-        report['missing_interfaces_netplan'] = sorted(system_only)
+        netplan_only = sorted(netplan_only)
+        system_only = sorted(system_only)
+
+        system_state = self.system_state.get_data()
+
+        for iface in netplan_only:
+            iface_type = self.netplan_state.netdefs.get(iface).type
+            report['missing_interfaces_system'][iface] = {
+                'type': DEVICE_TYPES.get(iface_type, 'unknown')
+            }
+
+        for iface in system_only:
+            report['missing_interfaces_netplan'][iface] = {
+                'type': system_state.get(iface).get('type', 'unknown'),
+                'index': system_state.get(iface).get('index'),
+            }
 
     def _normalize_routes(self, routes: set) -> set:
         ''' Apply some transformations to Netplan routes so their representation

--- a/netplan_cli/meson.build
+++ b/netplan_cli/meson.build
@@ -25,6 +25,7 @@ cli_sources = files(
     'cli/core.py',
     'cli/ovs.py',
     'cli/state.py',
+    'cli/state_diff.py',
     'cli/sriov.py',
     'cli/utils.py')
 

--- a/python-cffi/netplan/netdef.py
+++ b/python-cffi/netplan/netdef.py
@@ -242,7 +242,7 @@ class _NetdefSearchDomainIterator:
         return ffi.string(next_value).decode('utf-8')
 
 
-@dataclass(unsafe_hash=True)
+@dataclass
 class NetplanRoute:
     _METRIC_UNSPEC_ = lib.UINT_MAX
     _TABLE_UNSPEC_ = 0
@@ -297,6 +297,25 @@ class NetplanRoute:
         route['type'] = self.type
 
         return route
+
+    def __hash__(self):
+        return hash(
+            (self.to, self.via,
+             self.from_addr, self.table,
+             self.family, self.metric,
+             self.type, self.scope))
+
+    def __eq__(self, route):
+        return (
+            self.to == route.to and
+            self.via == route.via and
+            self.from_addr == route.from_addr and
+            self.table == route.table and
+            self.family == route.family and
+            self.metric == route.metric and
+            self.type == route.type and
+            self.scope == route.scope
+        )
 
 
 class _NetdefRouteIterator:

--- a/tests/cli/test_state_diff.py
+++ b/tests/cli/test_state_diff.py
@@ -1,0 +1,336 @@
+#!/usr/bin/python3
+# Closed-box tests of netplan CLI. These are run during "make check" and don't
+# touch the system configuration at all.
+#
+# Copyright (C) 2023 Canonical, Ltd.
+# Authors: Danilo Egea Gondolfo <danilo.egea.gondolfo@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import tempfile
+import unittest
+
+from unittest.mock import Mock
+from netplan.netdef import NetplanRoute
+from netplan_cli.cli.state import NetplanConfigState, SystemConfigState
+from netplan_cli.cli.state_diff import NetplanDiffState
+
+
+class TestNetplanDiff(unittest.TestCase):
+    '''Test netplan state NetplanDiffState class'''
+
+    def setUp(self):
+        self.workdir = tempfile.TemporaryDirectory(prefix='netplan_')
+        self.file = '90-netplan.yaml'
+        self.path = os.path.join(self.workdir.name, 'etc', 'netplan', self.file)
+        os.makedirs(os.path.join(self.workdir.name, 'etc', 'netplan'))
+
+        self.diff_state = NetplanDiffState(Mock(spec=SystemConfigState), Mock(spec=NetplanConfigState))
+
+    def test_get_full_state(self):
+        with open(self.path, "w") as f:
+            f.write('''network:
+  ethernets:
+    mynic:
+      match:
+        name: eth0
+      dhcp4: true
+      dhcp6: false''')
+
+        netplan_state = NetplanConfigState(rootdir=self.workdir.name)
+        system_state = Mock(spec=SystemConfigState)
+        system_state.get_data.return_value = {
+            'netplan-global-state': {},
+            'eth0': {
+                'name': 'eth0',
+                'id': 'mynic',
+                'index': 2,
+                'type': 'ethernet',
+                'addresses': [
+                    {
+                        '1.2.3.4': {
+                            'prefix': 24,
+                            'flags': ['dhcp'],
+                        }
+                    },
+                ],
+            }
+        }
+        system_state.interface_list = []
+        diff_state = NetplanDiffState(system_state, netplan_state)
+
+        full_state = diff_state.get_full_state()
+        expected = {
+            'interfaces': {
+                'eth0': {
+                    'system_state': {
+                        'type': 'ethernet',
+                        'addresses': {
+                            '1.2.3.4/24': {
+                                'flags': ['dhcp']
+                            }
+                        },
+                        'id': 'mynic',
+                        'index': 2,
+                    },
+                    'netplan_state': {
+                        'id': 'mynic',
+                        'type': 'ethernet',
+                        'dhcp4': True,
+                        'dhcp6': False
+                    }
+                }
+            }
+        }
+
+        self.assertDictEqual(full_state, expected)
+
+    def test_get_netplan_interfaces(self):
+        with open(self.path, "w") as f:
+            f.write('''network:
+  ethernets:
+    mynic:
+      match:
+        name: eth0
+      dhcp4: false
+      dhcp6: false
+      macaddress: aa:bb:cc:dd:ee:ff
+      routes:
+        - to: default
+          via: 1.2.3.4
+      nameservers:
+        addresses:
+          - 1.1.1.1
+          - 2.2.2.2
+        search:
+          - mydomain.local
+      addresses:
+        - 192.168.0.2/24:
+            label: myip
+            lifetime: forever
+        - 192.168.0.1/24''')
+
+        netplan_state = NetplanConfigState(rootdir=self.workdir.name)
+        system_state = Mock(spec=SystemConfigState)
+        system_state.get_data.return_value = {
+            'netplan-global-state': {},
+            'eth0': {
+                'name': 'eth0',
+                'id': 'mynic',
+                'index': 2,
+            }
+        }
+        system_state.interface_list = []
+        diff_state = NetplanDiffState(system_state, netplan_state)
+
+        interfaces = diff_state._get_netplan_interfaces()
+        expected = {
+            'eth0': {
+                'netplan_state': {
+                    'id': 'mynic',
+                    'addresses': {
+                        '192.168.0.1/24': {
+                            'flags': {}
+                        },
+                        '192.168.0.2/24': {
+                            'flags': {'label': 'myip', 'lifetime': 'forever'},
+                        }
+                    },
+                    'dhcp4': False,
+                    'dhcp6': False,
+                    'nameservers_addresses': ['1.1.1.1', '2.2.2.2'],
+                    'nameservers_search': ['mydomain.local'],
+                    'macaddress': 'aa:bb:cc:dd:ee:ff',
+                    'type': 'ethernet',
+                    'routes': [NetplanRoute(to='default', via='1.2.3.4', family=2)],
+                }
+            }
+        }
+        self.assertDictEqual(interfaces, expected)
+
+    def test_get_netplan_interfaces_with_match(self):
+        with open(self.path, "w") as f:
+            f.write('''network:
+  ethernets:
+    # not matching any physical device
+    myeths:
+      match:
+        name: eth*
+    mynics:
+      dhcp4: false
+      dhcp6: false
+      match:
+        name: enp0*''')
+
+        netplan_state = NetplanConfigState(rootdir=self.workdir.name)
+        system_state = Mock(spec=SystemConfigState)
+        system_state.get_data.return_value = {
+            'netplan-global-state': {},
+            'enp0s3': {
+                'name': 'enp0s3',
+                'id': 'mynics',
+                'index': 2,
+            },
+            'enp0s4': {
+                'name': 'enp0s4',
+                'id': 'mynics',
+                'index': 3,
+            },
+            'enp0s5': {
+                'name': 'enp0s5',
+                'id': 'mynics',
+                'index': 4,
+            }
+        }
+        system_state.interface_list = []
+        diff_state = NetplanDiffState(system_state, netplan_state)
+
+        interfaces = diff_state._get_netplan_interfaces()
+        expected = {
+            'enp0s3': {
+                'netplan_state': {
+                    'id': 'mynics',
+                    'dhcp4': False,
+                    'dhcp6': False,
+                    'type': 'ethernet',
+                }
+            },
+            'enp0s4': {
+                'netplan_state': {
+                    'id': 'mynics',
+                    'dhcp4': False,
+                    'dhcp6': False,
+                    'type': 'ethernet',
+                }
+            },
+            'enp0s5': {
+                'netplan_state': {
+                    'id': 'mynics',
+                    'dhcp4': False,
+                    'dhcp6': False,
+                    'type': 'ethernet',
+                },
+            },
+            'myeths': {
+                'netplan_state': {
+                    'id': 'myeths',
+                    'dhcp4': False,
+                    'dhcp6': False,
+                    'type': 'ethernet',
+                }
+            }
+        }
+        self.assertDictEqual(interfaces, expected)
+
+    def test_get_system_interfaces(self):
+        system_state = Mock(spec=SystemConfigState)
+        netplan_state = Mock(spec=NetplanConfigState)
+
+        system_state.get_data.return_value = {
+            'netplan-global-state': {},
+            'eth0': {
+                'name': 'eth0',
+                'id': 'mynic',
+                'type': 'ethernet',
+                'index': 2,
+                'addresses': [
+                    {
+                        '1.2.3.4': {
+                            'prefix': 24,
+                            'flags': [],
+                        }
+                    },
+                ],
+                'dns_addresses': ['1.1.1.1', '2.2.2.2'],
+                'dns_search': ['mydomain.local'],
+                'routes': [
+                    {
+                        'to': 'default',
+                        'via': '192.168.5.1',
+                        'from': '192.168.5.122',
+                        'metric': 100,
+                        'type': 'unicast',
+                        'scope': 'global',
+                        'protocol': 'kernel',
+                        'family': 2,
+                        'table': 'main'
+                    }
+                ],
+                'macaddress': 'aa:bb:cc:dd:ee:ff',
+            }
+        }
+        system_state.interface_list = []
+
+        diff_state = NetplanDiffState(system_state, netplan_state)
+        interfaces = diff_state._get_system_interfaces()
+        expected = {
+            'eth0': {
+                'system_state': {
+                    'type': 'ethernet',
+                    'id': 'mynic',
+                    'index': 2,
+                    'addresses': {
+                        '1.2.3.4/24': {
+                            'flags': []
+                        }
+                    },
+                    'nameservers_addresses': ['1.1.1.1', '2.2.2.2'],
+                    'nameservers_search': ['mydomain.local'],
+                    'routes': [
+                        NetplanRoute(to='default',
+                                     via='192.168.5.1',
+                                     from_addr='192.168.5.122',
+                                     type='unicast',
+                                     scope='global',
+                                     protocol='kernel',
+                                     table=254,
+                                     family=2,
+                                     metric=100)
+                    ],
+                    'macaddress': 'aa:bb:cc:dd:ee:ff'
+                },
+            }
+        }
+        self.assertDictEqual(interfaces, expected)
+
+    def test_diff_default_table_names_to_number(self):
+        self.assertEqual(self.diff_state._default_route_tables_name_to_number('main'), 254)
+        self.assertEqual(self.diff_state._default_route_tables_name_to_number('default'), 253)
+        self.assertEqual(self.diff_state._default_route_tables_name_to_number('local'), 255)
+        self.assertEqual(self.diff_state._default_route_tables_name_to_number('1000'), 1000)
+        self.assertEqual(self.diff_state._default_route_tables_name_to_number('blah'), 0)
+
+    def test__system_route_to_netplan_empty_input(self):
+        route = self.diff_state._system_route_to_netplan({})
+        expected = NetplanRoute()
+        self.assertEqual(route, expected)
+
+    def test__system_route_to_netplan(self):
+        route = {
+            'to': 'default',
+            'via': '192.168.5.1',
+            'from': '192.168.5.122',
+            'metric': 100,
+            'type': 'unicast',
+            'scope': 'global',
+            'protocol': 'kernel',
+            'family': 2,
+            'table': 'main'
+        }
+
+        netplan_route = self.diff_state._system_route_to_netplan(route)
+        expected = NetplanRoute(to='default', via='192.168.5.1', from_addr='192.168.5.122',
+                                metric=100, type='unicast', scope='global', protocol='kernel',
+                                family=2, table=254)
+        self.assertEqual(netplan_route, expected)

--- a/tests/cli/test_state_diff.py
+++ b/tests/cli/test_state_diff.py
@@ -462,8 +462,8 @@ class TestNetplanDiff(unittest.TestCase):
 
         diff = NetplanDiffState(system_state, netplan_state)
         diff_data = diff.get_diff()
-        missing = diff_data.get('missing_interfaces_system', [])
-        self.assertListEqual(missing, [])
+        missing = diff_data.get('missing_interfaces_system', {})
+        self.assertDictEqual(missing, {})
 
     def test__get_comparable_interfaces_empty(self):
         res = self.diff_state._get_comparable_interfaces({})

--- a/tests/integration/diff.py
+++ b/tests/integration/diff.py
@@ -1,0 +1,283 @@
+#!/usr/bin/python3
+# Netplan Diff integration tests.
+#
+# These need to be run in a VM and do change the system
+# configuration.
+#
+# Copyright (C) 2023 Canonical, Ltd.
+# Author: Danilo Egea Gondolfo <danilo.egea.gondolfo@canonical.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import sys
+import subprocess
+import unittest
+
+from base import IntegrationTestsBase, test_backends
+
+
+class _CommonTests():
+
+    def test_missing_netplan_ips(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dummy0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:
+    dummy0:
+      dhcp4: false
+      dhcp6: false''' % {'r': self.backend})
+        self.generate_and_settle(['dummy0'])
+
+        subprocess.call(['ip', 'addr', 'add', '1.2.3.4/24', 'dev', 'dummy0'])
+        subprocess.call(['ip', 'addr', 'add', '1.2.3.40/24', 'dev', 'dummy0'])
+
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        diff_ips = diff['interfaces']['dummy0']['netplan_state'].get('missing_addresses')
+        self.assertIn('1.2.3.4/24', diff_ips)
+        self.assertIn('1.2.3.40/24', diff_ips)
+
+    def test_missing_system_ips(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dummy0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:
+    dummy0:
+      addresses:
+        - 1.2.3.4/24
+        - 1.2.3.40/24
+      dhcp4: false
+      dhcp6: false''' % {'r': self.backend})
+        self.generate_and_settle(['dummy0'])
+
+        subprocess.call(['ip', 'addr', 'del', '1.2.3.4/24', 'dev', 'dummy0'])
+        subprocess.call(['ip', 'addr', 'del', '1.2.3.40/24', 'dev', 'dummy0'])
+
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        diff_ips = diff['interfaces']['dummy0']['system_state'].get('missing_addresses', [])
+        self.assertIn('1.2.3.4/24', diff_ips)
+        self.assertIn('1.2.3.40/24', diff_ips)
+
+    def test_missing_sytem_ips_with_match(self):
+        self.setup_eth(None)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    mynic:
+      match: {name: %(e2c)s}
+      addresses:
+        - 1.2.3.4/24
+        - 1.2.3.40/24
+      dhcp6: false
+      dhcp4: false''' % {'r': self.backend, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e2_client])
+
+        subprocess.call(['ip', 'addr', 'del', '1.2.3.4/24', 'dev', self.dev_e2_client])
+        subprocess.call(['ip', 'addr', 'del', '1.2.3.40/24', 'dev', self.dev_e2_client])
+
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        diff_ips = diff['interfaces'][self.dev_e2_client]['system_state'].get('missing_addresses', [])
+        netdef_id = diff['interfaces'][self.dev_e2_client]['id']
+        self.assertIn('1.2.3.4/24', diff_ips)
+        self.assertIn('1.2.3.40/24', diff_ips)
+        self.assertEqual(netdef_id, 'mynic')
+
+    def test_missing_interfaces(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dummy1'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  ethernets:
+    eth123456:
+      dhcp4: false
+      dhcp6: false''' % {'r': self.backend})
+
+        # Add an extra interface not present in any YAML
+        subprocess.check_call(['ip', 'link', 'add', 'type', 'dummy', 'dev', 'dummy1'])
+        subprocess.check_call(['ip', 'link', 'add', 'type', 'dummy', 'dev', 'dummy1'])
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        missing_system = diff.get('missing_interfaces_system', {})
+        missing_netplan = diff.get('missing_interfaces_netplan', {})
+        self.assertIn('dummy1', missing_netplan)
+        self.assertIn('eth123456', missing_system)
+
+    def test_missing_system_nameservers_addresses(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dummy0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:
+    dummy0:
+      nameservers:
+        addresses:
+          - 1.1.1.1
+          - 8.8.8.8
+      addresses:
+        - 1.2.3.4/24
+      dhcp4: false
+      dhcp6: false''' % {'r': self.backend})
+        self.generate_and_settle(['dummy0'])
+
+        subprocess.call(['resolvectl', 'dns', 'dummy0', '8.8.8.8'])
+
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        diff_dns = diff['interfaces']['dummy0']['system_state'].get('missing_nameservers_addresses', [])
+        self.assertIn('1.1.1.1', diff_dns)
+
+    def test_missing_netplan_nameservers_addresses(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dummy0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:
+    dummy0:
+      nameservers:
+        addresses:
+          - 1.1.1.1
+      addresses:
+        - 1.2.3.4/24
+      dhcp4: false
+      dhcp6: false''' % {'r': self.backend})
+        self.generate_and_settle(['dummy0'])
+
+        subprocess.call(['resolvectl', 'dns', 'dummy0', '1.1.1.1', '8.8.8.8'])
+
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        diff_dns = diff['interfaces']['dummy0']['netplan_state'].get('missing_nameservers_addresses', [])
+        self.assertIn('8.8.8.8', diff_dns)
+
+    def test_missing_system_nameservers_search(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dummy0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:
+    dummy0:
+      nameservers:
+        addresses:
+          - 1.1.1.1
+          - 8.8.8.8
+        search:
+          - mynet.local
+          - mydomain.local
+      addresses:
+        - 1.2.3.4/24
+      dhcp4: false
+      dhcp6: false''' % {'r': self.backend})
+        self.generate_and_settle(['dummy0'])
+
+        subprocess.call(['resolvectl', 'domain', 'dummy0', 'mynet.local'])
+
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        diff_dns = diff['interfaces']['dummy0']['system_state'].get('missing_nameservers_search', [])
+        self.assertIn('mydomain.local', diff_dns)
+
+    def test_missing_netplan_nameservers_search(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dummy0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:
+    dummy0:
+      nameservers:
+        search:
+          - mynet.local
+        addresses:
+          - 1.1.1.1
+      addresses:
+        - 1.2.3.4/24
+      dhcp4: false
+      dhcp6: false''' % {'r': self.backend})
+        self.generate_and_settle(['dummy0'])
+
+        subprocess.call(['resolvectl', 'domain', 'dummy0', 'mynet.local', 'mydomain.local'])
+
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        diff_dns = diff['interfaces']['dummy0']['netplan_state'].get('missing_nameservers_search', [])
+        self.assertIn('mydomain.local', diff_dns)
+
+    def test_missing_netplan_route(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dummy0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:
+    dummy0:
+      addresses:
+        - 1.2.3.4/24
+      dhcp4: false
+      dhcp6: false''' % {'r': self.backend})
+        self.generate_and_settle(['dummy0'])
+
+        subprocess.call(['ip', 'route', 'add', '3.2.1.0/24', 'via', '1.2.3.4'])
+
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        diff_routes = diff['interfaces']['dummy0']['netplan_state'].get('missing_routes', [])
+        self.assertEqual(len(diff_routes), 1)
+        route = diff_routes[0]
+        self.assertEqual('3.2.1.0/24', route['to'])
+        self.assertEqual('1.2.3.4', route['via'])
+        self.assertEqual(2, route['family'])
+
+    def test_missing_system_route(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'dummy0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  dummy-devices:
+    dummy0:
+      routes:
+        - to: 3.2.1.0/24
+          via: 1.2.3.4
+      addresses:
+        - 1.2.3.4/24
+      dhcp4: false
+      dhcp6: false''' % {'r': self.backend})
+        self.generate_and_settle(['dummy0'])
+
+        subprocess.call(['ip', 'route', 'del', '3.2.1.0/24', 'via', '1.2.3.4'])
+
+        diff = json.loads(subprocess.check_output(['python3', 'tools/diff.py', '-j']))
+        diff_routes = diff['interfaces']['dummy0']['system_state'].get('missing_routes', [])
+        self.assertEqual(len(diff_routes), 1)
+        route = diff_routes[0]
+        self.assertEqual('3.2.1.0/24', route['to'])
+        self.assertEqual('1.2.3.4', route['via'])
+        self.assertEqual(2, route['family'])
+
+
+@unittest.skipIf("networkd" not in test_backends,
+                 "skipping as networkd backend tests are disabled")
+class TestNetworkd(IntegrationTestsBase, _CommonTests):
+    backend = 'networkd'
+
+
+@unittest.skipIf("NetworkManager" not in test_backends,
+                 "skipping as NetworkManager backend tests are disabled")
+class TestNetworkManager(IntegrationTestsBase, _CommonTests):
+    backend = 'NetworkManager'
+
+
+unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))

--- a/tools/diff.py
+++ b/tools/diff.py
@@ -1,0 +1,130 @@
+import argparse
+import json
+from itertools import zip_longest
+
+from rich.console import Console
+from rich.table import Table
+
+from netplan_cli.cli.state import SystemConfigState, NetplanConfigState
+from netplan_cli.cli.state_diff import DiffJSONEncoder, NetplanDiffState
+
+parser = argparse.ArgumentParser(
+    prog='Diff',
+    description='Demo tool for netplan diff')
+parser.add_argument('-r', '--root-dir', default='/')
+parser.add_argument('-t', '--table', action='store_true')
+parser.add_argument('-j', '--json', action='store_true')
+
+
+def print_table(diff: dict, **style: dict):
+    main_table = Table.grid()
+
+    if interfaces := diff.get('interfaces'):
+        for iface, data in interfaces.items():
+            name = data.get('name')
+            id = data.get('id')
+
+            missing_dhcp = data.get('missing_dhcp4_address', False)
+            missing_dhcp = missing_dhcp or data.get('missing_dhcp6_address', False)
+            # Skip interfaces without diff
+            if not data.get('system_state') and not data.get('netplan_state') and not missing_dhcp:
+                continue
+
+            table = Table(expand=True, title=f'Interface: {name}\nNetplan ID: {id}', **style)
+            table.add_column('Missing resources in Netplan\'s State', justify="center", ratio=2)
+            table.add_column('Missing resources in System\'s State', justify="center", ratio=2)
+
+            system_macaddress = data.get('system_state', {}).get('missing_macaddress')
+            netplan_macaddress = data.get('netplan_state', {}).get('missing_macaddress')
+            if system_macaddress or netplan_macaddress:
+                table.add_section()
+                table.add_row('MAC Address', 'MAC Address', style='magenta')
+                table.add_row(netplan_macaddress, system_macaddress)
+
+            system_addresses = data.get('system_state', {}).get('missing_addresses', [])
+            netplan_addresses = data.get('netplan_state', {}).get('missing_addresses', [])
+            missing_dhcp4 = data.get('system_state', {}).get('missing_dhcp4_address', False)
+            missing_dhcp6 = data.get('system_state', {}).get('missing_dhcp6_address', False)
+
+            if system_addresses or netplan_addresses or missing_dhcp4 or missing_dhcp6:
+                table.add_section()
+                table.add_row('Addresses', 'Addresses', style='magenta')
+
+                if missing_dhcp4:
+                    system_addresses.append('DHCPv4: missing IP')
+                if missing_dhcp6:
+                    system_addresses.append('DHCPv6: missing IP')
+
+                for (ip1, ip2) in zip_longest(netplan_addresses, system_addresses):
+                    table.add_row(ip1, ip2)
+
+            system_nameservers = data.get('system_state', {}).get('missing_nameservers_addresses', [])
+            netplan_nameservers = data.get('netplan_state', {}).get('missing_nameservers_addresses', [])
+
+            if system_nameservers or netplan_nameservers:
+                table.add_section()
+                table.add_row('Nameservers', 'Nameservers', style='magenta')
+                for (ns1, ns2) in zip_longest(netplan_nameservers, system_nameservers):
+                    table.add_row(ns1, ns2)
+
+            system_search = data.get('system_state', {}).get('missing_nameservers_search', [])
+            netplan_search = data.get('netplan_state', {}).get('missing_nameservers_search', [])
+
+            if system_search or netplan_search:
+                table.add_section()
+                table.add_row('Search domains', 'Search domains', style='magenta')
+                for (search1, search2) in zip_longest(netplan_search, system_search):
+                    table.add_row(search1, search2)
+
+            system_routes = data.get('system_state', {}).get('missing_routes', [])
+            netplan_routes = data.get('netplan_state', {}).get('missing_routes', [])
+
+            if system_routes or netplan_routes:
+                table.add_section()
+                table.add_row('Routes', 'Routes', style='magenta', end_section=True)
+                for (route1, route2) in zip_longest(netplan_routes, system_routes):
+                    table.add_row(str(route1) if route1 else None, str(route2) if route2 else None)
+
+            if data.get('netplan_state') or data.get('system_state'):
+                main_table.add_section()
+                main_table.add_row(table, end_section=True)
+
+    # Add missing interfaces to the grid
+    missing_interfaces_system = diff.get('missing_interfaces_system', {})
+    missing_interfaces_netplan = diff.get('missing_interfaces_netplan', {})
+    if missing_interfaces_system or missing_interfaces_netplan:
+        table = Table(expand=True, title='Missing Interfaces', **style)
+        table.add_column('Missing interfaces in Netplan\'s State', justify="center", ratio=2)
+        table.add_column('Missing interfaces in System\'s State', justify="center", ratio=2)
+        for (iface1, iface2) in zip_longest(missing_interfaces_netplan.items(), missing_interfaces_system.items()):
+            iface1_name = iface1[0] if iface1 else None
+            iface2_name = iface2[0] if iface2 else None
+            table.add_row(iface1_name, iface2_name)
+
+        main_table.add_section()
+        main_table.add_row(table, end_section=True)
+
+    # Draw the grid
+    if main_table.columns:
+        console = Console()
+        console.print(main_table)
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+    system_state = SystemConfigState(all=True)
+    netplan_state = NetplanConfigState(rootdir=args.root_dir)
+
+    diff_state = NetplanDiffState(system_state, netplan_state)
+    diff = diff_state.get_diff()
+
+    if args.table:
+        style = {
+            'title_style': 'bold magenta',
+        }
+        print_table(diff, **style)
+    elif args.json:
+        print(json.dumps(diff, indent=2, cls=DiffJSONEncoder))
+    else:
+        print('Use either -t or -j (or both)')


### PR DESCRIPTION
## Description

This is the first iteration of the `diff` feature. At the moment, only a few number of resources are analyzed:

1) IP Addresses
2) DNS nameserver and search domains
3) Routes
4) MAC addresses
5) Missing interfaces

A number of heuristics were used to eliminate configuration we don't want to compare. These are basically settings that are very likely assigned automatically, such as IPs and routes assigned via DHCP. The reason for that is that this information will not be found in Netplan.
For example: if the interface has `dhcp4` enabled and an empty list of addresses in Netplan, we don't report to the user that the IP that is assigned, via DHCP, to that interface in the system is not present in Netplan. We do report though the case where the interface has no IPs but DHCP is enabled in Netplan and when extra IPs are found.

#### Experimental user interface

It still doesn't include a user interface for the data presentation, but I have an experimental one available in a separate branch.

I added a new experimental command, `netplan diff`, to enable people to look at one of the suggestions for the user interface. I also added a `--diff` to `netplan status` that makes the diff be shown along with the original information. None of this is definitive and can be changed/removed as I get peoples opinions.

I packaged it in a PPA. It's available here: https://launchpad.net/~danilogondolfo/+archive/ubuntu/netplan-diff/

Please, install the PPA and try running `netplan status --all --diff` and `netplan diff` and let me know your opinion :)

`netplan diff` accepts the parameter `-s` which you can use to change the table style. There are 6 styles available, from 0 to 5.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

