### PR TITLE
parse: allow COMMON_LINK_HANDLERS for VRFs (LP: #2031421, Closes: #1049432)

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2864,6 +2864,7 @@ static const mapping_entry_handler vlan_def_handlers[] = {
 };
 
 static const mapping_entry_handler vrf_def_handlers[] = {
+    COMMON_LINK_HANDLERS,
     COMMON_BACKEND_HANDLERS,
     {"renderer", YAML_SCALAR_NODE, {.generic=handle_netdef_renderer}, NULL},
     {"interfaces", YAML_SEQUENCE_NODE, {.generic=handle_vrf_interfaces}, NULL},

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -295,6 +295,7 @@ class _CommonTests():
         table: 1000
   vrfs:
     vrf0:
+      addresses: [10.10.10.20/24]
       table: 1000
       interfaces: [%(ec)s]
       routes:


### PR DESCRIPTION
## Description
This is to fix test failures with latest NetworkManager v1.44, after they slightly changed behavior:
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/dabfa26a41edc7911a45a4689d555e8f055b0373

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [X] \(Optional\) Closes an open bug in Launchpad. LP#2031421

