### PR TITLE
added mii-monitor-interval

### DIFF
--- a/examples/bonding.yaml
+++ b/examples/bonding.yaml
@@ -13,3 +13,4 @@ network:
       parameters:
         mode: active-backup
         primary: enp3s0
+        mii-monitor-interval: 1


### PR DESCRIPTION
…needed


## Description
I added mii-monitor-interval to the example so the active-backup connection would failover. The default value is 0 and doesn't monitor the carrier connection. 

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

