### PR TITLE
ovs: disable StartLimitBurst in the ovs-cleanup service (LP: #2047827)

### DIFF
--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -60,6 +60,11 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     }
 
     g_string_append(s, "\n[Service]\nType=oneshot\nTimeoutStartSec=10s\n");
+    /* During tests the rate in which the netplan-ovs-cleanup service is started/stopped
+     * might exceed StartLimitBurst.
+     */
+    if (cleanup)
+        g_string_append(s, "StartLimitBurst=0\n");
     g_string_append(s, cmds->str);
 
     g_string_free_to_file(s, rootdir, path, NULL);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -70,7 +70,7 @@ rstp_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-id
 OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
 Type=oneshot\nTimeoutStartSec=10s\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
 OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\
-[Service]\nType=oneshot\nTimeoutStartSec=10s\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
+[Service]\nType=oneshot\nTimeoutStartSec=10s\nStartLimitBurst=0\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
 UDEV_SRIOV_RULE = 'ACTION=="add", SUBSYSTEM=="net", ATTRS{sriov_totalvfs}=="?*", RUN+="/usr/sbin/netplan apply --sriov-only"\n'


### PR DESCRIPTION
With systemd 255, the ovs integration test is hitting this limit and the test fails due to that. As it's a oneshot service, it should be OK to disable this limit.


## Description

The alternative solution is to add a delay between each OVS integration test. In my tests, the required delay to get all the tests passing was 3 seconds. This change is to avoid increasing the time spent during tests.

LP bug: https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2047827

What do you think, Lukas?

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

