### PR TITLE
check if ovsdb-server.service is active before displaying warning

### DIFF
--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -31,7 +31,7 @@ import time
 from .. import utils
 from ...configmanager import ConfigManager, ConfigurationError
 from ..sriov import apply_sriov_config
-from ..ovs import OvsDbServerNotRunning, apply_ovs_cleanup
+from ..ovs import OvsDbServerNotRunning, OvsDbServerNotInstalled, apply_ovs_cleanup
 
 
 OVS_CLEANUP_SERVICE = 'netplan-ovs-cleanup.service'
@@ -433,3 +433,5 @@ class NetplanApply(utils.NetplanCommand):
                 sys.exit(1)
         except OvsDbServerNotRunning as e:
             logging.warning('Cannot call Open vSwitch: {}.'.format(e))
+        except OvsDbServerNotInstalled as e:
+            logging.debug('Cannot call Open vSwitch: %s.', e)

--- a/netplan_cli/cli/ovs.py
+++ b/netplan_cli/cli/ovs.py
@@ -20,7 +20,7 @@ import os
 import subprocess
 import re
 
-from .utils import systemctl_is_active
+from .utils import systemctl_is_active, systemctl_is_installed
 
 OPENVSWITCH_OVS_VSCTL = '/usr/bin/ovs-vsctl'
 OPENVSWITCH_OVSDB_SERVER_UNIT = 'ovsdb-server.service'
@@ -40,6 +40,10 @@ GLOBALS = {
 
 
 class OvsDbServerNotRunning(Exception):
+    pass
+
+
+class OvsDbServerNotInstalled(Exception):
     pass
 
 
@@ -125,6 +129,9 @@ def apply_ovs_cleanup(config_manager, ovs_old, ovs_current):  # pragma: nocover 
     Also filter for individual settings tagged netplan/<column>[/<key]=value
     in external-ids and clear them if they have been set by netplan.
     """
+    if not systemctl_is_installed(OPENVSWITCH_OVSDB_SERVER_UNIT):
+        raise OvsDbServerNotInstalled("Cannot apply OVS cleanup: %s is 'not-found'.",
+                                      OPENVSWITCH_OVSDB_SERVER_UNIT)
     if not systemctl_is_active(OPENVSWITCH_OVSDB_SERVER_UNIT):
         raise OvsDbServerNotRunning('{} is not running'.format(OPENVSWITCH_OVSDB_SERVER_UNIT))
 

--- a/netplan_cli/cli/utils.py
+++ b/netplan_cli/cli/utils.py
@@ -148,6 +148,16 @@ def systemctl_is_masked(unit_pattern):
     return False
 
 
+def systemctl_is_installed(unit_pattern):
+    '''Return True if returncode is other than "not-found" (4)'''
+    res = subprocess.run(['systemctl', 'is-enabled', unit_pattern],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         text=True)
+    if res.returncode != 4:
+        return True
+    return False
+
+
 def systemctl_daemon_reload():
     '''Reload systemd unit files from disk and re-calculate its dependencies'''
     subprocess.check_call(['systemctl', 'daemon-reload'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -354,6 +354,26 @@ class TestUtils(unittest.TestCase):
             ['systemctl', 'is-enabled', 'some.service']
         ])
 
+    def test_systemctl_is_installed(self):
+        self.mock_cmd = MockCmd('systemctl')
+        self.mock_cmd.set_returncode(0)
+        path_env = os.environ['PATH']
+        os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
+        self.assertTrue(utils.systemctl_is_installed('some.service'))
+        self.assertEqual(self.mock_cmd.calls(), [
+            ['systemctl', 'is-enabled', 'some.service']
+        ])
+
+    def test_systemctl_is_installed_false(self):
+        self.mock_cmd = MockCmd('systemctl')
+        self.mock_cmd.set_returncode(4)
+        path_env = os.environ['PATH']
+        os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
+        self.assertFalse(utils.systemctl_is_installed('some.service'))
+        self.assertEqual(self.mock_cmd.calls(), [
+            ['systemctl', 'is-enabled', 'some.service']
+        ])
+
     def test_systemctl_daemon_reload(self):
         self.mock_cmd = MockCmd('systemctl')
         path_env = os.environ['PATH']


### PR DESCRIPTION
## Description
Made changes outlined in this bug
Credit:  @brianfinley https://launchpad.net/~finley
https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2041727 
Tested on Ubuntu 22.04.3 LTS and the error message no longer displays

## Checklist
- [X] Runs `make check` successfully.
- [X] Retains 100% code coverage (`make check-coverage`).
- [X] New/changed keys in YAML format are documented.
```
@@ -414,4 +414,5 @@
             if exit_on_error:
                 sys.exit(1)
         except OvsDbServerNotRunning as e:
- logging.warning('Cannot call Open vSwitch: {}.'.format(e))
+ if utils.systemctl_is_active('ovsdb-server.service'):
+ logging.warning('Cannot call Open vSwitch: {}.'.format(e))
```
- [X] Closes an open bug in Launchpad.
https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2041727

