### PR TITLE
Migrate CriticalConnection (deprecated) to KeepConfiguration (LP: #1896799)

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -353,7 +353,7 @@ write_bond_parameters(const NetplanNetDefinition* def, GString* s)
     if (def->bond_params.selection_logic)
         g_string_append_printf(params, "\nAdSelect=%s", def->bond_params.selection_logic);
     if (def->bond_params.all_members_active)
-        g_string_append_printf(params, "\nAllSlavesActive=%d", def->bond_params.all_members_active); /* wokeignore:rule=slave */ 
+        g_string_append_printf(params, "\nAllSlavesActive=%d", def->bond_params.all_members_active); /* wokeignore:rule=slave */
     if (def->bond_params.arp_interval) {
         g_string_append(params, "\nARPIntervalSec=");
         if (interval_has_suffix(def->bond_params.arp_interval))
@@ -393,7 +393,7 @@ write_bond_parameters(const NetplanNetDefinition* def, GString* s)
         g_string_append_printf(params, "\nGratuitousARP=%d", def->bond_params.gratuitous_arp);
     /* TODO: add unsolicited_na, not documented as supported by NM. */
     if (def->bond_params.packets_per_member)
-        g_string_append_printf(params, "\nPacketsPerSlave=%d", def->bond_params.packets_per_member); /* wokeignore:rule=slave */ 
+        g_string_append_printf(params, "\nPacketsPerSlave=%d", def->bond_params.packets_per_member); /* wokeignore:rule=slave */
     if (def->bond_params.primary_reselect_policy)
         g_string_append_printf(params, "\nPrimaryReselectPolicy=%s", def->bond_params.primary_reselect_policy);
     if (def->bond_params.resend_igmp)

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -922,7 +922,7 @@ netplan_netdef_write_network_file(
     }
 
     if (def->critical)
-        g_string_append_printf(network, "CriticalConnection=true\n");
+        g_string_append_printf(network, "KeepConfiguration=true\n");
 
     if (def->dhcp4 || def->dhcp6) {
         if (def->dhcp_identifier)

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -482,7 +482,7 @@ Name=engreen
 LinkLocalAddressing=ipv6
 
 [DHCP]
-CriticalConnection=true
+KeepConfiguration=true
 '''})
 
     def test_dhcp_identifier_mac(self):


### PR DESCRIPTION
## Description

With systemd-v243 (which is the default since focal), the "CriticalConnection" attribute was
revamped into "KeepConfiguration" [1], addressing several issues, especially in high-availability
environents [2][3].

This PR is preparatory work for #409 

If I understand the code correctly, it still uses "CriticalConnection" when setting "critical: true" in the netplan configuration.

- [1] https://github.com/systemd/systemd/pull/12511/files
- [2] https://github.com/systemd/systemd/issues/12050
- [3] https://chr4.org/blog/2019/01/21/make-keepalived-play-nicely-with-netplan-slash-systemd-network/

Closes: https://bugs.launchpad.net/netplan/+bug/1896799

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [] New/changed keys in YAML format are documented.
- [] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1896799
