### PR TITLE
Expose macaddress and DNS configuration from the netdef

### DIFF
--- a/include/netplan.h
+++ b/include/netplan.h
@@ -133,6 +133,9 @@ netplan_netdef_get_dhcp4(const NetplanNetDefinition* netdef);
 NETPLAN_PUBLIC gboolean
 netplan_netdef_get_dhcp6(const NetplanNetDefinition* netdef);
 
+NETPLAN_PUBLIC ssize_t
+netplan_netdef_get_macaddress(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);
+
 /********** Old API below this ***********/
 
 NETPLAN_DEPRECATED NETPLAN_PUBLIC const char *

--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -41,6 +41,7 @@ ffibuilder.cdef("""
         char* label;
     } NetplanAddressOptions;
     struct address_iter { ...; };
+    struct nameserver_iter { ...; };
 
     // Error handling
     uint64_t netplan_error_code(NetplanError* error);
@@ -105,6 +106,12 @@ ffibuilder.cdef("""
     struct address_iter* _netplan_netdef_new_address_iter(NetplanNetDefinition* netdef);
     NetplanAddressOptions* _netplan_address_iter_next(struct address_iter* it);
     void _netplan_address_iter_free(struct address_iter* it);
+    struct nameserver_iter* _netplan_netdef_new_nameserver_iter(NetplanNetDefinition* netdef);
+    char* _netplan_nameserver_iter_next(struct nameserver_iter* it);
+    void _netplan_nameserver_iter_free(struct nameserver_iter* it);
+    struct nameserver_iter* _netplan_netdef_new_search_domain_iter(NetplanNetDefinition* netdef);
+    char* _netplan_search_domain_iter_next(struct nameserver_iter* it);
+    void _netplan_search_domain_iter_free(struct nameserver_iter* it);
 
     // Utils
     gboolean netplan_util_dump_yaml_subtree(const char* prefix, int input_fd, int output_fd, NetplanError** error);

--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -87,6 +87,7 @@ ffibuilder.cdef("""
         const NetplanNetDefinition* netdef, const char* name, const char* mac, const char* driver_name);
     gboolean netplan_netdef_get_dhcp4(const NetplanNetDefinition* netdef);
     gboolean netplan_netdef_get_dhcp6(const NetplanNetDefinition* netdef);
+    ssize_t netplan_netdef_get_macaddress(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);
 
     // NetDefinition (internal)
     ssize_t _netplan_netdef_get_embedded_switch_mode(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size);

--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -40,7 +40,7 @@ ffibuilder.cdef("""
         char* lifetime;
         char* label;
     } NetplanAddressOptions;
-    struct netdef_address_iter { ...; };
+    struct address_iter { ...; };
 
     // Error handling
     uint64_t netplan_error_code(NetplanError* error);
@@ -102,9 +102,9 @@ ffibuilder.cdef("""
     struct netdef_pertype_iter* _netplan_state_new_netdef_pertype_iter(NetplanState* np_state, const char* def_type);
     NetplanNetDefinition* _netplan_netdef_pertype_iter_next(struct netdef_pertype_iter* it);
     void _netplan_netdef_pertype_iter_free(struct netdef_pertype_iter* it);
-    struct netdef_address_iter* _netplan_new_netdef_address_iter(NetplanNetDefinition* netdef);
-    NetplanAddressOptions* _netplan_netdef_address_iter_next(struct netdef_address_iter* it);
-    void _netplan_netdef_address_free_iter(struct netdef_address_iter* it);
+    struct address_iter* _netplan_netdef_new_address_iter(NetplanNetDefinition* netdef);
+    NetplanAddressOptions* _netplan_address_iter_next(struct address_iter* it);
+    void _netplan_address_iter_free(struct address_iter* it);
 
     // Utils
     gboolean netplan_util_dump_yaml_subtree(const char* prefix, int input_fd, int output_fd, NetplanError** error);

--- a/python-cffi/netplan/netdef.py
+++ b/python-cffi/netplan/netdef.py
@@ -170,21 +170,21 @@ class NetplanAddress:
 class _NetdefAddressIterator:
     def __init__(self, netdef: NetDefinition):
         self.netdef = netdef
-        self.iterator = lib._netplan_new_netdef_address_iter(netdef)
+        self.iterator = lib._netplan_netdef_new_address_iter(netdef)
 
     def __del__(self):
-        lib._netplan_netdef_address_free_iter(self.iterator)
+        lib._netplan_address_iter_free(self.iterator)
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        next_value = lib._netplan_netdef_address_iter_next(self.iterator)
+        next_value = lib._netplan_address_iter_next(self.iterator)
         if not next_value:
             raise StopIteration
         content = next_value
         # XXX: Introduce getters for .address/.lifetime/.label, to avoid
-        #      exposing the 'netdef_address_iter' struct in _netplan_cffi.so
+        #      exposing the 'address_iter' struct in _netplan_cffi.so
         address = ffi.string(content.address).decode('utf-8') if content.address else None
         lifetime = ffi.string(content.lifetime).decode('utf-8') if content.lifetime else None
         label = ffi.string(content.label).decode('utf-8') if content.label else None

--- a/python-cffi/netplan/netdef.py
+++ b/python-cffi/netplan/netdef.py
@@ -48,6 +48,9 @@ class NetDefinition():
     def dhcp6(self) -> bool:
         return bool(lib.netplan_netdef_get_dhcp6(self._ptr))
 
+    def macaddress(self) -> str:
+        return _string_realloc_call_no_error(lambda b: lib.netplan_netdef_get_macaddress(self._ptr, b, len(b)))
+
     @property
     def _has_match(self) -> bool:
         return bool(lib.netplan_netdef_has_match(self._ptr))

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -99,7 +99,7 @@ typedef struct {
     char* label;
 } NetplanAddressOptions;
 
-struct netdef_address_iter {
+struct address_iter {
     guint ip4_index;
     guint ip6_index;
     guint address_options_index;

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -107,6 +107,13 @@ struct address_iter {
     NetplanAddressOptions* last_address;
 };
 
+struct nameserver_iter {
+    guint ip4_index;
+    guint ip6_index;
+    guint search_index;
+    NetplanNetDefinition* netdef;
+};
+
 typedef struct {
     NetplanWifiMode mode;
     char* ssid;

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -132,14 +132,14 @@ is_route_rule_present(const NetplanNetDefinition* netdef, const NetplanIPRule* r
 NETPLAN_INTERNAL gboolean //FIXME: avoid exporting private symbol
 is_string_in_array(GArray* array, const char* value);
 
-NETPLAN_INTERNAL struct netdef_address_iter*
-_netplan_new_netdef_address_iter(NetplanNetDefinition* netdef);
+NETPLAN_INTERNAL struct address_iter*
+_netplan_netdef_new_address_iter(NetplanNetDefinition* netdef);
 
 NETPLAN_INTERNAL NetplanAddressOptions*
-_netplan_netdef_address_iter_next(struct netdef_address_iter* it);
+_netplan_address_iter_next(struct address_iter* it);
 
 NETPLAN_INTERNAL void
-_netplan_netdef_address_free_iter(struct netdef_address_iter* it);
+_netplan_address_iter_free(struct address_iter* it);
 
 NETPLAN_INTERNAL struct netdef_pertype_iter*
 _netplan_state_new_netdef_pertype_iter(NetplanState* np_state, const char* def_type);

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -141,6 +141,24 @@ _netplan_address_iter_next(struct address_iter* it);
 NETPLAN_INTERNAL void
 _netplan_address_iter_free(struct address_iter* it);
 
+NETPLAN_INTERNAL struct nameserver_iter*
+_netplan_netdef_new_nameserver_iter(NetplanNetDefinition* netdef);
+
+NETPLAN_INTERNAL char*
+_netplan_nameserver_iter_next(struct nameserver_iter* it);
+
+NETPLAN_INTERNAL void
+_netplan_nameserver_iter_free(struct nameserver_iter* it);
+
+NETPLAN_INTERNAL struct nameserver_iter*
+_netplan_netdef_new_search_domain_iter(NetplanNetDefinition* netdef);
+
+NETPLAN_INTERNAL char*
+_netplan_search_domain_iter_next(struct nameserver_iter* it);
+
+NETPLAN_INTERNAL void
+_netplan_search_domain_iter_free(struct nameserver_iter* it);
+
 NETPLAN_INTERNAL struct netdef_pertype_iter*
 _netplan_state_new_netdef_pertype_iter(NetplanState* np_state, const char* def_type);
 

--- a/src/util.c
+++ b/src/util.c
@@ -715,10 +715,10 @@ get_unspecified_address(int ip_family)
     return (ip_family == AF_INET) ? "0.0.0.0" : "::";
 }
 
-struct netdef_address_iter*
-_netplan_new_netdef_address_iter(NetplanNetDefinition* netdef)
+struct address_iter*
+_netplan_netdef_new_address_iter(NetplanNetDefinition* netdef)
 {
-    struct netdef_address_iter* it = g_malloc0(sizeof(struct netdef_address_iter));
+    struct address_iter* it = g_malloc0(sizeof(struct address_iter));
     it->ip4_index = 0;
     it->ip6_index = 0;
     it->address_options_index = 0;
@@ -740,7 +740,7 @@ _netplan_new_netdef_address_iter(NetplanNetDefinition* netdef)
  * nothing else to be produced and the iterator was called one last time.
  */
 NetplanAddressOptions*
-_netplan_netdef_address_iter_next(struct netdef_address_iter* it)
+_netplan_address_iter_next(struct address_iter* it)
 {
     NetplanAddressOptions* options = NULL;
 
@@ -777,7 +777,7 @@ _netplan_netdef_address_iter_next(struct netdef_address_iter* it)
 }
 
 void
-_netplan_netdef_address_free_iter(struct netdef_address_iter* it)
+_netplan_address_iter_free(struct address_iter* it)
 {
     if (it->last_address)
         free_address_options(it->last_address);

--- a/src/util.c
+++ b/src/util.c
@@ -784,6 +784,63 @@ _netplan_address_iter_free(struct address_iter* it)
     g_free(it);
 }
 
+struct nameserver_iter*
+_netplan_netdef_new_nameserver_iter(NetplanNetDefinition* netdef)
+{
+    struct nameserver_iter* it = g_malloc0(sizeof(struct nameserver_iter));
+    it->ip4_index = 0;
+    it->ip6_index = 0;
+    it->netdef = netdef;
+
+    return it;
+}
+
+char*
+_netplan_nameserver_iter_next(struct nameserver_iter* it)
+{
+    if (it->netdef->ip4_nameservers && it->ip4_index < it->netdef->ip4_nameservers->len) {
+        return g_array_index(it->netdef->ip4_nameservers, char*, it->ip4_index++);
+    }
+
+    if (it->netdef->ip6_nameservers && it->ip6_index < it->netdef->ip6_nameservers->len) {
+        return g_array_index(it->netdef->ip6_nameservers, char*, it->ip6_index++);
+    }
+
+    return NULL;
+}
+
+void
+_netplan_nameserver_iter_free(struct nameserver_iter* it)
+{
+    g_free(it);
+}
+
+struct nameserver_iter*
+_netplan_netdef_new_search_domain_iter(NetplanNetDefinition* netdef)
+{
+    struct nameserver_iter* it = g_malloc0(sizeof(struct nameserver_iter));
+    it->search_index = 0;
+    it->netdef = netdef;
+
+    return it;
+}
+
+char*
+_netplan_search_domain_iter_next(struct nameserver_iter* it)
+{
+    if (it->netdef->search_domains && it->search_index < it->netdef->search_domains->len) {
+        return g_array_index(it->netdef->search_domains, char*, it->search_index++);
+    }
+
+    return NULL;
+}
+
+void
+_netplan_search_domain_iter_free(struct nameserver_iter* it)
+{
+    g_free(it);
+}
+
 struct netdef_pertype_iter {
     NetplanDefType type;
     GHashTableIter iter;

--- a/src/util.c
+++ b/src/util.c
@@ -940,6 +940,12 @@ netplan_netdef_get_set_name(const NetplanNetDefinition* netdef, char* out_buffer
     return netplan_copy_string(netdef->set_name, out_buffer, out_buf_size);
 }
 
+ssize_t
+netplan_netdef_get_macaddress(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size)
+{
+    return netplan_copy_string(netdef->set_mac, out_buffer, out_buf_size);
+}
+
 gboolean
 netplan_netdef_get_dhcp4(const NetplanNetDefinition* netdef)
 {

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -684,6 +684,21 @@ class TestNetDefinition(TestBase):
         self.assertFalse(state['eth0'].dhcp4)
         self.assertTrue(state['eth0'].dhcp6)
 
+    def test_get_macaddress(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      macaddress: aa:bb:cc:dd:ee:ff
+      ''')
+
+        self.assertEqual(state['eth0'].macaddress, 'aa:bb:cc:dd:ee:ff')
+
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0: {}''')
+
+        self.assertIsNone(state['eth0'].macaddress)
+
 
 class TestFreeFunctions(TestBase):
     def test_create_yaml_patch_dict(self):


### PR DESCRIPTION
## Description

Add a property to retrieve the macaddress field from the netdef.

Refactor the addresses iterator to comply with our naming standards as advised in the PR #386 code review.

Add iterators for DNS nameservers and search domains following the naming standards as mentioned above.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

