### PR TITLE
wireguard: ignore empty endpoints (LP: #2038811)

### DIFF
--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -552,7 +552,11 @@ parse_tunnels(GKeyFile* kf, NetplanNetDefinition* nd)
                 }
 
                 /* Handle endpoint */
-                wireguard_peer->endpoint = g_key_file_get_string(kf, group, "endpoint", NULL);
+                gchar* endpoint = g_key_file_get_string(kf, group, "endpoint", NULL);
+                if (endpoint && g_strcmp0(endpoint, "")) {
+                    /* Only set the endpoint if it's not NULL nor an empty string */
+                    wireguard_peer->endpoint = endpoint;
+                }
                 _kf_clear_key(kf, group, "endpoint");
 
                 g_array_append_val(nd->wireguard_peers, wireguard_peer);

--- a/src/parse.c
+++ b/src/parse.c
@@ -2465,6 +2465,11 @@ handle_wireguard_endpoint(NetplanParser* npp, yaml_node_t* node, __unused const 
     char* address;
     guint64 port_num;
 
+    /* If endpoint is an empty string just ignore it */
+    if (!g_strcmp0(scalar(node), "")) {
+        return TRUE;
+    }
+
     endpoint = g_strdup(scalar(node));
     /* absolute minimal length of endpoint is 3 chars: 'h:8' */
     if (strlen(endpoint) < 3) {

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -309,6 +309,15 @@ must be X.X.X.X/NN or X:X:X:X:X:X:X:X/NN", out)
         out = self.generate(config, expect_fail=True)
         self.assertIn("Error in network definition: wg0: a public key is required.", out)
 
+    def test_empty_string_as_endpoint_should_be_ignored(self):
+        """[wireguard] If the endpoint key is present but set to '' it should just be ignored"""
+        config = prepare_wg_config(listen=12345, privkey='KPt9BzQjejRerEv8RMaFlpsD675gNexELOQRXt/AcH0=',
+                                   peers=[{'public-key': 'rlbInAj0qV69CysWPQY7KEBnKxpYCpaWqOs/dLevdWc=',
+                                           'allowed-ips': '[0.0.0.0/0, "2001:fe:ad:de:ad:be:ef:1/24"]',
+                                           'keepalive': 14,
+                                           'endpoint': '\"\"'}], renderer=self.backend)
+        self.generate(config, skip_generated_yaml_validation=True)
+
     def test_vxlan_port_range_fail(self):
         out = self.generate('''network:
   tunnels:

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1722,6 +1722,43 @@ method=auto\n'''.format(UUID))
           connection.interface-name: "wg0"
 '''.format(UUID, UUID)})
 
+    def test_wireguard_with_empty_endpoint(self):
+        self.generate_from_keyfile('''[connection]
+id=wg0
+type=wireguard
+uuid={}
+interface-name=wg0
+
+[wireguard]
+private-key=aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A=
+
+[wireguard-peer.cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI=]
+endpoint=
+allowed-ips=192.168.0.0/24;
+
+[ipv4]
+method=auto\n'''.format(UUID), regenerate=False)
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  tunnels:
+    NM-{}:
+      renderer: NetworkManager
+      dhcp4: true
+      mode: "wireguard"
+      keys:
+        private: "aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A="
+      peers:
+      - keys:
+          public: "cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI="
+        allowed-ips:
+        - "192.168.0.0/24"
+      networkmanager:
+        uuid: "{}"
+        name: "wg0"
+        passthrough:
+          connection.interface-name: "wg0"
+'''.format(UUID, UUID)})
+
     def test_wireguard_allowed_ips_without_prefix(self):
         '''
         When the IP prefix is not present we should default to /32


### PR DESCRIPTION
The Network Manager GUI will emit 'Endpoint=' if it's not specified when creating the tunnel. libnetplan is generating 'endpoint: ""' in this case and the parser is returning an error.

In nm-parse, if Endpoint is either empty or NULL we'll just not read it. In the parser, if we find 'endpoint: ""', we'll just ignore it as if it were not defined.

See LP: #2038811


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

