### PR TITLE
wifi: make it possible to have a psk and an eap password simultaneously

### DIFF
--- a/src/abi.h
+++ b/src/abi.h
@@ -120,6 +120,7 @@ typedef enum {
     NETPLAN_AUTH_EAP_TTLS,
     NETPLAN_AUTH_EAP_LEAP,
     NETPLAN_AUTH_EAP_PWD,
+    NETPLAN_AUTH_EAP_UNKNOWN,
     NETPLAN_AUTH_EAP_METHOD_MAX,
 } NetplanAuthEAPMethod;
 
@@ -142,6 +143,7 @@ typedef struct authentication_settings {
     char* client_key;
     char* client_key_password;
     char* phase2_auth;  /* netplan-feature: auth-phase2 */
+    char* psk;
 } NetplanAuthenticationSettings;
 
 typedef enum {

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -135,7 +135,11 @@ write_auth(yaml_event_t* event, yaml_emitter_t* emitter, NetplanAuthenticationSe
     YAML_NONNULL_STRING(event, emitter, "client-key", auth.client_key);
     YAML_NONNULL_STRING(event, emitter, "client-key-password", auth.client_key_password);
     YAML_NONNULL_STRING(event, emitter, "phase2-auth", auth.phase2_auth);
-    YAML_NONNULL_STRING(event, emitter, "password", auth.password);
+    if (!auth.password && auth.psk) {
+        YAML_NONNULL_STRING(event, emitter, "password", auth.psk);
+    } else {
+        YAML_NONNULL_STRING(event, emitter, "password", auth.password);
+    }
     YAML_MAPPING_CLOSE(event, emitter);
     return TRUE;
 err_path: return FALSE; // LCOV_EXCL_LINE
@@ -389,7 +393,7 @@ write_access_points(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanN
         }
 
         YAML_UINT_0(def, event, emitter, "channel", ap->channel);
-        if (ap->auth.psk)
+        if (ap->auth.psk && !_is_auth_key_management_psk(&ap->auth))
             YAML_NONNULL_STRING(event, emitter, "password", ap->auth.psk);
         if (ap->has_auth || DIRTY(def, ap->auth))
             write_auth(event, emitter, ap->auth);

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -389,6 +389,8 @@ write_access_points(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanN
         }
 
         YAML_UINT_0(def, event, emitter, "channel", ap->channel);
+        if (ap->auth.psk)
+            YAML_NONNULL_STRING(event, emitter, "password", ap->auth.psk);
         if (ap->has_auth || DIRTY(def, ap->auth))
             write_auth(event, emitter, ap->auth);
         if (ap->mode != NETPLAN_WIFI_MODE_INFRASTRUCTURE || DIRTY(def, ap->mode))

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1126,11 +1126,8 @@ append_wpa_auth_conf(GString* s, const NetplanAuthenticationSettings* auth, cons
     char* psk = NULL;
     if (auth->psk)
         psk = auth->psk;
-    else if (auth->password
-            && (auth->key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK
-                || auth->key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_SAE)
-        )
-            psk = auth->password;
+    else if (auth->password && _is_auth_key_management_psk(auth))
+        psk = auth->password;
 
     if (psk) {
         size_t len = strlen(psk);
@@ -1153,10 +1150,7 @@ append_wpa_auth_conf(GString* s, const NetplanAuthenticationSettings* auth, cons
     }
 
     if (auth->password
-        && ((   auth->key_management != NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK
-             && auth->key_management != NETPLAN_AUTH_KEY_MANAGEMENT_WPA_SAE
-            )
-            || auth->eap_method != NETPLAN_AUTH_EAP_NONE)) {
+        && (!_is_auth_key_management_psk(auth) || auth->eap_method != NETPLAN_AUTH_EAP_NONE)) {
         if (strncmp(auth->password, "hash:", 5) == 0) {
             g_string_append_printf(s, "  password=%s\n", auth->password);
         } else {

--- a/src/nm.c
+++ b/src/nm.c
@@ -434,12 +434,7 @@ write_dot1x_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile 
      * We only write auth-password in [802-1x].password if it's not a PSK used by either PSK or SAE
      * or if an EAP method was defined.
      */
-    if (auth->password
-        && ((   auth->key_management != NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK
-             && auth->key_management != NETPLAN_AUTH_KEY_MANAGEMENT_WPA_SAE
-            )
-            || auth->eap_method != NETPLAN_AUTH_EAP_NONE)
-    )
+    if (auth->password && (!_is_auth_key_management_psk(auth) || auth->eap_method != NETPLAN_AUTH_EAP_NONE))
         g_key_file_set_string(kf, "802-1x", "password", auth->password);
     if (auth->ca_certificate)
         g_key_file_set_string(kf, "802-1x", "ca-cert", auth->ca_certificate);
@@ -499,9 +494,7 @@ write_wifi_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile *
 
     if (auth->psk)
         g_key_file_set_string(kf, "wifi-security", "psk", auth->psk);
-    else if (auth->password
-        && (auth->key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK
-            || auth->key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_SAE))
+    else if (auth->password && _is_auth_key_management_psk(auth))
         g_key_file_set_string(kf, "wifi-security", "psk", auth->password);
 }
 

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -401,7 +401,7 @@ parse_dot1x_auth(GKeyFile* kf, NetplanAuthenticationSettings* auth)
          *
          * TODO: eap_method needs to be fixed to store multiple methods.
          *
-         * If at this point the eap_method is still NONE we also keep the property because
+         * If at this point the eap_method is still UNKNOWN we also keep the property because
          * it's probably a setting we still don't support.
          */
         if (auth->eap_method != NETPLAN_AUTH_EAP_UNKNOWN && (split[1] == NULL || !g_strcmp0(split[1], "")))
@@ -412,9 +412,7 @@ parse_dot1x_auth(GKeyFile* kf, NetplanAuthenticationSettings* auth)
 
     keyfile_handle_generic_str(kf, "802-1x", "identity", &auth->identity);
     keyfile_handle_generic_str(kf, "802-1x", "anonymous-identity", &auth->anonymous_identity);
-    if (auth->key_management != NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK &&
-        auth->key_management != NETPLAN_AUTH_KEY_MANAGEMENT_WPA_SAE)
-        keyfile_handle_generic_str(kf, "802-1x", "password", &auth->password);
+    keyfile_handle_generic_str(kf, "802-1x", "password", &auth->password);
     keyfile_handle_generic_str(kf, "802-1x", "ca-cert", &auth->ca_certificate);
     keyfile_handle_generic_str(kf, "802-1x", "client-cert", &auth->client_certificate);
     keyfile_handle_generic_str(kf, "802-1x", "private-key", &auth->client_key);
@@ -1020,16 +1018,9 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
             default: break;
         }
 
-        if (ap->auth.key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK
-            || ap->auth.key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_SAE) {
-            keyfile_handle_generic_str(kf, "wifi-security", "psk", &ap->auth.password);
-            if (ap->auth.password)
-                ap->has_auth = TRUE;
-        } else {
-            keyfile_handle_generic_str(kf, "wifi-security", "psk", &ap->auth.psk);
-            if (ap->auth.psk)
-                ap->has_auth = TRUE;
-        }
+        keyfile_handle_generic_str(kf, "wifi-security", "psk", &ap->auth.psk);
+        if (ap->auth.psk)
+            ap->has_auth = TRUE;
 
         parse_dot1x_auth(kf, &ap->auth);
         if (ap->auth.eap_method != NETPLAN_AUTH_EAP_NONE)

--- a/src/parse.c
+++ b/src/parse.c
@@ -1045,10 +1045,12 @@ handle_access_point_password(NetplanParser* npp, yaml_node_t* node, __unused con
     g_assert(access_point);
     /* shortcut for WPA-PSK */
     access_point->has_auth = TRUE;
-    access_point->auth.key_management = NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK;
+    if (access_point->auth.key_management == NETPLAN_AUTH_KEY_MANAGEMENT_NONE)
+        access_point->auth.key_management = NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK;
+
     access_point->auth.pmf_mode = NETPLAN_AUTH_PMF_MODE_OPTIONAL;
-    g_free(access_point->auth.password);
-    access_point->auth.password = g_strdup(scalar(node));
+    g_free(access_point->auth.psk);
+    access_point->auth.psk = g_strdup(scalar(node));
     return TRUE;
 }
 

--- a/src/types.c
+++ b/src/types.c
@@ -107,6 +107,7 @@ reset_auth_settings(NetplanAuthenticationSettings* auth)
     FREE_AND_NULLIFY(auth->identity);
     FREE_AND_NULLIFY(auth->anonymous_identity);
     FREE_AND_NULLIFY(auth->password);
+    FREE_AND_NULLIFY(auth->psk);
     FREE_AND_NULLIFY(auth->ca_certificate);
     FREE_AND_NULLIFY(auth->client_certificate);
     FREE_AND_NULLIFY(auth->client_key);

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -132,6 +132,9 @@ is_route_rule_present(const NetplanNetDefinition* netdef, const NetplanIPRule* r
 NETPLAN_INTERNAL gboolean //FIXME: avoid exporting private symbol
 is_string_in_array(GArray* array, const char* value);
 
+gboolean
+_is_auth_key_management_psk(const NetplanAuthenticationSettings* auth);
+
 NETPLAN_INTERNAL struct address_iter*
 _netplan_netdef_new_address_iter(NetplanNetDefinition* netdef);
 

--- a/src/util.c
+++ b/src/util.c
@@ -1169,3 +1169,11 @@ is_string_in_array(GArray* array, const char* value)
     }
     return FALSE;
 }
+
+/* Check if the authentication key management algorithm uses a PSK password */
+gboolean
+_is_auth_key_management_psk(const NetplanAuthenticationSettings* auth)
+{
+    return (   auth->key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK
+            || auth->key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_SAE);
+}

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -481,6 +481,33 @@ network={
 }
 """)
 
+    def test_wifi_ieee8021x_eap_and_psk(self):
+        self.generate('''network:
+  version: 2
+  wifis:
+    wl0:
+      access-points:
+        homenet:
+          password: psk_password
+          auth:
+            key-management: eap
+            method: leap
+            identity: some-id
+            password: "********"''')
+
+        self.assert_wpa_supplicant("wl0", """ctrl_interface=/run/wpa_supplicant
+
+network={
+  ssid="homenet"
+  key_mgmt=WPA-EAP
+  eap=LEAP
+  ieee80211w=1
+  identity="some-id"
+  psk="psk_password"
+  password="********"
+}
+""")
+
 
 class TestNetworkManager(TestBase):
 
@@ -995,6 +1022,47 @@ key-mgmt=ieee8021x
 
 [802-1x]
 eap=pwd
+identity=some-id
+password=**********
+'''})
+
+    def test_wifi_eap_and_psk(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  wifis:
+    wl0:
+      access-points:
+        homenet:
+          password: psk_password
+          auth:
+            key-management: eap
+            method: leap
+            identity: "some-id"
+            password: "**********"''')
+
+        self.assert_nm({'wl0-homenet': '''[connection]
+id=netplan-wl0-homenet
+type=wifi
+interface-name=wl0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=homenet
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-eap
+pmf=2
+psk=psk_password
+
+[802-1x]
+eap=leap
 identity=some-id
 password=**********
 '''})

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -647,7 +647,7 @@ identity=some-id
 password=v3rys3cr3t!
 
 [ipv4]
-method=auto'''.format(UUID), regenerate=False)
+method=auto'''.format(UUID))
         self.assert_netplan({UUID: '''network:
   version: 2
   wifis:
@@ -696,6 +696,12 @@ password=v3rys3cr3t!
 
 [ipv4]
 method=auto'''.format(UUID), regenerate=False)
+        # Regeneration is disabled for the previous test because when both,
+        # identity and PSK passwords are used, the PSK will be stored in the
+        # access-points.<ap>.password key and, because of that, a keyfile with
+        # [wifi-security].pmf=2 will be emitted and will differ from the original
+        # keyfile.
+
         self.assert_netplan({UUID: '''network:
   version: 2
   wifis:


### PR DESCRIPTION
## Description
Originally, Netplan assumes the PSK and 802-1x identity password will
not be used simultaneously.

With this change, when both passwords are used, the PSK is expected to
be placed in "ssid".password and the identity in "ssid".auth.password.
"ssid".auth.password can also be used by the PSK if it's the only password.

When 802-1x is used, the PMF setting will not be emitted if the PSK is
also present. NM will error out if both settings are used simultaneously.

It also copes with unsupported EAP methods.

Here are some test cases that are currently leading to NM crashes:

```
nmcli con add type wifi ifname wlan0 ssid asdasd wifi-sec.key-mgmt wpa-psk wifi-sec.psk asdasdasd 802-1x.eap md5 802-1x.identity username 802-1x.password aaaaaaaa
```
```
nmcli con add type wifi ifname wlan0 ssid asdasd wifi-sec.key-mgmt wpa-psk wifi-sec.psk asdasdasd 802-1x.eap fast 802-1x.identity username 802-1x.password aaaaaaaa
```
```
nmcli con add type wifi ifname wlan0 ssid asdasd wifi-sec.key-mgmt ieee8021x wifi-sec.psk bbbbbbbb 802-1x.eap leap 802-1x.identity username 802-1x.password aaaaaaaa
```
```
nmcli con add type wifi ifname wlan0 ssid asdasd wifi-sec.key-mgmt wpa-eap 802-1x.eap md5 802-1x.identity username 802-1x.password aaaaaaaa
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

