### PR TITLE
util: don't return a placeholder netdef in the iterator

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -895,6 +895,8 @@ _netplan_netdef_pertype_iter_next(struct netdef_pertype_iter* it)
 
     while (g_hash_table_iter_next(&it->iter, &key, &value)) {
         NetplanNetDefinition* netdef = value;
+        if (netdef->type == NETPLAN_DEF_TYPE_NM_PLACEHOLDER_)
+            continue;
         if (it->type == NETPLAN_DEF_TYPE_NONE || netdef->type == it->type)
             return netdef;
     }

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -189,6 +189,25 @@ class TestNetdefIterator(TestBase):
       dhcp4: false''')
         self.assertSetEqual(set(["eth0", "br0"]), set(d.id for d in netplan.netdef.NetDefinitionIterator(state, None)))
 
+    def test_iter_all_types_with_placeholder(self):
+        state = state_from_yaml(self.confdir, '''network:
+  renderer: NetworkManager
+  ethernets:
+    eth0:
+      dhcp4: false
+  virtual-ethernets:
+    # Netplan will create a placeholder netdef for veth321
+    veth123:
+      peer: veth321
+  bridges:
+    br0:
+      dhcp4: false''')
+
+        # We call the property "type" here so it will try to translate the netdef type to a string
+        # and crash if it's a placeholder
+        expected = {"ethernets", "virtual-ethernets", "bridges"}
+        self.assertSetEqual(expected, set(d.type for d in netplan.netdef.NetDefinitionIterator(state, None)))
+
     def test_iter_ethernets(self):
         state = state_from_yaml(self.confdir, '''network:
   ethernets:


### PR DESCRIPTION
## Description

Tripped on this while working on netplan diff. We probably want to patch the netplan package as well.

```
Traceback (most recent call last):
  File "/root/netplan/tools/diff.py", line 117, in <module>
    diff = diff_state.get_diff()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/netplan/netplan_cli/cli/state_diff.py", line 149, in get_diff
    full_state = self.get_full_state()
                 ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/netplan/netplan_cli/cli/state_diff.py", line 103, in get_full_state
    device_type = DEVICE_TYPES.get(config.type, 'unknown')
                                   ^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/netplan/netdef.py", line 118, in type
    return ffi.string(lib.netplan_def_type_name(lib.netplan_netdef_get_type(self._ptr))).decode('utf-8')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: cannot use string() on <cdata 'char *' NULL>
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

