### PR TITLE
wifi: support WPA2 and WPA3 Personal simultaneously

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1042,7 +1042,13 @@ append_wpa_auth_conf(GString* s, const NetplanAuthenticationSettings* auth, cons
             break;
 
         case NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK:
-            g_string_append(s, "  key_mgmt=WPA-PSK\n");
+            if (auth->pmf_mode == NETPLAN_AUTH_PMF_MODE_OPTIONAL)
+                /* Case where the user only provided the password.
+                 * We enable support for WPA2 and WPA3 personal.
+                 */
+                g_string_append(s, "  key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE\n");
+            else
+                g_string_append(s, "  key_mgmt=WPA-PSK\n");
             break;
 
         case NETPLAN_AUTH_KEY_MANAGEMENT_WPA_EAP:

--- a/src/parse.c
+++ b/src/parse.c
@@ -1039,6 +1039,7 @@ handle_access_point_password(NetplanParser* npp, yaml_node_t* node, __unused con
     /* shortcut for WPA-PSK */
     access_point->has_auth = TRUE;
     access_point->auth.key_management = NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK;
+    access_point->auth.pmf_mode = NETPLAN_AUTH_PMF_MODE_OPTIONAL;
     g_free(access_point->auth.password);
     access_point->auth.password = g_strdup(scalar(node));
     return TRUE;

--- a/tests/generator/test_auth.py
+++ b/tests/generator/test_auth.py
@@ -107,7 +107,8 @@ network={
             self.assertIn('''
 network={
   ssid="BobsHome"
-  key_mgmt=WPA-PSK
+  key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
+  ieee80211w=1
   psk=e03ce667c87bc81ca968d9120ca37f89eb09aec3c55b80386e5d772efd6b926e
 }
 ''', new_config)
@@ -170,7 +171,8 @@ network={
             self.assertIn('''
 network={
   ssid="Joe's Home"
-  key_mgmt=WPA-PSK
+  key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
+  ieee80211w=1
   psk="s0s3kr1t"
 }
 ''', new_config)
@@ -303,6 +305,7 @@ mode=infrastructure
 
 [wifi-security]
 key-mgmt=wpa-psk
+pmf=2
 psk=s0s3kr1t
 ''',
                         'wl0-Luke%27s%20Home': '''[connection]

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -101,14 +101,16 @@ network={
 network={
   ssid="hidden-y"
   scan_ssid=1
-  key_mgmt=WPA-PSK
+  key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
+  ieee80211w=1
   psk="0bscur1ty"
 }
 ''', new_config)
             self.assertIn('''
 network={
   ssid="hidden-n"
-  key_mgmt=WPA-PSK
+  key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
+  ieee80211w=1
   psk="5ecur1ty"
 }
 ''', new_config)
@@ -117,7 +119,8 @@ network={
   ssid="workplace"
   bssid=de:ad:be:ef:ca:fe
   freq_list=5500
-  key_mgmt=WPA-PSK
+  key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
+  ieee80211w=1
   psk="c0mpany1"
 }
 ''', new_config)
@@ -126,7 +129,8 @@ network={
   ssid="Joe's Home"
   bssid=00:11:22:33:44:55
   freq_list=2462
-  key_mgmt=WPA-PSK
+  key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
+  ieee80211w=1
   psk="s0s3kr1t"
 }
 ''', new_config)
@@ -481,6 +485,7 @@ channel=11
 
 [wifi-security]
 key-mgmt=wpa-psk
+pmf=2
 psk=s0s3kr1t
 ''',
                         'wl0-workplace': '''[connection]
@@ -503,6 +508,7 @@ channel=100
 
 [wifi-security]
 key-mgmt=wpa-psk
+pmf=2
 psk=c0mpany1
 ''',
                         'wl0-hidden-y': '''[connection]
@@ -523,6 +529,7 @@ hidden=true
 
 [wifi-security]
 key-mgmt=wpa-psk
+pmf=2
 psk=0bscur1ty
 ''',
                         'wl0-hidden-n': '''[connection]
@@ -542,6 +549,7 @@ mode=infrastructure
 
 [wifi-security]
 key-mgmt=wpa-psk
+pmf=2
 psk=5ecur1ty
 ''',
                         'wl0-channel-no-band': '''[connection]
@@ -660,6 +668,7 @@ mode=ap
 
 [wifi-security]
 key-mgmt=wpa-psk
+pmf=2
 psk=s0s3cret
 '''})
         self.assert_networkd({})
@@ -709,7 +718,8 @@ network={
   ssid="homenet"
   frequency=2442
   mode=1
-  key_mgmt=WPA-PSK
+  key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
+  ieee80211w=1
   psk="********"
 }
 """)
@@ -732,7 +742,8 @@ network={
   ssid="homenet"
   frequency=5035
   mode=1
-  key_mgmt=WPA-PSK
+  key_mgmt=WPA-PSK WPA-PSK-SHA256 SAE
+  ieee80211w=1
   psk="********"
 }
 """)


### PR DESCRIPTION
When using WPA-PSK and defining the password without the "auth" section, enable support for both WPA2 and 3 Personal. This will set the support for Protected Management Frames to optional implicitly.


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

