### PR TITLE
tests: fix test coverage report with newer python-coverage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -126,12 +126,12 @@ if get_option('b_coverage')
     test('coverage-py-output',
          pycoverage,
          args: ['html', '-d', join_paths(meson.current_build_dir(),
-                'meson-logs', 'coveragereport-py'), '--omit=/usr*'],
+                'meson-logs', 'coveragereport-py'), '--omit=/usr/*'],
          priority: -95, # run before 'coverage-py'
          is_parallel: false)
     test('coverage-py',
          pycoverage,
-         args: ['report', '--omit=/usr*', '--show-missing', '--fail-under=100'],
+         args: ['report', '--omit=/usr/*', '--show-missing', '--fail-under=100'],
          priority: -99, # run last
          is_parallel: false)
 endif


### PR DESCRIPTION
Python-coverage 7.x changed the pattern matching behavior for filesystem paths.


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

