### PR TITLE
tunnels/validation: do not error out if "local" is not defined

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -141,7 +141,8 @@ write_tunnel_params(GString* s, const NetplanNetDefinition* def)
     g_string_printf(params, "Independent=true\n");
     if (def->tunnel.mode == NETPLAN_TUNNEL_MODE_IPIP6 || def->tunnel.mode == NETPLAN_TUNNEL_MODE_IP6IP6)
         g_string_append_printf(params, "Mode=%s\n", netplan_tunnel_mode_name(def->tunnel.mode));
-    g_string_append_printf(params, "Local=%s\n", def->tunnel.local_ip);
+    if (def->tunnel.local_ip)
+        g_string_append_printf(params, "Local=%s\n", def->tunnel.local_ip);
     g_string_append_printf(params, "Remote=%s\n", def->tunnel.remote_ip);
     if (def->tunnel_ttl)
         g_string_append_printf(params, "TTL=%u\n", def->tunnel_ttl);

--- a/src/nm.c
+++ b/src/nm.c
@@ -393,7 +393,8 @@ static void
 write_tunnel_params(const NetplanNetDefinition* def, GKeyFile *kf)
 {
     g_key_file_set_integer(kf, "ip-tunnel", "mode", def->tunnel.mode);
-    g_key_file_set_string(kf, "ip-tunnel", "local", def->tunnel.local_ip);
+    if (def->tunnel.local_ip)
+        g_key_file_set_string(kf, "ip-tunnel", "local", def->tunnel.local_ip);
     g_key_file_set_string(kf, "ip-tunnel", "remote", def->tunnel.remote_ip);
     if (def->tunnel_ttl)
         g_key_file_set_uint64(kf, "ip-tunnel", "ttl", def->tunnel_ttl);

--- a/src/validation.c
+++ b/src/validation.c
@@ -241,8 +241,6 @@ validate_tunnel_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
 
     /* Validate local/remote IPs */
     if (nd->tunnel.mode != NETPLAN_TUNNEL_MODE_VXLAN) {
-        if (!nd->tunnel.local_ip)
-            return yaml_error(npp, node, error, "%s: missing 'local' property for tunnel", nd->id);
         if (!nd->tunnel.remote_ip)
             return yaml_error(npp, node, error, "%s: missing 'remote' property for tunnel", nd->id);
     }
@@ -255,7 +253,7 @@ validate_tunnel_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
         case NETPLAN_TUNNEL_MODE_IP6GRE:
         case NETPLAN_TUNNEL_MODE_IP6GRETAP:
         case NETPLAN_TUNNEL_MODE_VTI6:
-            if (!is_ip6_address(nd->tunnel.local_ip))
+            if (nd->tunnel.local_ip && !is_ip6_address(nd->tunnel.local_ip))
                 return yaml_error(npp, node, error, "%s: 'local' must be a valid IPv6 address for this tunnel type", nd->id);
             if (!is_ip6_address(nd->tunnel.remote_ip))
                 return yaml_error(npp, node, error, "%s: 'remote' must be a valid IPv6 address for this tunnel type", nd->id);
@@ -268,7 +266,7 @@ validate_tunnel_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
             break;
 
         default:
-            if (!is_ip4_address(nd->tunnel.local_ip))
+            if (nd->tunnel.local_ip && !is_ip4_address(nd->tunnel.local_ip))
                 return yaml_error(npp, node, error, "%s: 'local' must be a valid IPv4 address for this tunnel type", nd->id);
             if (!is_ip4_address(nd->tunnel.remote_ip))
                 return yaml_error(npp, node, error, "%s: 'remote' must be a valid IPv4 address for this tunnel type", nd->id);

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -1643,18 +1643,6 @@ class TestConfigErrors(TestBase):
         out = self.generate(config, expect_fail=True)
         self.assertIn("Error in network definition: address '10.10.10.10/21' should not include /prefixlength", out)
 
-    def test_missing_local_ip(self):
-        """Fail if local IP is missing"""
-        config = '''network:
-  version: 2
-  tunnels:
-    tun0:
-      mode: gre
-      remote: 20.20.20.20
-'''
-        out = self.generate(config, expect_fail=True)
-        self.assertIn("Error in network definition: tun0: missing 'local' property for tunnel", out)
-
     def test_missing_remote_ip(self):
         """Fail if remote IP is missing"""
         config = '''network:

--- a/tests/integration/tunnels.py
+++ b/tests/integration/tunnels.py
@@ -45,6 +45,20 @@ class _CommonTests():
         self.generate_and_settle(['sit-tun0'])
         self.assert_iface('sit-tun0', ['sit-tun0@NONE', 'link.* 192.168.5.1 peer 99.99.99.99'])
 
+    def test_tunnel_sit_without_local_address(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'sit-tun0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  tunnels:
+    sit-tun0:
+      mode: sit
+      remote: 99.99.99.99
+''' % {'r': self.backend})
+        self.generate_and_settle(['sit-tun0'])
+        self.assert_iface('sit-tun0', ['sit-tun0@NONE', 'link.* 0.0.0.0 peer 99.99.99.99'])
+
     def test_tunnel_ipip(self):
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'tun0'], stderr=subprocess.DEVNULL)
         with open(self.config, 'w') as f:
@@ -60,6 +74,21 @@ class _CommonTests():
 ''' % {'r': self.backend})
         self.generate_and_settle(['tun0'])
         self.assert_iface('tun0', ['tun0@NONE', 'link.* 192.168.5.1 peer 99.99.99.99'])
+
+    def test_tunnel_ipip_without_local_address(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'tun0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  tunnels:
+    tun0:
+      mode: ipip
+      remote: 99.99.99.99
+      ttl: 64
+''' % {'r': self.backend})
+        self.generate_and_settle(['tun0'])
+        self.assert_iface('tun0', ['tun0@NONE', 'link.* 0.0.0.0 peer 99.99.99.99'])
 
     def test_tunnel_wireguard(self):
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'wg0'], stderr=subprocess.DEVNULL)
@@ -141,6 +170,20 @@ class _CommonTests():
 ''' % {'r': self.backend})
         self.generate_and_settle(['tun0'])
         self.assert_iface('tun0', ['tun0@NONE', 'link.* 192.168.5.1 peer 99.99.99.99'])
+
+    def test_tunnel_gre_without_local_address(self):
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'tun0'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  version: 2
+  tunnels:
+    tun0:
+      mode: gre
+      remote: 99.99.99.99
+''' % {'r': self.backend})
+        self.generate_and_settle(['tun0'])
+        self.assert_iface('tun0', ['tun0@NONE', 'link.* 0.0.0.0 peer 99.99.99.99'])
 
     def test_tunnel_gre6(self):
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'tun0'], stderr=subprocess.DEVNULL)


### PR DESCRIPTION
The "local" IP property is not required by backends so we shouldn't error out if it's not defined.

Tracking LP bug https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2034067

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

