### PR TITLE
parser: accept the special MAC address options (LP: #2045096)

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -491,7 +491,10 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
 - **`macaddress`** (scalar)
 
   > Set the device's MAC address. The MAC address must be in the form
-  > `XX:XX:XX:XX:XX:XX`.
+  > "XX:XX:XX:XX:XX:XX". The following special options are also accepted:
+  > `permanent` and `random`.
+  > In addition to these options, the NetworkManager renderer also accepts
+  > `stable` and `preserve`.
   >
   > **Note:** This will not work reliably for devices matched by name
   > only and rendered by networkd, due to interactions with device

--- a/src/nm.c
+++ b/src/nm.c
@@ -1104,7 +1104,7 @@ netplan_state_finish_nm_write(
                 g_string_append_printf(udev_rules, "%s ENV{ID_NET_NAME}==\"%s\",%s", prefix, nd->id, suffix);
             }
             /* Also, match by explicit (new) MAC, if available */
-            if (nd->set_mac) {
+            if (nd->set_mac && _is_valid_macaddress(nd->set_mac)) {
                 tmp = g_string_new(nd->set_mac);
                 g_string_append_printf(udev_rules, "%s ATTR{address}==\"%s\",%s", prefix, g_string_ascii_down(tmp)->str, suffix);
                 g_string_free(tmp, TRUE);

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -169,17 +169,8 @@ keyfile_handle_cloned_mac_address(GKeyFile *kf, NetplanNetDefinition* nd, const 
 
     if (!mac) return;
 
-    /* If the value of "cloned-mac-address" is one of the below we don't try to
-     * parse it and leave it in the passthrough section.
-     */
-    if (   g_strcmp0(mac, "preserve")
-        && g_strcmp0(mac, "permanent")
-        && g_strcmp0(mac, "random")
-        && g_strcmp0(mac, "stable")
-    ) {
-        nd->set_mac = g_strdup(mac);
-        _kf_clear_key(kf, group, "cloned-mac-address");
-    }
+    nd->set_mac = g_strdup(mac);
+    _kf_clear_key(kf, group, "cloned-mac-address");
 }
 
 STATIC void

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -126,6 +126,15 @@ is_string_in_array(GArray* array, const char* value);
 gboolean
 _is_auth_key_management_psk(const NetplanAuthenticationSettings* auth);
 
+gboolean
+_is_macaddress_special_nm_option(const char* value);
+
+gboolean
+_is_macaddress_special_nd_option(const char* value);
+
+gboolean
+_is_valid_macaddress(const char* value);
+
 NETPLAN_INTERNAL struct address_iter*
 _netplan_netdef_new_address_iter(NetplanNetDefinition* netdef);
 

--- a/src/util.c
+++ b/src/util.c
@@ -20,6 +20,7 @@
 #include <arpa/inet.h>
 #include <fnmatch.h>
 #include <errno.h>
+#include <regex.h>
 #include <string.h>
 #include <sys/mman.h>
 
@@ -1140,4 +1141,34 @@ _is_auth_key_management_psk(const NetplanAuthenticationSettings* auth)
 {
     return (   auth->key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_PSK
             || auth->key_management == NETPLAN_AUTH_KEY_MANAGEMENT_WPA_SAE);
+}
+
+gboolean
+_is_macaddress_special_nm_option(const char* value)
+{
+    return (   !g_strcmp0(value, "preserve")
+            || !g_strcmp0(value, "permanent")
+            || !g_strcmp0(value, "random")
+            || !g_strcmp0(value, "stable"));
+}
+
+gboolean
+_is_macaddress_special_nd_option(const char* value)
+{
+    return (   !g_strcmp0(value, "permanent")
+            || !g_strcmp0(value, "random"));
+}
+
+gboolean
+_is_valid_macaddress(const char* value)
+{
+    static regex_t re;
+    static gboolean re_inited = FALSE;
+
+    if (!re_inited) {
+        g_assert(regcomp(&re, "^[[:xdigit:]][[:xdigit:]](:[[:xdigit:]][[:xdigit:]]){5}((:[[:xdigit:]][[:xdigit:]]){14})?$", REG_EXTENDED|REG_NOSUB) == 0);
+        re_inited = TRUE;
+    }
+
+    return regexec(&re, value, 0, NULL, 0) == 0;
 }

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -2229,6 +2229,7 @@ dns-search='''.format(UUID))
       match:
         name: "eth0"
       dhcp4: true
+      macaddress: "random"
       access-points:
         "SOME-SSID":
           auth:
@@ -2237,7 +2238,6 @@ dns-search='''.format(UUID))
             uuid: "{}"
             name: "myid with spaces"
             passthrough:
-              wifi.cloned-mac-address: "random"
               ipv4.dns-search: ""
       networkmanager:
         uuid: "{}"
@@ -2265,12 +2265,12 @@ dns-search='''.format(UUID))
       match:
         name: "eth0"
       dhcp4: true
+      macaddress: "random"
       wakeonlan: true
       networkmanager:
         uuid: "{}"
         name: "myid with spaces"
         passthrough:
-          ethernet.cloned-mac-address: "random"
           ipv4.dns-search: ""
 '''.format(UUID, UUID)})
 


### PR DESCRIPTION
Besides the actual MAC address value, Network Manager also accepts the following values: preserve, permanent, random and stable.

When set via NetworkManager, these special values would end up in the passthrough section. But if users try to set it manually, the parsing would fail.

This changes add support for these special values for the NetworkManager renderer and return an error if the user tries to use them with networkd.

Related to https://bugs.launchpad.net/ubuntu/+source/network-manager/+bug/2045096

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

