### PR TITLE
apply: bring "lo" back up if it's managed by NM (LP# 2034595)

### DIFF
--- a/netplan_cli/cli/utils.py
+++ b/netplan_cli/cli/utils.py
@@ -78,6 +78,20 @@ def nm_interfaces(paths, devices):
     return interfaces
 
 
+def nm_get_connection_for_interface(interface: str) -> str:
+    output = nmcli_out(['-m', 'tabular', '-f', 'GENERAL.CONNECTION', 'device', 'show', interface])
+    lines = output.strip().split('\n')
+    connection = lines[1]
+    return connection if connection != '--' else ''
+
+
+def nm_bring_interface_up(connection: str) -> None:  # pragma: nocover (must be covered by NM autopkgtests)
+    try:
+        nmcli(['connection', 'up', connection])
+    except subprocess.CalledProcessError:
+        pass
+
+
 def systemctl_network_manager(action, sync=False):
     # If the network-manager snap is installed use its service
     # name rather than the one of the deb packaged NetworkManager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -371,3 +371,15 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(self.mock_cmd.calls(), [
             ['ip', 'addr', 'flush', 'eth42']
         ])
+
+    @patch('netplan_cli.cli.utils.nmcli_out')
+    def test_nm_get_connection_for_interface(self, nmcli):
+        nmcli.return_value = 'CONNECTION \nlo         \n'
+        out = utils.nm_get_connection_for_interface('lo')
+        self.assertEqual(out, 'lo')
+
+    @patch('netplan_cli.cli.utils.nmcli_out')
+    def test_nm_get_connection_for_interface_no_connection(self, nmcli):
+        nmcli.return_value = 'CONNECTION \n--         \n'
+        out = utils.nm_get_connection_for_interface('asd0')
+        self.assertEqual(out, '')


### PR DESCRIPTION
NM is not bringing it back automatically after we flush its addresses. It's not clear if it's a bug or intended behavior.

It's bad because we have services listening on the loopback interface, such as resolved.

How to reproduce:

1. Install network-manager in Mantic and let it manage at least one of your interfaces
2. You'll see it's managing 'lo' automatically
3. Try to change the 'lo' connection, something like `nmcli con mod lo mtu 1500`
4. NM will emit a YAML (an nm-device) for 'lo'
5. Run `netplan apply`
6. You'll see that the 'lo' connection is down and the 'lo' interface has no IPs

As an alternative (was my original patch) we could just stop flushing 'lo', but that might be what the user want to do, because they can add extra addresses to it for example.

This might actually be a bug in NM and if it's fixed in the future we could drop this change.

## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

