### PR TITLE
Fix permissions on folder '/run/NetworkManager/'

### DIFF
--- a/netplan_cli/cli/commands/try_command.py
+++ b/netplan_cli/cli/commands/try_command.py
@@ -18,7 +18,6 @@
 '''netplan try command line'''
 
 import logging
-import netplan
 import os
 import time
 import shutil
@@ -179,7 +178,7 @@ class NetplanTry(utils.NetplanCommand):
         # more than one device in them, and they can be set with special parameters
         # to tweak their behavior, which are really hard to "revert", especially
         # as systemd-networkd doesn't necessarily touch them when config changes.
-        multi_iface = {}  # type: dict[str, netplan.NetDefinition]
+        multi_iface = {}  # dict[str, netplan.NetDefinition]
         multi_iface.update(np_state.bridges)
         multi_iface.update(np_state.bonds)
         for itf in multi_iface.values():


### PR DESCRIPTION
When the Netplan systemd generator runs before the NetworkManager service, Netplan will preempt NetworkManager from creating folder '/run/NetworkManager' and will assign it permissions 700.
This is a side effect of the call to umask in function write_nm_conf_access_point, made to restrict the permissions on subfolder '/run/NetworkManger/system-connections'. A regular user needs to read from /run/NetworkManager where, in some systems, files such as resolv.conf ultimately reside.


## Description

In my Yocto image /etc/resolv.conf  is a symlink to /etc/resolv-conf.NetworkManager itself to /run/Netw
orkManager/resolv.conf.  Because the /run/NetworkManager folder created by Netplan has 700 permissions a regular user has no access to resolv.conf which breaks domain name resolution.

This fix assigns the proper access to rights to /run/NetworkManager, 755,  if Netplan happens to be the first to create it, without elevating privileges to /run/NetworkManager/system-connections, which is what was intended by the original code.


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

