### PR TITLE
Add additional bridge port settings

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -591,17 +591,18 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
   > Takes a boolean. Configures whether ARP and ND neighbour suppression is
   > enabled for this bridge port. When unset, the kernel's default will be used.
 
-- **hairpin** (scalar) – since **0.108**
+- **`hairpin`** (scalar) – since **1.0**
 
   > Takes a boolean. Configures whether traffic may be sent back out of the
   > bridge port on which it was received. When this flag is false, then the
   > bridge will not forward traffic back out of the receiving port. When
-  > unset, the kernel's default will be used.
+  > unset, the backend's default will be used.
 
-- **learning** (scalar) – since **0.108**
+- **`port-mac-learning`** (scalar) – since **1.0**
 
   > Takes a boolean. Configures whether MAC address learning is enabled for
   > this bridge port. When unset, the kernel's default will be used.
+  > Currently supported on the `networkd` backend only.
 
 ## DHCP Overrides
 Several DHCP behaviour overrides are available. Most currently only have any

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -589,19 +589,19 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
 - **`neigh-suppress`** (scalar) – since 0.105
 
   > Takes a boolean. Configures whether ARP and ND neighbour suppression is
-  > enabled for this port. When unset, the kernel's default will be used.
+  > enabled for this bridge port. When unset, the kernel's default will be used.
 
-- **hairpin** (scalar) – since **???**
+- **hairpin** (scalar) – since **0.108**
 
   > Takes a boolean. Configures whether traffic may be sent back out of the
-  > port on which it was received. When this flag is false, then the bridge
-  > will not forward traffic back out of the receiving port. When unset,
-  > the kernel's default will be used.
+  > bridge port on which it was received. When this flag is false, then the
+  > bridge will not forward traffic back out of the receiving port. When
+  > unset, the kernel's default will be used.
 
-- **learning** (scalar) – since **???**
+- **learning** (scalar) – since **0.108**
 
   > Takes a boolean. Configures whether MAC address learning is enabled for
-  > this port. When unset, the kernel's default will be used.
+  > this bridge port. When unset, the kernel's default will be used.
 
 ## DHCP Overrides
 Several DHCP behaviour overrides are available. Most currently only have any

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -591,6 +591,18 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
   > Takes a boolean. Configures whether ARP and ND neighbour suppression is
   > enabled for this port. When unset, the kernel's default will be used.
 
+- **hairpin** (scalar) – since **???**
+
+  > Takes a boolean. Configures whether traffic may be sent back out of the
+  > port on which it was received. When this flag is false, then the bridge
+  > will not forward traffic back out of the receiving port. When unset,
+  > the kernel's default will be used.
+
+- **learning** (scalar) – since **???**
+
+  > Takes a boolean. Configures whether MAC address learning is enabled for
+  > this port. When unset, the kernel's default will be used.
+
 ## DHCP Overrides
 Several DHCP behaviour overrides are available. Most currently only have any
 effect when using the networkd back end, with the exception of `use-routes`

--- a/src/abi.h
+++ b/src/abi.h
@@ -392,6 +392,8 @@ struct netplan_net_definition {
     NetplanNetDefinition* vrf_link;
     guint vrf_table;
 
+    NetplanTristate bridge_hairpin;
+    NetplanTristate bridge_learning;
     NetplanTristate bridge_neigh_suppress;
 
     /* vxlan */

--- a/src/abi.h
+++ b/src/abi.h
@@ -392,8 +392,6 @@ struct netplan_net_definition {
     NetplanNetDefinition* vrf_link;
     guint vrf_table;
 
-    NetplanTristate bridge_hairpin;
-    NetplanTristate bridge_learning;
     NetplanTristate bridge_neigh_suppress;
 
     /* vxlan */
@@ -413,4 +411,7 @@ struct netplan_net_definition {
     /* virtual-ethernet */
     /* netplan-feature: virtual-ethernet */
     NetplanNetDefinition* veth_peer_link;
+
+    NetplanTristate bridge_hairpin;
+    NetplanTristate bridge_learning;
 };

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -825,7 +825,7 @@ _serialize_yaml(
 
     write_routes(event, emitter, def);
     YAML_BOOL_TRISTATE(def, event, emitter, "hairpin", def->bridge_hairpin);
-    YAML_BOOL_TRISTATE(def, event, emitter, "learning", def->bridge_learning);
+    YAML_BOOL_TRISTATE(def, event, emitter, "port-mac-learning", def->bridge_learning);
     YAML_BOOL_TRISTATE(def, event, emitter, "neigh-suppress", def->bridge_neigh_suppress);
 
     /* VLAN settings */

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -824,6 +824,8 @@ _serialize_yaml(
     }
 
     write_routes(event, emitter, def);
+    YAML_BOOL_TRISTATE(def, event, emitter, "hairpin", def->bridge_hairpin);
+    YAML_BOOL_TRISTATE(def, event, emitter, "learning", def->bridge_learning);
     YAML_BOOL_TRISTATE(def, event, emitter, "neigh-suppress", def->bridge_neigh_suppress);
 
     /* VLAN settings */

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -851,15 +851,20 @@ _netplan_netdef_write_network_file(
 
         if (   def->bridge_params.path_cost
             || def->bridge_params.port_priority
+            || def->bridge_hairpin != NETPLAN_TRISTATE_UNSET
+            || def->bridge_learning != NETPLAN_TRISTATE_UNSET
             || def->bridge_neigh_suppress != NETPLAN_TRISTATE_UNSET)
             g_string_append_printf(network, "\n[Bridge]\n");
         if (def->bridge_params.path_cost)
             g_string_append_printf(network, "Cost=%u\n", def->bridge_params.path_cost);
         if (def->bridge_params.port_priority)
             g_string_append_printf(network, "Priority=%u\n", def->bridge_params.port_priority);
-        if (def->bridge_neigh_suppress != NETPLAN_TRISTATE_UNSET) {
+        if (def->bridge_hairpin != NETPLAN_TRISTATE_UNSET)
+            g_string_append_printf(network, "HairPin=%s\n", def->bridge_hairpin ? "true" : "false");
+        if (def->bridge_learning != NETPLAN_TRISTATE_UNSET)
+            g_string_append_printf(network, "Learning=%s\n", def->bridge_learning ? "true" : "false");
+        if (def->bridge_neigh_suppress != NETPLAN_TRISTATE_UNSET)
             g_string_append_printf(network, "NeighborSuppression=%s\n", def->bridge_neigh_suppress ? "true" : "false");
-    }
 
     }
     if (def->bond && def->backend != NETPLAN_BACKEND_OVS) {

--- a/src/nm.c
+++ b/src/nm.c
@@ -758,6 +758,8 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
             g_key_file_set_uint64(kf, "bridge-port", "path-cost", def->bridge_params.path_cost);
         if (def->bridge_params.port_priority)
             g_key_file_set_uint64(kf, "bridge-port", "priority", def->bridge_params.port_priority);
+        if (def->bridge_hairpin != NETPLAN_TRISTATE_UNSET)
+            g_key_file_set_boolean(kf, "bridge-port", "hairpin-mode", def->bridge_hairpin);
     }
     if (def->bond) {
         g_key_file_set_string(kf, "connection", "slave-type", "bond"); /* wokeignore:rule=slave */

--- a/src/parse.c
+++ b/src/parse.c
@@ -2840,6 +2840,8 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"renderer", YAML_SCALAR_NODE, {.generic=handle_netdef_renderer}, NULL}, \
     {"routes", YAML_SEQUENCE_NODE, {.generic=handle_routes}, NULL}, \
     {"routing-policy", YAML_SEQUENCE_NODE, {.generic=handle_ip_rules}, NULL}, \
+    {"hairpin", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(bridge_hairpin)}, \
+    {"learning", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(bridge_learning)}, \
     {"neigh-suppress", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(bridge_neigh_suppress)}
 
 #define COMMON_BACKEND_HANDLERS \

--- a/src/parse.c
+++ b/src/parse.c
@@ -2841,7 +2841,7 @@ static const mapping_entry_handler dhcp6_overrides_handlers[] = {
     {"routes", YAML_SEQUENCE_NODE, {.generic=handle_routes}, NULL}, \
     {"routing-policy", YAML_SEQUENCE_NODE, {.generic=handle_ip_rules}, NULL}, \
     {"hairpin", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(bridge_hairpin)}, \
-    {"learning", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(bridge_learning)}, \
+    {"port-mac-learning", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(bridge_learning)}, \
     {"neigh-suppress", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(bridge_neigh_suppress)}
 
 #define COMMON_BACKEND_HANDLERS \

--- a/src/types.c
+++ b/src/types.c
@@ -323,6 +323,8 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     FREE_AND_NULLIFY(netdef->modem_params.username);
     memset(&netdef->modem_params, 0, sizeof(netdef->modem_params));
 
+    netdef->bridge_hairpin = NETPLAN_TRISTATE_UNSET;
+    netdef->bridge_learning = NETPLAN_TRISTATE_UNSET;
     netdef->bridge_neigh_suppress = NETPLAN_TRISTATE_UNSET;
     FREE_AND_NULLIFY(netdef->bridge_params.ageing_time);
     FREE_AND_NULLIFY(netdef->bridge_params.forward_delay);

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -594,6 +594,8 @@ allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24;''')})
       extensions: [group-policy, generic-protocol]
       port-range: [42, 442]
       neigh-suppress: false
+      hairpin: false
+      learning: false
   bridges:
     br0:
       interfaces: [vxlan1005]''' % {'r': self.backend})
@@ -631,6 +633,8 @@ ConfigureWithoutCarrier=yes
 Bridge=br0
 
 [Bridge]
+HairPin=false
+Learning=false
 NeighborSuppression=false\n''',
                                   'br0.network': '''[Match]
 Name=br0
@@ -651,6 +655,9 @@ type=vxlan
 interface-name=vxlan1005
 slave-type=bridge # wokeignore:rule=slave
 master=br0 # wokeignore:rule=master
+
+[bridge-port]
+hairpin-mode=false
 
 [vxlan]
 ageing=42

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -595,7 +595,7 @@ allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24;''')})
       port-range: [42, 442]
       neigh-suppress: false
       hairpin: false
-      learning: false
+      port-mac-learning: false
   bridges:
     br0:
       interfaces: [vxlan1005]''' % {'r': self.backend})

--- a/tests/integration/bridges.py
+++ b/tests/integration/bridges.py
@@ -348,10 +348,10 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
   ethernets:
     ethbr0:
       match: {name: %(ec)s}
-      learning: true
+      port-mac-learning: true
     ethbr1:
       match: {name: %(e2c)s}
-      learning: false
+      port-mac-learning: false
   bridges:
     mybr:
       interfaces: [ethbr0, ethbr1]

--- a/tests/integration/bridges.py
+++ b/tests/integration/bridges.py
@@ -247,6 +247,36 @@ class _CommonTests():
         with open('/sys/class/net/mybr/brif/%s/priority' % self.dev_e2_client) as f:
             self.assertEqual(f.read().strip(), '42')
 
+    def test_bridge_port_hairpin(self):
+        self.setup_eth(None)
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'mybr'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    ethbr0:
+      match: {name: %(ec)s}
+      hairpin: true
+    ethbr1:
+      match: {name: %(e2c)s}
+      hairpin: false
+  bridges:
+    mybr:
+      interfaces: [ethbr0, ethbr1]
+      dhcp4: false''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client])
+        self.assert_iface_up(self.dev_e_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
+        lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
+                                        text=True).splitlines()
+        self.assertEqual(len(lines), 2, lines)
+        self.assertIn(self.dev_e_client, lines[0])
+        self.assertIn(self.dev_e2_client, lines[1])
+        with open('/sys/devices/virtual/net/mybr/lower_%s/brport/hairpin_mode' % self.dev_e_client) as f:
+            self.assertEqual(f.read().strip(), '1')
+        with open('/sys/devices/virtual/net/mybr/lower_%s/brport/hairpin_mode' % self.dev_e2_client) as f:
+            self.assertEqual(f.read().strip(), '0')
+
 
 @unittest.skipIf("networkd" not in test_backends,
                  "skipping as networkd backend tests are disabled")
@@ -308,6 +338,36 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       addresses: [10.10.10.10/24]''' % {'r': self.backend})
         self.generate_and_settle(['mybr'])
         self.assert_iface('mybr', ['inet 10.10.10.10/24'])
+
+    def test_bridge_port_learning(self):
+        self.setup_eth(None)
+        self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'mybr'], stderr=subprocess.DEVNULL)
+        with open(self.config, 'w') as f:
+            f.write('''network:
+  renderer: %(r)s
+  ethernets:
+    ethbr0:
+      match: {name: %(ec)s}
+      learning: true
+    ethbr1:
+      match: {name: %(e2c)s}
+      learning: false
+  bridges:
+    mybr:
+      interfaces: [ethbr0, ethbr1]
+      dhcp4: false''' % {'r': self.backend, 'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+        self.generate_and_settle([self.dev_e_client, self.dev_e2_client])
+        self.assert_iface_up(self.dev_e_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
+        self.assert_iface_up(self.dev_e2_client, ['master mybr'], ['inet '])  # wokeignore:rule=master
+        lines = subprocess.check_output(['bridge', 'link', 'show', 'mybr'],
+                                        text=True).splitlines()
+        self.assertEqual(len(lines), 2, lines)
+        self.assertIn(self.dev_e_client, lines[0])
+        self.assertIn(self.dev_e2_client, lines[1])
+        with open('/sys/devices/virtual/net/mybr/lower_%s/brport/learning' % self.dev_e_client) as f:
+            self.assertEqual(f.read().strip(), '1')
+        with open('/sys/devices/virtual/net/mybr/lower_%s/brport/learning' % self.dev_e2_client) as f:
+            self.assertEqual(f.read().strip(), '0')
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,


### PR DESCRIPTION
## Description
This MR adds additional bridge settings `hairpin` and `port-mac-learning` on bridge ports. They are useful when using VXLAN tunnels with e.g. FRR.

This is my first MR to netplan, I tried my best to run the tests locally first.

## Checklist

- [x] Runs `make check` successfully. (except some nmcli local tests)
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented. (but with version ???)
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

