### PR TITLE
libnetplan: expose the routes list in the netdef

### DIFF
--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -27,6 +27,7 @@ ffibuilder.cdef("""
     #define UINT_MAX ...
     typedef int gboolean;
     typedef unsigned int guint;
+    typedef int gint;
     typedef struct GError NetplanError;
     typedef struct netplan_parser NetplanParser;
     typedef struct netplan_state NetplanState;
@@ -42,6 +43,23 @@ ffibuilder.cdef("""
     } NetplanAddressOptions;
     struct address_iter { ...; };
     struct nameserver_iter { ...; };
+    struct route_iter { ...; };
+
+    // TODO: Introduce getters for all these fields to avoid exposing the raw struct
+    typedef struct {
+        gint family;
+        char* type;
+        char* scope;
+        guint table;
+        char* from;
+        char* to;
+        char* via;
+        gboolean onlink;
+        guint metric;
+        guint mtubytes;
+        guint congestion_window;
+        guint advertised_receive_window;
+    } NetplanIPRoute;
 
     // Error handling
     uint64_t netplan_error_code(NetplanError* error);
@@ -112,6 +130,9 @@ ffibuilder.cdef("""
     struct nameserver_iter* _netplan_netdef_new_search_domain_iter(NetplanNetDefinition* netdef);
     char* _netplan_search_domain_iter_next(struct nameserver_iter* it);
     void _netplan_search_domain_iter_free(struct nameserver_iter* it);
+    struct route_iter* _netplan_netdef_new_route_iter(NetplanNetDefinition* netdef);
+    NetplanIPRoute* _netplan_route_iter_next(struct route_iter* it);
+    void _netplan_route_iter_free(struct route_iter* it);
 
     // Utils
     gboolean netplan_util_dump_yaml_subtree(const char* prefix, int input_fd, int output_fd, NetplanError** error);

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -114,6 +114,11 @@ struct nameserver_iter {
     NetplanNetDefinition* netdef;
 };
 
+struct route_iter {
+    guint route_index;
+    NetplanNetDefinition* netdef;
+};
+
 typedef struct {
     NetplanWifiMode mode;
     char* ssid;

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -159,6 +159,15 @@ _netplan_search_domain_iter_next(struct nameserver_iter* it);
 NETPLAN_INTERNAL void
 _netplan_search_domain_iter_free(struct nameserver_iter* it);
 
+NETPLAN_INTERNAL struct route_iter*
+_netplan_netdef_new_route_iter(NetplanNetDefinition* netdef);
+
+NETPLAN_INTERNAL NetplanIPRoute*
+_netplan_route_iter_next(struct route_iter* it);
+
+NETPLAN_INTERNAL void
+_netplan_route_iter_free(struct route_iter* it);
+
 NETPLAN_INTERNAL struct netdef_pertype_iter*
 _netplan_state_new_netdef_pertype_iter(NetplanState* np_state, const char* def_type);
 

--- a/src/util.c
+++ b/src/util.c
@@ -841,6 +841,31 @@ _netplan_search_domain_iter_free(struct nameserver_iter* it)
     g_free(it);
 }
 
+struct route_iter*
+_netplan_netdef_new_route_iter(NetplanNetDefinition* netdef)
+{
+    struct route_iter* it = g_malloc0(sizeof(struct route_iter));
+    it->route_index = 0;
+    it->netdef = netdef;
+
+    return it;
+}
+
+NetplanIPRoute*
+_netplan_route_iter_next(struct route_iter* it)
+{
+    if (it->netdef->routes && it->route_index < it->netdef->routes->len)
+        return g_array_index(it->netdef->routes, NetplanIPRoute*, it->route_index++);
+
+    return NULL;
+}
+
+void
+_netplan_route_iter_free(struct route_iter* it)
+{
+    g_free(it);
+}
+
 struct netdef_pertype_iter {
     NetplanDefType type;
     GHashTableIter iter;


### PR DESCRIPTION
## Description

I created the NetplanRoute class as a dataclass but I'm not convinced it's a good idea... I feel like it's better to assign each property separately without an `__init__` method...

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

