### PR TITLE
parse-nm/wg: append the correct prefix to IPv6 addresses (LP: #2046158)

### DIFF
--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -543,13 +543,16 @@ parse_tunnels(GKeyFile* kf, NetplanNetDefinition* nd)
                             /*
                              * NM doesn't care if the prefix was omitted.
                              * Even though the WG manual says it requires the prefix,
-                             * if it's omitted in its config file it will default to /32
-                             * so we should do the same here and append a /32 if it's not present,
-                             * otherwise we will generate a YAML that will fail validation.
+                             * if it's omitted in its config file it will default to /32 for IPv4
+                             * and /128 for IPv6 so we should do the same here and append a /32 or /128
+                             * if it's not present, otherwise we will generate a YAML that will fail validation.
                              */
-                            if (!g_strrstr(ip, "/"))
-                                address = g_strdup_printf("%s/32", ip);
-                            else
+                            if (!g_strrstr(ip, "/")) {
+                                if (is_ip4_address(ip))
+                                    address = g_strdup_printf("%s/32", ip);
+                                else
+                                    address = g_strdup_printf("%s/128", ip);
+                            } else
                                 address = g_strdup(ip);
                             g_array_append_val(wireguard_peer->allowed_ips, address);
                         }

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -1963,7 +1963,8 @@ method=auto\n'''.format(UUID), regenerate=False)
 
     def test_wireguard_allowed_ips_without_prefix(self):
         '''
-        When the IP prefix is not present we should default to /32
+        When the IP prefix is not present we should default to /32 for IPv4
+        and /128 for IPv6.
         '''
         self.generate_from_keyfile('''[connection]
 id=wg0
@@ -1976,7 +1977,7 @@ private-key=aPUcp5vHz8yMLrzk8SsDyYnV33IhE/k20e52iKJFV0A=
 
 [wireguard-peer.cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI=]
 endpoint=1.2.3.4:12345
-allowed-ips=192.168.0.10
+allowed-ips=192.168.0.10;2001::1;
 
 [ipv4]
 method=auto\n'''.format(UUID), regenerate=False)
@@ -1995,6 +1996,7 @@ method=auto\n'''.format(UUID), regenerate=False)
           public: "cwkb7k0xDgLSnunZpFIjLJw4u+mJDDr+aBR5DqzpmgI="
         allowed-ips:
         - "192.168.0.10/32"
+        - "2001::1/128"
       networkmanager:
         uuid: "{}"
         name: "wg0"


### PR DESCRIPTION
When the prefix is omitted for IPs in the allowed-ips list, we were appending a /32 to them without checking the address family.

IPv6 addresses will have a /128 appended to them if it's not present.

See LP#2046158


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

