### PR TITLE
Ignore bad NetDefs and files via parser flags

### DIFF
--- a/doc/explanation.md
+++ b/doc/explanation.md
@@ -6,6 +6,12 @@
 structure-id
 ```
 
+## Netplan Generator
+
+```{toctree}
+generator
+```
+
 ## NetworkManager
 
 ```{toctree}

--- a/doc/generator.md
+++ b/doc/generator.md
@@ -1,0 +1,19 @@
+---
+title: "Netplan Generator"
+---
+
+Netplan uses a [systemd-generator](https://www.freedesktop.org/software/systemd/man/latest/systemd.generator.html)
+to emit network configuration at boot time. This generator is called very early during the boot
+process to ensure that all the configuration needed will be available for the back end
+the user chose to use.
+
+The generator executes the same tool used by the command `netplan generate`. One of the
+differences is that, when called as a systemd generator, parsing errors will be ignored by default.
+That means that errors in the configuration will not prevent Netplan to emit network configuration.
+When executed via the CLI, via `netplan generate` or `netplan apply` for example, errors will not
+be ignored and the user is encouraged to fix them, otherwise the commands will fail.
+
+When an error is ignored, Netplan might end up with network definitions that are not
+fully valid and incomplete. Users are advised to fix any issues present in their
+configuration to avoid having network connectivity problems.
+

--- a/doc/netplan-generate.md
+++ b/doc/netplan-generate.md
@@ -30,6 +30,11 @@ Only if executed during the systemd `initializing` phase
 it attempt to start/apply the newly created service units.
 **Requires feature: `generate-just-in-time*`*
 
+When called as a systemd.generator(7), all the parsing and validation errors
+will be ignored by default. If network definitions are skipped due to
+parsing errors, they might be incomplete. That means that the
+back end configuration emitted might not be fully valid.
+
 For details of the configuration file format, see **`netplan`**(5).
 
 ## OPTIONS

--- a/include/parse.h
+++ b/include/parse.h
@@ -54,6 +54,26 @@ NETPLAN_PUBLIC void
 netplan_parser_clear(NetplanParser **npp);
 
 /**
+ * @brief   Set @ref NetplanParser flags.
+ * @details Parser flags are used to change the default behavior of the parser.
+ * @param[in] npp       The @ref NetplanParser to set the flags.
+ * @param[in] flags     The value of the flags. The possible values are defined in @ref NETPLAN_PARSER_FLAGS
+ * @param[out] error    Filled with a @ref NetplanError in case of failure
+ * @return              Indication of success or failure
+ */
+NETPLAN_PUBLIC gboolean
+netplan_parser_set_flags(NetplanParser* npp, unsigned int flags, NetplanError** error);
+
+/**
+ * @brief   Get @ref NetplanParser flags.
+ * @details Parser flags are used to change the default behavior of the parser.
+ * @param[in] npp   The @ref NetplanParser to get the flags from.
+ * @return          The current flags set in the parser.
+ */
+NETPLAN_PUBLIC unsigned int
+netplan_parser_get_flags(const NetplanParser* npp);
+
+/**
  * @brief Parse a given YAML file and create or update the list of @ref NetplanNetDefinition inside @p npp.
  * @param[in]  npp      The @ref NetplanParser object that should contain the parsed data
  * @param[in]  filename Full path to a Netplan YAML configuration file

--- a/include/parse.h
+++ b/include/parse.h
@@ -74,6 +74,15 @@ NETPLAN_PUBLIC unsigned int
 netplan_parser_get_flags(const NetplanParser* npp);
 
 /**
+ * @brief   Get @ref NetplanParser error count.
+ * @details The number of errors that were ignored when the IGNORE_ERRORS is used.
+ * @param[in] npp   The @ref NetplanParser to get the error count from.
+ * @return          The current error count.
+ */
+NETPLAN_PUBLIC unsigned int
+netplan_parser_get_error_count(const NetplanParser* npp);
+
+/**
  * @brief Parse a given YAML file and create or update the list of @ref NetplanNetDefinition inside @p npp.
  * @param[in]  npp      The @ref NetplanParser object that should contain the parsed data
  * @param[in]  filename Full path to a Netplan YAML configuration file

--- a/include/types.h
+++ b/include/types.h
@@ -132,7 +132,8 @@ enum NETPLAN_ERROR_DOMAINS {
  */
 enum NETPLAN_PARSER_ERRORS {
     NETPLAN_ERROR_INVALID_YAML,
-    NETPLAN_ERROR_INVALID_CONFIG
+    NETPLAN_ERROR_INVALID_CONFIG,
+    NETPLAN_ERROR_INVALID_FLAG,
 };
 
 /**
@@ -163,4 +164,12 @@ enum NETPLAN_EMITTER_ERRORS {
  */
 enum NETPLAN_FORMAT_ERRORS {
     NETPLAN_ERROR_FORMAT_INVALID_YAML,
+};
+
+/**
+ * @brief   Flags used to change the parser behavior.
+ */
+enum NETPLAN_PARSER_FLAGS {
+    NETPLAN_PARSER_IGNORE_ERRORS = 1 << 0, ///< Ignore parsing errors such as bad YAML files and definitions.
+    NETPLAN_PARSER_FLAGS_MAX_,
 };

--- a/python-cffi/netplan/__init__.py
+++ b/python-cffi/netplan/__init__.py
@@ -26,7 +26,7 @@ from ._utils import _checked_lib_call
 from ._utils import (NetplanException, NetplanBackendException,
                      NetplanEmitterException, NetplanFileException,
                      NetplanFormatException, NetplanParserException,
-                     NetplanValidationException)
+                     NetplanValidationException, NetplanParserFlagsException)
 
 
 def _dump_yaml_subtree(prefix: List[str], input_file: IO, output_file: IO):
@@ -70,4 +70,4 @@ __all__ = ['Parser', 'State', 'NetDefinition', 'NetDefinitionIterator',
            '_dump_yaml_subtree', '_create_yaml_patch',
            'NetplanException', 'NetplanBackendException', 'NetplanEmitterException',
            'NetplanFileException', 'NetplanFormatException', 'NetplanParserException',
-           'NetplanValidationException']
+           'NetplanValidationException', 'NetplanParserFlagsException']

--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -68,6 +68,9 @@ ffibuilder.cdef("""
     // Parser
     NetplanParser* netplan_parser_new();
     void netplan_parser_clear(NetplanParser **npp);
+    gboolean netplan_parser_set_flags(NetplanParser *npp, unsigned int flags, NetplanError** error);
+    unsigned int netplan_parser_get_flags(NetplanParser *npp);
+    unsigned int netplan_parser_get_error_count(NetplanParser *npp);
     gboolean netplan_parser_load_yaml(NetplanParser* npp, const char* filename, NetplanError** error);
     gboolean netplan_parser_load_yaml_from_fd(NetplanParser* npp, int input_fd, NetplanError** error);
     gboolean netplan_parser_load_yaml_hierarchy(NetplanParser* npp, const char* rootdir, NetplanError** error);

--- a/python-cffi/netplan/_utils.py
+++ b/python-cffi/netplan/_utils.py
@@ -36,6 +36,7 @@ class NETPLAN_ERROR_DOMAINS(IntEnum):
 class NETPLAN_PARSER_ERRORS(IntEnum):
     NETPLAN_ERROR_INVALID_YAML = 0
     NETPLAN_ERROR_INVALID_CONFIG = 1
+    NETPLAN_ERROR_INVALID_FLAG = 2
 
 
 class NETPLAN_VALIDATION_ERRORS(IntEnum):
@@ -134,6 +135,10 @@ class NetplanParserException(NetplanException):
         self.message = schema_error["message"]
 
 
+class NetplanParserFlagsException(NetplanException):
+    pass
+
+
 class NetplanBackendException(NetplanException):
     pass
 
@@ -155,6 +160,7 @@ NETPLAN_EXCEPTIONS = defaultdict(lambda: NETPLAN_EXCEPTIONS_FALLBACK, {
         NETPLAN_ERROR_DOMAINS.NETPLAN_PARSER_ERROR: {
             NETPLAN_PARSER_ERRORS.NETPLAN_ERROR_INVALID_YAML: NetplanParserException,
             NETPLAN_PARSER_ERRORS.NETPLAN_ERROR_INVALID_CONFIG: NetplanParserException,
+            NETPLAN_PARSER_ERRORS.NETPLAN_ERROR_INVALID_FLAG: NetplanParserFlagsException,
             },
 
         NETPLAN_ERROR_DOMAINS.NETPLAN_VALIDATION_ERROR: {

--- a/python-cffi/netplan/parser.py
+++ b/python-cffi/netplan/parser.py
@@ -13,10 +13,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from enum import IntEnum
 from typing import Union, IO
 
 from ._netplan_cffi import ffi, lib
 from ._utils import _checked_lib_call
+
+
+class Flags(IntEnum):
+    IGNORE_ERRORS = 1 << 0
 
 
 class Parser():
@@ -46,3 +51,15 @@ class Parser():
     def _load_nullable_overrides(self, input_file: IO, constraint: str):
         return _checked_lib_call(lib.netplan_parser_load_nullable_overrides,
                                  self._ptr, input_file.fileno(), constraint.encode('utf-8'))
+
+    @property
+    def flags(self) -> int:
+        return lib.netplan_parser_get_flags(self._ptr)
+
+    @flags.setter
+    def flags(self, flags: int):
+        _ = _checked_lib_call(lib.netplan_parser_set_flags, self._ptr, flags)
+
+    @property
+    def error_count(self) -> int:
+        return lib.netplan_parser_get_error_count(self._ptr)

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -620,12 +620,15 @@ write_netdev_file(const NetplanNetDefinition* def, const char* rootdir, const ch
              * and, if the selected name is the name of the netdef being written, we generate
              * the .netdev file. Otherwise we skip the netdef.
              */
-            gchar* first = g_strcmp0(def->id, def->veth_peer_link->id) < 0 ? def->id : def->veth_peer_link->id;
-            if (first != def->id) {
-                g_string_free(s, TRUE);
-                return;
+            g_string_append_printf(s, "Kind=veth\n");
+            if (def->veth_peer_link) {
+                gchar* first = g_strcmp0(def->id, def->veth_peer_link->id) < 0 ? def->id : def->veth_peer_link->id;
+                if (first != def->id) {
+                    g_string_free(s, TRUE);
+                    return;
+                }
+                g_string_append_printf(s, "\n[Peer]\nName=%s\n", def->veth_peer_link->id);
             }
-            g_string_append_printf(s, "Kind=veth\n\n[Peer]\nName=%s\n", def->veth_peer_link->id);
             break;
 
         case NETPLAN_DEF_TYPE_TUNNEL:

--- a/src/nm.c
+++ b/src/nm.c
@@ -715,7 +715,7 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
                 return FALSE;
         }
 
-        if (def->type == NETPLAN_DEF_TYPE_VETH) {
+        if (def->type == NETPLAN_DEF_TYPE_VETH && def->veth_peer_link) {
             g_key_file_set_string(kf, "veth", "peer", def->veth_peer_link->id);
         }
     }

--- a/src/parse.c
+++ b/src/parse.c
@@ -3718,6 +3718,8 @@ netplan_parser_reset(NetplanParser* npp)
         g_hash_table_destroy(npp->global_renderer);
         npp->global_renderer = NULL;
     }
+
+    npp->flags = 0;
 }
 
 void
@@ -3727,6 +3729,25 @@ netplan_parser_clear(NetplanParser** npp_p)
     *npp_p = NULL;
     netplan_parser_reset(npp);
     g_free(npp);
+}
+
+gboolean
+netplan_parser_set_flags(NetplanParser* npp, const unsigned int flags, GError** error)
+{
+    if (flags >= NETPLAN_PARSER_FLAGS_MAX_) {
+        g_set_error(error, NETPLAN_PARSER_ERROR, NETPLAN_ERROR_INVALID_FLAG,
+                    "Invalid flag set");
+        return FALSE;
+    }
+
+    npp->flags = flags;
+    return TRUE;
+}
+
+unsigned int
+netplan_parser_get_flags(const NetplanParser* npp)
+{
+    return npp->flags;
 }
 
 /* Check if this is a Netdef-ID or global keyword which can be nullified.

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -263,6 +263,9 @@ struct netplan_parser {
     GHashTable* null_fields;
     GHashTable* null_overrides;
     GHashTable* global_renderer;
+
+    /* Flags used to change the parser's behavior */
+    unsigned int flags;
 };
 
 struct netplan_state_iterator {

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -266,6 +266,12 @@ struct netplan_parser {
 
     /* Flags used to change the parser's behavior */
     unsigned int flags;
+
+    /* Number of parsing errors
+     * Records the number of parsing errors that happened
+     * when the flag IGNORE_ERRORS is set
+     * */
+    unsigned int error_count;
 };
 
 struct netplan_state_iterator {

--- a/src/validation.c
+++ b/src/validation.c
@@ -346,7 +346,7 @@ validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, GErr
     /* Skip all validation if we're missing some definition IDs (devices).
      * The ones we have yet to see may be necessary for validation to succeed,
      * we can complete it on the next parser pass. */
-    if (missing_id_count > 0)
+    if (missing_id_count > 0 && (npp->flags & NETPLAN_PARSER_IGNORE_ERRORS) == 0)
         return TRUE;
 
     /* set-name: requires match: */

--- a/tests/config_fuzzer/runner.sh
+++ b/tests/config_fuzzer/runner.sh
@@ -119,4 +119,32 @@ done
 
 echo "$(date) - Done"
 
+echo "$(date) - Running netplan generate -i"
+
+for yaml in ${FAKEDATADIR}/*.yaml
+do
+    rm -rf fakeroot3
+    mkdir -p fakeroot3/etc/netplan
+    cp ${yaml} fakeroot3/etc/netplan/
+
+    OUTPUT=$(${NETPLAN_GENERATE_PATH} --root-dir fakeroot3 -i 2>&1)
+    code=$?
+    if [ $code -eq 139 ] || [ $code -eq 245 ] || [ $code -eq 133 ]
+    then
+        echo "GENERATE --ignore-errors CRASHED"
+        cat ${yaml}
+        error=1
+    fi
+
+    if grep 'detected memory leaks' <<< "$OUTPUT" > /dev/null
+    then
+        echo "GENERATE --ignore-errors MEMORY LEAK DETECTED"
+        cat ${yaml}
+        error=1
+    fi
+
+done
+
+echo "$(date) - Done"
+
 exit ${error}

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -255,6 +255,35 @@ test_nm_device_backend_is_nm_by_default(__unused void** state)
     netplan_state_clear(&np_state);
 }
 
+void
+test_parser_flags(__unused void** state)
+{
+    NetplanParser* npp = netplan_parser_new();
+    GError *error = NULL;
+    gboolean ret = netplan_parser_set_flags(npp, NETPLAN_PARSER_IGNORE_ERRORS, &error);
+
+    assert_true(ret);
+    assert_null(error);
+    assert_int_equal(netplan_parser_get_flags(npp), NETPLAN_PARSER_IGNORE_ERRORS);
+
+    netplan_parser_clear(&npp);
+}
+
+void
+test_parser_flags_bad_flags(__unused void** state)
+{
+    NetplanParser* npp = netplan_parser_new();
+    GError *error = NULL;
+    // Flag 1 << 29 doesn't exist (at least for now)
+    gboolean ret = netplan_parser_set_flags(npp, 1 << 29, &error);
+
+    assert_false(ret);
+    assert_string_equal(error->message, "Invalid flag set");
+    assert_int_equal(error->domain, NETPLAN_PARSER_ERROR);
+    assert_int_equal(error->code, NETPLAN_ERROR_INVALID_FLAG);
+    netplan_parser_clear(&npp);
+}
+
 int
 setup(__unused void** state)
 {
@@ -284,6 +313,8 @@ main()
            cmocka_unit_test(test_netplan_parser_process_document_proper_error),
            cmocka_unit_test(test_netplan_parser_process_document_missing_interface_error),
            cmocka_unit_test(test_nm_device_backend_is_nm_by_default),
+           cmocka_unit_test(test_parser_flags),
+           cmocka_unit_test(test_parser_flags_bad_flags),
        };
 
        return cmocka_run_group_tests(tests, setup, tear_down);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -317,7 +317,8 @@ class TestBase(unittest.TestCase):
                     print(line, flush=True)
                 self.fail('Re-generated YAML file does not match (adopt netplan.c YAML generator?)')
 
-    def generate(self, yaml, expect_fail=False, extra_args=[], confs=None, skip_generated_yaml_validation=False):
+    def generate(self, yaml, expect_fail=False, extra_args=[], confs=None, skip_generated_yaml_validation=False,
+                 ignore_errors=False):
         '''Call generate with given YAML string as configuration
 
         Return stderr output.
@@ -343,6 +344,9 @@ class TestBase(unittest.TestCase):
             print('Test is about to run:\n%s' % ' '.join(argv))
             subprocess.call(['bash', '-i'], cwd=self.workdir.name)
 
+        if ignore_errors:
+            argv += ['--ignore-errors']
+
         p = subprocess.Popen(argv, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, text=True)
         (out, err) = p.communicate()
@@ -364,6 +368,13 @@ class TestBase(unittest.TestCase):
         encode a made up name in the test.
         """
         return 'eth' + ''.join(random.sample(string.ascii_letters + string.digits, k=4))
+
+    def file_exists(self, filename, backend='systemd') -> bool:
+        if backend == 'systemd':
+            path = os.path.join(self.workdir.name, 'run', 'systemd', 'network', filename)
+        else:
+            path = os.path.join(self.workdir.name, 'run', 'NetworkManager', 'system-connections', filename)
+        return os.path.exists(path)
 
     def assert_networkd(self, file_contents_map):
         networkd_dir = os.path.join(self.workdir.name, 'run', 'systemd', 'network')

--- a/tests/integration/dbus.py
+++ b/tests/integration/dbus.py
@@ -154,6 +154,7 @@ class _CommonTests():
         # The path has the following format: /io/netplan/Netplan/config/WM6X01
         BUSCTL_CONFIG_GET[5] = config_path
         BUSCTL_CONFIG_SET[5] = config_path
+        BUSCTL_CONFIG_APPLY[5] = config_path
 
         # Changing the configuration
         out = subprocess.run(BUSCTL_CONFIG_SET, capture_output=True, text=True)
@@ -172,6 +173,10 @@ class _CommonTests():
         self.assertNotEqual(netplan_data, "", msg="Got an empty response from DBUS")
         self.assertEqual(NETPLAN_YAML_AFTER % {'nic': self.dev_e_client},
                          netplan_data, msg="The final YAML is different than expected")
+
+        # Applying the configuration
+        out = subprocess.run(BUSCTL_CONFIG_APPLY, capture_output=True, text=True)
+        self.assertEqual(out.returncode, 0, msg=f"Busctl Apply() failed with error: {out.stderr}")
 
     def test_dbus_config_apply(self):
         NETPLAN_YAML = '''network:

--- a/tests/integration/run.py
+++ b/tests/integration/run.py
@@ -78,10 +78,23 @@ else:
 
 os.environ["NETPLAN_TEST_BACKENDS"] = ",".join(backends)
 
+run_with_ignore_errors = os.environ.get("NETPLAN_PARSER_IGNORE_ERRORS", "1")
+
 returncode = 0
 for test in requested_tests:
+    os.environ["NETPLAN_PARSER_IGNORE_ERRORS"] = "0"
     ret = subprocess.call(['python3', os.path.join(tests_dir, "{}.py".format(test))])
     if returncode == 0 and ret != 0:
         returncode = ret
+
+    # Running tests again with NETPLAN_PARSER_IGNORE_ERRORS
+    # If NETPLAN_PARSER_IGNORE_ERRORS=0 is defined initially, this step will be skipped
+    # When this variable is set to 1, the netplan generator will set the IGNORE_ERRORS flag
+    if run_with_ignore_errors == "1":
+        print(f"Running '{test}' tests again with IGNORE_ERRORS flag set", flush=True)
+        os.environ["NETPLAN_PARSER_IGNORE_ERRORS"] = "1"
+        ret = subprocess.call(['python3', os.path.join(tests_dir, "{}.py".format(test))])
+        if returncode == 0 and ret != 0:
+            returncode = ret
 
 sys.exit(returncode)


### PR DESCRIPTION
## Description

This is an implementation of what I called "parser flags". The idea is to enable the user to change some parsing decisions.

The main application at the moment is to support ignoring parsing errors. Currently Netplan will not generate any configuration if a little mistake is made in one of its YAML files. It can be really bad if you're operating a remote system and end up rebooting the system with a syntax issue in one of your files. Your system will basically boot without any network configuration.

The IGNORE_ERRORS flag will allow the Netplan generator to ignore bad files and bad netdefs so it will still generate some configuration.

**TESTS**

Integration tests will be executed twice now, once without the ignore_errors flags and once with it enabled. It's intended to increase the confidence that the parser behaves as expected when the flag is enabled and the configuration is good.

I prepared a PPA for Ubuntu Noble with this patch: https://launchpad.net/~danilogondolfo/+archive/ubuntu/netplan-parser-flags

Suggestions of tests:

It can be easily tested in a LXD VM. You can add some broken configuration and reboot the VM or call `/usr/libexec/netplan/generate -i` to see the parsing process when it's ignoring errors

1. Break the default `50-cloud-init.yaml` and reboot the VM. For example, the config below should still bring enp5s0 up and with DHCP working.

```yaml
network:
  version: 2
  ethernets:
    enp5s0:
      dhcp4: true
      dhcp: true
```

2. Add a second file that is not a valid YAML
3.  Add a third broken file with some complex configuration and dependencies between netdefs. For example, with the configuration below `eth2` should still have a backend configuration file and it should contain `Bond=bond0`.
```yaml
network:
  ethernets:
    eth0: {}
    eth1: {}
    eth2:
      a: b

  bonds:
    bond0:
      interfaces:
        - eth0
        - eth1
        - eth2
```
4. Add a fourth broken file with missing dependencies. For example, with the config below you still should have a `br0` interface created:
```yaml
network:
  bridges:
    br0:
      addresses:
        - 10.20.30.40/24

      interfaces:
        - aaaa
        - bbbb
        - dddd
```

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

