### PR TITLE
GitHub CI fixes

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -42,7 +42,6 @@ jobs:
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
-          echo "usr/lib/python3/dist-packages/netplan/*" >> debian/netplan.io.install  # bindings
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"
@@ -51,4 +50,8 @@ jobs:
         run: |
           # using --setup-commands temporarily to install:
           # cmocka/pytest/rich/ethtool until they become proper test-deps
-          autopkgtest . --setup-commands='apt -y install ethtool python3-rich python3-pytest python3-pytest-cov python3-cffi libpython3-dev libcmocka-dev' -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/jammy/amd64
+          # The network-manager PPA is used here temporally due to a bug with veths and network-manager 1.36. See LP: #2032824
+          autopkgtest . \
+            --setup-commands='apt -y install ethtool python3-rich python3-pytest python3-pytest-cov python3-cffi libpython3-dev libcmocka-dev' \
+            --setup-commands='sudo add-apt-repository -y -u -s ppa:danilogondolfo/network-manager' \
+            -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/jammy/amd64

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -30,6 +30,7 @@ jobs:
           tar czf netplan.tar.gz cov-int
       - name: Upload results
         run: |
+          git fetch --unshallow --tags
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"

--- a/.github/workflows/debci.yml
+++ b/.github/workflows/debci.yml
@@ -46,9 +46,6 @@ jobs:
           dget -u "https://deb.debian.org/debian/pool/main/n/netplan.io/netplan.io_$V.dsc"
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
-          echo "usr/lib/python3/dist-packages/netplan/*" >> debian/netplan.io.install  # bindings
-          echo "override_dh_auto_configure:" >> debian/rules
-          echo "	dh_auto_configure -- -Dpython.purelibdir=/usr/lib/python3/dist-packages -Dpython.platlibdir=/usr/lib/python3/dist-packages" >> debian/rules
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"

--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -38,9 +38,6 @@ jobs:
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
           echo "3.0 (native)" > debian/source/format  # force native build
-          echo "usr/lib/python3/dist-packages/netplan/*" >> debian/netplan.io.install  # bindings
-          echo "override_dh_auto_configure:" >> debian/rules
-          echo "	dh_auto_configure -- -Dpython.purelibdir=/usr/lib/python3/dist-packages -Dpython.platlibdir=/usr/lib/python3/dist-packages" >> debian/rules
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"


### PR DESCRIPTION
## Description

Changes:

- Coverity: fetch tags before trying to use them
- Autopkgtests: use my network-manager PPA temporally with the fix for veths
- Autopkgtest/debci/network-manager ci: fix the workflows after the python3-netplan split

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

