### PR TITLE
ctests: stop including C files in the test files

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -31,7 +31,7 @@
  * Loading and error handling
  ****************************************************/
 
-static void
+STATIC void
 write_error_marker(GString *message, int column)
 {
     int i;
@@ -42,7 +42,7 @@ write_error_marker(GString *message, int column)
     g_string_append_printf(message, "^");
 }
 
-static char *
+STATIC char *
 get_syntax_error_context(const NetplanParser* npp, const int line_num, const int column, GError **error)
 {
     GString *message = NULL;
@@ -72,7 +72,7 @@ get_syntax_error_context(const NetplanParser* npp, const int line_num, const int
     return g_string_free(message, FALSE);
 }
 
-static char *
+STATIC char *
 get_parser_error_context(const yaml_parser_t *parser, __unused GError **error)
 {
     GString *message = NULL;

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,6 +21,16 @@ libnetplan = library(
     soversion: '0.0',
     install: true)
 
+libnetplan_testing = library(
+    'netplan_testing',
+    sources,
+    gnu_symbol_visibility: 'default',
+    c_args: ['-DUNITTESTS'],
+    dependencies: [glib, gio, yaml, uuid],
+    include_directories: inc,
+    soversion: '0.0',
+    install: false)
+
 libexec_netplan = join_paths(get_option('libexecdir'), 'netplan')
 executable(
     'generate',

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -99,7 +99,7 @@ gchar *tmp = NULL;
 
 #define DIRTY_COMPLEX(_def, _data) complex_object_is_dirty(_def, (char*)(&_data), sizeof(_data))
 
-static gboolean
+STATIC gboolean
 write_match(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     YAML_SCALAR_PLAIN(event, emitter, "match");
@@ -121,7 +121,7 @@ write_match(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefini
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_auth(yaml_event_t* event, yaml_emitter_t* emitter, NetplanAuthenticationSettings auth)
 {
     YAML_SCALAR_PLAIN(event, emitter, "auth");
@@ -145,7 +145,7 @@ write_auth(yaml_event_t* event, yaml_emitter_t* emitter, NetplanAuthenticationSe
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_bond_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     if (DIRTY(def, def->bond_params)
@@ -205,7 +205,7 @@ write_bond_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNet
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_vxlan(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     if (def->type == NETPLAN_DEF_TYPE_TUNNEL && def->tunnel.mode == NETPLAN_TUNNEL_MODE_VXLAN) {
@@ -267,7 +267,7 @@ write_vxlan(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefini
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_bridge_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def, const GArray *interfaces)
 {
     if (def->custom_bridging || DIRTY_COMPLEX(def, def->bridge_params)) {
@@ -316,7 +316,7 @@ write_bridge_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanN
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_modem_params(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     /* some modem settings to auto-detect GSM vs CDMA connections */
@@ -339,7 +339,7 @@ typedef struct {
     yaml_emitter_t* emitter;
 } _passthrough_handler_data;
 
-static void
+STATIC void
 _passthrough_handler(GQuark key_id, gpointer value, gpointer user_data)
 {
     _passthrough_handler_data *d = user_data;
@@ -348,7 +348,7 @@ _passthrough_handler(GQuark key_id, gpointer value, gpointer user_data)
 err_path: return; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_backend_settings(yaml_event_t* event, yaml_emitter_t* emitter, NetplanBackendSettings s) {
     if (s.uuid || s.name || s.passthrough) {
         YAML_SCALAR_PLAIN(event, emitter, "networkmanager");
@@ -371,7 +371,7 @@ write_backend_settings(yaml_event_t* event, yaml_emitter_t* emitter, NetplanBack
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_access_points(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     NetplanWifiAccessPoint* ap = NULL;
@@ -407,7 +407,7 @@ write_access_points(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanN
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_addresses(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     YAML_SCALAR_PLAIN(event, emitter, "addresses");
@@ -438,7 +438,7 @@ write_addresses(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDe
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_nameservers(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     YAML_SCALAR_PLAIN(event, emitter, "nameservers");
@@ -470,7 +470,7 @@ write_nameservers(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNet
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_dhcp_overrides(yaml_event_t* event, yaml_emitter_t* emitter, const char* key, const NetplanNetDefinition* def, const NetplanDHCPOverrides* data)
 {
     if (DIRTY_COMPLEX(def, *data)
@@ -500,7 +500,7 @@ write_dhcp_overrides(yaml_event_t* event, yaml_emitter_t* emitter, const char* k
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_tunnel_settings(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     YAML_NONNULL_STRING(event, emitter, "mode", netplan_tunnel_mode_name(def->tunnel.mode));
@@ -573,7 +573,7 @@ write_tunnel_settings(yaml_event_t* event, yaml_emitter_t* emitter, const Netpla
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_routes(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     if (def->routes && def->routes->len > 0) {
@@ -625,7 +625,7 @@ write_routes(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefin
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static gboolean
+STATIC gboolean
 write_openvswitch(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanOVSSettings* ovs, NetplanBackend backend, GHashTable *ovs_ports)
 {
     GHashTableIter iter;
@@ -714,7 +714,7 @@ write_openvswitch(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanOVS
 err_path: return FALSE; // LCOV_EXCL_LINE
 }
 
-static void
+STATIC void
 _serialize_yaml(
         const NetplanState* np_state,
         yaml_event_t* event,
@@ -1007,7 +1007,7 @@ err_path:
     // LCOV_EXCL_STOP
 }
 
-static int
+STATIC int
 contains_netdef_type(gconstpointer value, gconstpointer user_data)
 {
     const NetplanNetDefinition *nd = value;
@@ -1015,7 +1015,7 @@ contains_netdef_type(gconstpointer value, gconstpointer user_data)
     return nd->type == *type ? 0 : -1;
 }
 
-static gboolean
+STATIC gboolean
 netplan_netdef_list_write_yaml(const NetplanState* np_state, GList* netdefs, int out_fd, const char* out_fname, gboolean is_fallback, GError** error)
 {
     GHashTable *ovs_ports = NULL;

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -36,7 +36,7 @@
 /**
  * Append WiFi frequencies to wpa_supplicant's freq_list=
  */
-static void
+STATIC void
 wifi_append_freq(__unused gpointer key, gpointer value, gpointer user_data)
 {
     GString* s = user_data;
@@ -46,7 +46,7 @@ wifi_append_freq(__unused gpointer key, gpointer value, gpointer user_data)
 /**
  * append wowlan_triggers= string for wpa_supplicant.conf
  */
-static gboolean
+STATIC gboolean
 append_wifi_wowlan_flags(NetplanWifiWowlanFlag flag, GString* str, GError** error) {
     if (flag & NETPLAN_WIFI_WOWLAN_TYPES[0].flag || flag >= NETPLAN_WIFI_WOWLAN_TCP) {
         g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: unsupported wowlan_triggers mask: 0x%x\n", flag);
@@ -65,7 +65,7 @@ append_wifi_wowlan_flags(NetplanWifiWowlanFlag flag, GString* str, GError** erro
 /**
  * Append [Match] section of @def to @s.
  */
-static void
+STATIC void
 append_match_section(const NetplanNetDefinition* def, GString* s, gboolean match_rename)
 {
     /* Note: an empty [Match] section is interpreted as matching all devices,
@@ -105,7 +105,7 @@ append_match_section(const NetplanNetDefinition* def, GString* s, gboolean match
     }
 }
 
-static void
+STATIC void
 write_bridge_params_networkd(GString* s, const NetplanNetDefinition* def)
 {
     GString *params = NULL;
@@ -131,7 +131,7 @@ write_bridge_params_networkd(GString* s, const NetplanNetDefinition* def)
     }
 }
 
-static void
+STATIC void
 write_tunnel_params(GString* s, const NetplanNetDefinition* def)
 {
     GString *params = NULL;
@@ -155,7 +155,7 @@ write_tunnel_params(GString* s, const NetplanNetDefinition* def)
     g_string_free(params, TRUE);
 }
 
-static void
+STATIC void
 write_wireguard_params(GString* s, const NetplanNetDefinition* def)
 {
     GString *params = NULL;
@@ -218,7 +218,7 @@ write_wireguard_params(GString* s, const NetplanNetDefinition* def)
     }
 }
 
-static void
+STATIC void
 write_link_file(const NetplanNetDefinition* def, const char* rootdir, const char* path)
 {
     GString* s = NULL;
@@ -289,7 +289,7 @@ write_link_file(const NetplanNetDefinition* def, const char* rootdir, const char
     umask(orig_umask);
 }
 
-static gboolean
+STATIC gboolean
 write_regdom(const NetplanNetDefinition* def, const char* rootdir, GError** error)
 {
     g_assert(def->regulatory_domain);
@@ -316,7 +316,7 @@ write_regdom(const NetplanNetDefinition* def, const char* rootdir, GError** erro
 }
 
 
-static gboolean
+STATIC gboolean
 interval_has_suffix(const char* param) {
     gchar* endptr;
 
@@ -328,7 +328,7 @@ interval_has_suffix(const char* param) {
 }
 
 
-static void
+STATIC void
 write_bond_parameters(const NetplanNetDefinition* def, GString* s)
 {
     GString* params = NULL;
@@ -407,7 +407,7 @@ write_bond_parameters(const NetplanNetDefinition* def, GString* s)
     g_string_free(params, TRUE);
 }
 
-static void
+STATIC void
 write_vxlan_parameters(const NetplanNetDefinition* def, GString* s)
 {
     g_assert(def->vxlan);
@@ -480,7 +480,7 @@ write_vxlan_parameters(const NetplanNetDefinition* def, GString* s)
     g_string_free(params, TRUE);
 }
 
-static void
+STATIC void
 write_netdev_file(const NetplanNetDefinition* def, const char* rootdir, const char* path)
 {
     GString* s = NULL;
@@ -587,7 +587,7 @@ write_netdev_file(const NetplanNetDefinition* def, const char* rootdir, const ch
     umask(orig_umask);
 }
 
-static void
+STATIC void
 write_route(NetplanIPRoute* r, GString* s)
 {
     const char *to;
@@ -622,7 +622,7 @@ write_route(NetplanIPRoute* r, GString* s)
         g_string_append_printf(s, "InitialAdvertisedReceiveWindow=%u\n", r->advertised_receive_window);
 }
 
-static void
+STATIC void
 write_ip_rule(NetplanIPRule* r, GString* s)
 {
     g_string_append_printf(s, "\n[RoutingPolicyRule]\n");
@@ -642,7 +642,7 @@ write_ip_rule(NetplanIPRule* r, GString* s)
         g_string_append_printf(s, "TypeOfService=%d\n", r->tos);
 }
 
-static void
+STATIC void
 write_addr_option(NetplanAddressOptions* o, GString* s)
 {
     g_string_append_printf(s, "\n[Address]\n");
@@ -659,7 +659,7 @@ write_addr_option(NetplanAddressOptions* o, GString* s)
     "ERROR: %s: networkd requires that %s has the same value in both "  \
     "dhcp4_overrides and dhcp6_overrides\n"
 
-static gboolean
+STATIC gboolean
 combine_dhcp_overrides(const NetplanNetDefinition* def, NetplanDHCPOverrides* combined_dhcp_overrides, GError** error)
 {
     /* if only one of dhcp4 or dhcp6 is enabled, those overrides are used */
@@ -990,7 +990,7 @@ netplan_netdef_write_network_file(
     return TRUE;
 }
 
-static void
+STATIC void
 write_rules_file(const NetplanNetDefinition* def, const char* rootdir)
 {
     GString* s = NULL;
@@ -1034,7 +1034,7 @@ write_rules_file(const NetplanNetDefinition* def, const char* rootdir)
     umask(orig_umask);
 }
 
-static gboolean
+STATIC gboolean
 append_wpa_auth_conf(GString* s, const NetplanAuthenticationSettings* auth, const char* id, GError** error)
 {
     switch (auth->key_management) {
@@ -1176,7 +1176,7 @@ append_wpa_auth_conf(GString* s, const NetplanAuthenticationSettings* auth, cons
 }
 
 /* netplan-feature: generated-supplicant */
-static void
+STATIC void
 write_wpa_unit(const NetplanNetDefinition* def, const char* rootdir)
 {
     g_autofree gchar *stdouth = NULL;
@@ -1204,7 +1204,7 @@ write_wpa_unit(const NetplanNetDefinition* def, const char* rootdir)
     umask(orig_umask);
 }
 
-static gboolean
+STATIC gboolean
 write_wpa_conf(const NetplanNetDefinition* def, const char* rootdir, GError** error)
 {
     GHashTableIter iter;

--- a/src/nm.c
+++ b/src/nm.c
@@ -42,7 +42,7 @@
  * This is done by checking for certain modem_params, which are only
  * applicable to GSM connections.
  */
-static gboolean
+STATIC gboolean
 modem_is_gsm(const NetplanNetDefinition* def)
 {
     if (   def->modem_params.apn
@@ -60,7 +60,7 @@ modem_is_gsm(const NetplanNetDefinition* def)
 /**
  * Return NM "type=" string.
  */
-static char*
+STATIC char*
 type_str(const NetplanNetDefinition* def)
 {
     const NetplanDefType type = def->type;
@@ -111,7 +111,7 @@ type_str(const NetplanNetDefinition* def)
 /**
  * Return NM wifi "mode=" string.
  */
-static char*
+STATIC char*
 wifi_mode_str(const NetplanWifiMode mode)
 {
     switch (mode) {
@@ -131,7 +131,7 @@ wifi_mode_str(const NetplanWifiMode mode)
 /**
  * Return NM wifi "band=" string.
  */
-static char*
+STATIC char*
 wifi_band_str(const NetplanWifiBand band)
 {
     switch (band) {
@@ -149,7 +149,7 @@ wifi_band_str(const NetplanWifiBand band)
 /**
  * Return NM addr-gen-mode string.
  */
-static char*
+STATIC char*
 addr_gen_mode_str(const NetplanAddrGenMode mode)
 {
     switch (mode) {
@@ -164,7 +164,7 @@ addr_gen_mode_str(const NetplanAddrGenMode mode)
     }
 }
 
-static void
+STATIC void
 write_search_domains(const NetplanNetDefinition* def, const char* group, GKeyFile *kf)
 {
     if (def->search_domains) {
@@ -175,7 +175,7 @@ write_search_domains(const NetplanNetDefinition* def, const char* group, GKeyFil
     }
 }
 
-static gboolean
+STATIC gboolean
 write_routes_nm(const NetplanNetDefinition* def, GKeyFile *kf, gint family, GError** error)
 {
     const gchar* group = NULL;
@@ -255,8 +255,8 @@ write_routes_nm(const NetplanNetDefinition* def, GKeyFile *kf, gint family, GErr
     return TRUE;
 }
 
-static void
-write_bond_parameters(const NetplanNetDefinition* def, GKeyFile *kf)
+STATIC void
+write_nm_bond_parameters(const NetplanNetDefinition* def, GKeyFile *kf)
 {
     GString* tmp_val = NULL;
     if (def->bond_params.mode)
@@ -313,7 +313,7 @@ write_bond_parameters(const NetplanNetDefinition* def, GKeyFile *kf)
         g_key_file_set_string(kf, "bond", "primary", def->bond_params.primary_member);
 }
 
-static void
+STATIC void
 write_bridge_params_nm(const NetplanNetDefinition* def, GKeyFile *kf)
 {
     if (def->custom_bridging) {
@@ -331,8 +331,8 @@ write_bridge_params_nm(const NetplanNetDefinition* def, GKeyFile *kf)
     }
 }
 
-static gboolean
-write_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError** error)
+STATIC gboolean
+write_nm_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError** error)
 {
     /* The key was already validated via validate_tunnel_grammar(), but we need
      * to differentiate between base64 key VS absolute path key-file. And a base64
@@ -389,8 +389,8 @@ write_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError** e
     return TRUE;
 }
 
-static void
-write_tunnel_params(const NetplanNetDefinition* def, GKeyFile *kf)
+STATIC void
+write_nm_tunnel_params(const NetplanNetDefinition* def, GKeyFile *kf)
 {
     g_key_file_set_integer(kf, "ip-tunnel", "mode", def->tunnel.mode);
     if (def->tunnel.local_ip)
@@ -404,7 +404,7 @@ write_tunnel_params(const NetplanNetDefinition* def, GKeyFile *kf)
         g_key_file_set_string(kf, "ip-tunnel", "output-key", def->tunnel.output_key);
 }
 
-static void
+STATIC void
 write_dot1x_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile *kf)
 {
     switch (auth->eap_method) {
@@ -448,7 +448,7 @@ write_dot1x_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile 
         g_key_file_set_string(kf, "802-1x", "phase2-auth", auth->phase2_auth);
 }
 
-static void
+STATIC void
 write_wifi_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile *kf)
 {
     switch (auth->key_management) {
@@ -498,15 +498,15 @@ write_wifi_auth_parameters(const NetplanAuthenticationSettings* auth, GKeyFile *
         g_key_file_set_string(kf, "wifi-security", "psk", auth->password);
 }
 
-static void
+STATIC void
 maybe_generate_uuid(const NetplanNetDefinition* def)
 {
     if (uuid_is_null(def->uuid))
         uuid_generate((unsigned char*)def->uuid);
 }
 
-static void
-write_vxlan_parameters(const NetplanNetDefinition* def, GKeyFile* kf)
+STATIC void
+write_nm_vxlan_parameters(const NetplanNetDefinition* def, GKeyFile* kf)
 {
     g_assert(def->vxlan);
     char uuidstr[37];
@@ -563,7 +563,7 @@ write_vxlan_parameters(const NetplanNetDefinition* def, GKeyFile* kf)
  * Special handling for passthrough mode: read key-value pairs from
  * "backend_settings.passthrough" and inject them into the keyfile as-is.
  */
-static void
+STATIC void
 write_fallback_key_value(GQuark key_id, gpointer value, gpointer user_data)
 {
     GKeyFile *kf = user_data;
@@ -620,7 +620,7 @@ write_fallback_key_value(GQuark key_id, gpointer value, gpointer user_data)
  * @ap: The access point for which to create a connection. Must be %NULL for
  *      non-wifi types.
  */
-static gboolean
+STATIC gboolean
 write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir, const NetplanWifiAccessPoint* ap, GError** error)
 {
     g_autoptr(GKeyFile) kf = NULL;
@@ -815,16 +815,16 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
     }
 
     if (def->type == NETPLAN_DEF_TYPE_BOND)
-        write_bond_parameters(def, kf);
+        write_nm_bond_parameters(def, kf);
 
     if (def->type == NETPLAN_DEF_TYPE_TUNNEL) {
         if (def->tunnel.mode == NETPLAN_TUNNEL_MODE_WIREGUARD) {
-            if (!write_wireguard_params(def, kf, error))
+            if (!write_nm_wireguard_params(def, kf, error))
                 return FALSE;
         } else if (def->tunnel.mode == NETPLAN_TUNNEL_MODE_VXLAN) {
-            write_vxlan_parameters(def, kf);
+            write_nm_vxlan_parameters(def, kf);
         } else
-            write_tunnel_params(def, kf);
+            write_nm_tunnel_params(def, kf);
     }
 
     if (match_interface_name) {

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -29,7 +29,7 @@
 #include "util.h"
 #include "util-internal.h"
 
-static gboolean
+STATIC gboolean
 write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir, gboolean physical, gboolean cleanup, const char* dependency, GError** error)
 {
     g_autofree gchar* id_escaped = NULL;
@@ -86,7 +86,7 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
     g_string_append(s, "\n"); \
 }
 
-static char*
+STATIC char*
 netplan_type_to_table_name(const NetplanDefType type)
 {
     switch (type) {
@@ -100,7 +100,7 @@ netplan_type_to_table_name(const NetplanDefType type)
     }
 }
 
-static gboolean
+STATIC gboolean
 netplan_type_is_physical(const NetplanDefType type)
 {
     switch (type) {
@@ -113,7 +113,7 @@ netplan_type_is_physical(const NetplanDefType type)
     }
 }
 
-static void
+STATIC void
 write_ovs_tag_setting(const gchar* id, const char* type, const char* col, const char* key, const char* value, GString* cmds)
 {
     g_assert(col);
@@ -136,7 +136,7 @@ write_ovs_tag_setting(const gchar* id, const char* type, const char* col, const 
     g_string_free(s, TRUE);
 }
 
-static void
+STATIC void
 write_ovs_additional_data(GHashTable *data, const char* type, const gchar* id, GString* cmds, const char* setting)
 {
     GHashTableIter iter;
@@ -153,7 +153,7 @@ write_ovs_additional_data(GHashTable *data, const char* type, const gchar* id, G
     }
 }
 
-static void
+STATIC void
 setup_patch_port(GString* s, const NetplanNetDefinition* def)
 {
     /* Execute the setup commands to create an OVS patch port atomically within
@@ -165,7 +165,7 @@ setup_patch_port(GString* s, const NetplanNetDefinition* def)
                            def->id, def->peer);
 }
 
-static char*
+STATIC char*
 write_ovs_bond_interfaces(const NetplanState* np_state, const NetplanNetDefinition* def, GString* cmds, GError** error)
 {
     NetplanNetDefinition* tmp_nd;
@@ -203,7 +203,7 @@ write_ovs_bond_interfaces(const NetplanState* np_state, const NetplanNetDefiniti
     return def->bridge;
 }
 
-static void
+STATIC void
 write_ovs_tag_netplan(const gchar* id, const char* type, GString* cmds)
 {
     /* Mark this bridge/port/interface as created by netplan */
@@ -211,7 +211,7 @@ write_ovs_tag_netplan(const gchar* id, const char* type, GString* cmds)
                        type, id);
 }
 
-static gboolean
+STATIC gboolean
 write_ovs_bond_mode(const NetplanNetDefinition* def, GString* cmds, GError** error)
 {
     char* value = NULL;
@@ -231,7 +231,7 @@ write_ovs_bond_mode(const NetplanNetDefinition* def, GString* cmds, GError** err
     return TRUE;
 }
 
-static void
+STATIC void
 write_ovs_bridge_interfaces(const NetplanState* np_state, const NetplanNetDefinition* def, GString* cmds)
 {
     NetplanNetDefinition* tmp_nd;
@@ -255,7 +255,7 @@ write_ovs_bridge_interfaces(const NetplanState* np_state, const NetplanNetDefini
     }
 }
 
-static void
+STATIC void
 write_ovs_protocols(const NetplanOVSSettings* ovs_settings, const gchar* bridge, GString* cmds)
 {
     g_assert(bridge);
@@ -269,7 +269,7 @@ write_ovs_protocols(const NetplanOVSSettings* ovs_settings, const gchar* bridge,
     g_string_free(s, TRUE);
 }
 
-static gboolean
+STATIC gboolean
 check_ovs_ssl(const NetplanOVSSettings* settings, gchar* target, gboolean* needs_ssl, GError** error)
 {
     /* Check if target needs ssl */
@@ -287,7 +287,7 @@ check_ovs_ssl(const NetplanOVSSettings* settings, gchar* target, gboolean* needs
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 write_ovs_bridge_controller_targets(const NetplanOVSSettings* settings, const NetplanOVSController* controller, const gchar* bridge, GString* cmds, GError** error)
 {
     gchar* target = g_array_index(controller->addresses, char*, 0);

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -34,7 +34,7 @@
  * https://bugzilla.gnome.org/show_bug.cgi?id=696940
  * https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/c36200a225aefb2a3919618e75682646899b82c0
  */
-static NetplanDefType
+STATIC NetplanDefType
 type_from_str(const char* type_str)
 {
     if (!g_strcmp0(type_str, "ethernet") || !g_strcmp0(type_str, "802-3-ethernet"))
@@ -63,7 +63,7 @@ type_from_str(const char* type_str)
     return NETPLAN_DEF_TYPE_NM;
 }
 
-static NetplanWifiMode
+STATIC NetplanWifiMode
 ap_type_from_str(const char* type_str)
 {
     if (!g_strcmp0(type_str, "infrastructure"))
@@ -76,7 +76,7 @@ ap_type_from_str(const char* type_str)
     return NETPLAN_WIFI_MODE_OTHER;
 }
 
-static NetplanTunnelMode
+STATIC NetplanTunnelMode
 tunnel_mode_from_str(const char* type_str)
 {
     if (!g_strcmp0(type_str, "wireguard"))
@@ -87,7 +87,7 @@ tunnel_mode_from_str(const char* type_str)
     return NETPLAN_TUNNEL_MODE_UNKNOWN;
 }
 
-static void
+STATIC void
 _kf_clear_key(GKeyFile* kf, const gchar* group, const gchar* key)
 {
     gsize len = 1;
@@ -98,14 +98,14 @@ _kf_clear_key(GKeyFile* kf, const gchar* group, const gchar* key)
         g_key_file_remove_group(kf, group, NULL);
 }
 
-static gboolean
+STATIC gboolean
 kf_matches(GKeyFile* kf, const gchar* group, const gchar* key, const gchar* match)
 {
     g_autofree gchar *kf_value = g_key_file_get_string(kf, group, key, NULL);
     return g_strcmp0(kf_value, match) == 0;
 }
 
-static void
+STATIC void
 set_true_on_match(GKeyFile* kf, const gchar* group, const gchar* key, const gchar* match, const void* dataptr)
 {
     g_assert(dataptr);
@@ -115,7 +115,7 @@ set_true_on_match(GKeyFile* kf, const gchar* group, const gchar* key, const gcha
     }
 }
 
-static void
+STATIC void
 keyfile_handle_generic_bool(GKeyFile* kf, const gchar* group, const gchar* key, gboolean* dataptr)
 {
     g_assert(dataptr);
@@ -123,7 +123,7 @@ keyfile_handle_generic_bool(GKeyFile* kf, const gchar* group, const gchar* key, 
     _kf_clear_key(kf, group, key);
 }
 
-static void
+STATIC void
 keyfile_handle_generic_str(GKeyFile* kf, const gchar* group, const gchar* key, char** dataptr)
 {
     g_assert(dataptr);
@@ -133,7 +133,7 @@ keyfile_handle_generic_str(GKeyFile* kf, const gchar* group, const gchar* key, c
         _kf_clear_key(kf, group, key);
 }
 
-static void
+STATIC void
 keyfile_handle_generic_uint(GKeyFile* kf, const gchar* group, const gchar* key, guint* dataptr, guint default_value)
 {
     g_assert(dataptr);
@@ -145,7 +145,7 @@ keyfile_handle_generic_uint(GKeyFile* kf, const gchar* group, const gchar* key, 
     }
 }
 
-static void
+STATIC void
 keyfile_handle_common(GKeyFile* kf, NetplanNetDefinition* nd, const gchar* group) {
     keyfile_handle_generic_uint(kf, group, "mtu", &nd->mtubytes, NETPLAN_MTU_UNSPEC);
     keyfile_handle_generic_str(kf, group, "mac-address", &nd->match.mac);
@@ -153,7 +153,7 @@ keyfile_handle_common(GKeyFile* kf, NetplanNetDefinition* nd, const gchar* group
         nd->has_match = TRUE;
 }
 
-static void
+STATIC void
 keyfile_handle_bridge_uint(GKeyFile* kf, const gchar* key, NetplanNetDefinition* nd, char** dataptr) {
     if (g_key_file_get_uint64(kf, "bridge", key, NULL)) {
         nd->custom_bridging = TRUE;
@@ -162,7 +162,7 @@ keyfile_handle_bridge_uint(GKeyFile* kf, const gchar* key, NetplanNetDefinition*
     }
 }
 
-static void
+STATIC void
 keyfile_handle_cloned_mac_address(GKeyFile *kf, NetplanNetDefinition* nd, const gchar* group)
 {
     g_autofree gchar* mac = g_key_file_get_string(kf, group, "cloned-mac-address", NULL);
@@ -182,7 +182,7 @@ keyfile_handle_cloned_mac_address(GKeyFile *kf, NetplanNetDefinition* nd, const 
     }
 }
 
-static void
+STATIC void
 parse_addresses(GKeyFile* kf, const gchar* group, GArray** ip_arr)
 {
     g_assert(ip_arr);
@@ -222,7 +222,7 @@ parse_addresses(GKeyFile* kf, const gchar* group, GArray** ip_arr)
     }
 }
 
-static void
+STATIC void
 parse_routes(GKeyFile* kf, const gchar* group, GArray** routes_arr)
 {
     g_assert(routes_arr);
@@ -310,7 +310,7 @@ parse_routes(GKeyFile* kf, const gchar* group, GArray** routes_arr)
     }
 }
 
-static void
+STATIC void
 parse_dhcp_overrides(GKeyFile* kf, const gchar* group, NetplanDHCPOverrides* dataptr)
 {
     g_assert(dataptr);
@@ -351,7 +351,7 @@ parse_search_domains(GKeyFile* kf, const gchar* group, GArray** domains_arr)
 }
 */
 
-static void
+STATIC void
 parse_nameservers(GKeyFile* kf, const gchar* group, GArray** nameserver_arr)
 {
     g_assert(nameserver_arr);
@@ -370,7 +370,7 @@ parse_nameservers(GKeyFile* kf, const gchar* group, GArray** nameserver_arr)
     }
 }
 
-static void
+STATIC void
 parse_dot1x_auth(GKeyFile* kf, NetplanAuthenticationSettings* auth)
 {
     g_assert(auth);
@@ -420,7 +420,7 @@ parse_dot1x_auth(GKeyFile* kf, NetplanAuthenticationSettings* auth)
     keyfile_handle_generic_str(kf, "802-1x", "phase2-auth", &auth->phase2_auth);
 }
 
-static void
+STATIC void
 parse_bond_arp_ip_targets(GKeyFile* kf, GArray **targets_arr)
 {
     g_assert(targets_arr);
@@ -439,7 +439,7 @@ parse_bond_arp_ip_targets(GKeyFile* kf, GArray **targets_arr)
 }
 
 /* Read the key-value pairs from the keyfile and pass them through to a map */
-static void
+STATIC void
 read_passthrough(GKeyFile* kf, GData** list)
 {
     gchar **groups = NULL;
@@ -486,7 +486,7 @@ read_passthrough(GKeyFile* kf, GData** list)
  * Each of these three classes have different requirements so we handle them separately
  * in this function.
  */
-static void
+STATIC void
 parse_tunnels(GKeyFile* kf, NetplanNetDefinition* nd)
 {
     /* Handle wireguard tunnel */

--- a/src/parse.c
+++ b/src/parse.c
@@ -55,7 +55,7 @@
     dst = g_strdup(src); \
 } }
 
-static gboolean
+STATIC gboolean
 insert_kv_into_hash(void *key, void *value, void *hash);
 
 /**
@@ -66,7 +66,7 @@ insert_kv_into_hash(void *key, void *value, void *hash);
  *
  * Returns: TRUE on success, FALSE if the document is malformed; @error gets set then.
  */
-static gboolean
+STATIC gboolean
 load_yaml_from_fd(int input_fd, yaml_document_t* doc, GError** error)
 {
     int in_dup = -1;
@@ -109,7 +109,7 @@ file_error:
  *
  * Returns: TRUE on success, FALSE if the document is malformed; @error gets set then.
  */
-static gboolean
+STATIC gboolean
 load_yaml(const char* yaml, yaml_document_t* doc, GError** error)
 {
     FILE* fyaml = NULL;
@@ -138,7 +138,7 @@ load_yaml(const char* yaml, yaml_document_t* doc, GError** error)
 /**
  * Raise a GError about a type mismatch and return FALSE.
  */
-static gboolean
+STATIC gboolean
 assert_type_fn(const NetplanParser* npp, yaml_node_t* node, yaml_node_type_t expected_type, GError** error)
 {
     if (node->type == expected_type)
@@ -175,7 +175,7 @@ scalar(const yaml_node_t* node)
     return (const char*) node->data.scalar.value;
 }
 
-static void
+STATIC void
 add_missing_node(NetplanParser *npp, const yaml_node_t* node)
 {
     NetplanMissingNode* missing;
@@ -195,7 +195,7 @@ add_missing_node(NetplanParser *npp, const yaml_node_t* node)
 /**
  * Check that node contains a valid ID/interface name. Raise GError if not.
  */
-static gboolean
+STATIC gboolean
 assert_valid_id(const NetplanParser* npp, yaml_node_t* node, GError** error)
 {
     static regex_t re;
@@ -257,7 +257,7 @@ typedef struct mapping_entry_handler_s {
 /**
  * Return the #mapping_entry_handler that matches @key, or NULL if not found.
  */
-static const mapping_entry_handler*
+STATIC const mapping_entry_handler*
 get_handler(const mapping_entry_handler* handlers, const char* key)
 {
     for (unsigned i = 0; handlers[i].key != NULL; ++i) {
@@ -276,7 +276,7 @@ get_handler(const mapping_entry_handler* handlers, const char* key)
  *
  * Returns: TRUE on success, FALSE on error (@error gets set then).
  */
-static gboolean
+STATIC gboolean
 process_mapping(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const mapping_entry_handler* handlers, GList** out_values, GError** error)
 {
     yaml_node_pair_t* entry;
@@ -331,7 +331,7 @@ process_mapping(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, c
  * @entryptr: pointer to the begining of the to-be-modified data structure
  * @data: offset into entryptr struct where the guint field to write is located
  */
-static gboolean
+STATIC gboolean
 handle_generic_guint(NetplanParser* npp, yaml_node_t* node, const void* entryptr, const void* data, GError** error)
 {
     g_assert(entryptr);
@@ -354,7 +354,7 @@ handle_generic_guint(NetplanParser* npp, yaml_node_t* node, const void* entryptr
  * @data: offset into entryptr struct where the const char* field to write is
  *        located
  */
-static gboolean
+STATIC gboolean
 handle_generic_str(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, __unused GError** error)
 {
     g_assert(entryptr);
@@ -372,7 +372,7 @@ handle_generic_str(NetplanParser* npp, yaml_node_t* node, void* entryptr, const 
  * @data: offset into entryptr struct where the const char* field to write is
  *        located
  */
-static gboolean
+STATIC gboolean
 handle_generic_mac(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
     g_assert(entryptr);
@@ -397,7 +397,7 @@ handle_generic_mac(NetplanParser* npp, yaml_node_t* node, void* entryptr, const 
  * @entryptr: pointer to the beginning of the to-be-modified data structure
  * @data: offset into entryptr struct where the boolean field to write is located
  */
-static gboolean
+STATIC gboolean
 handle_generic_bool(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
     g_assert(entryptr);
@@ -428,7 +428,7 @@ handle_generic_bool(NetplanParser* npp, yaml_node_t* node, void* entryptr, const
  * @entryptr: pointer to the beginning of the to-be-modified data structure
  * @data: offset into entryptr struct where the boolean field to write is located
  */
-static gboolean
+STATIC gboolean
 handle_generic_tristate(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
     g_assert(entryptr);
@@ -459,7 +459,7 @@ handle_generic_tristate(NetplanParser* npp, yaml_node_t* node, void* entryptr, c
  * @entryptr: pointer to the beginning of the to-be-modified data structure
  * @data: offset into entryptr struct where the boolean field to write is located
 */
-static gboolean
+STATIC gboolean
 handle_generic_map(NetplanParser *npp, yaml_node_t* node, const char* key_prefix, void* entryptr, const void* data, GError** error)
 {
     guint offset = GPOINTER_TO_UINT(data);
@@ -503,7 +503,7 @@ handle_generic_map(NetplanParser *npp, yaml_node_t* node, const char* key_prefix
  * @entryptr: pointer to the beginning of the to-be-modified data structure
  * @data: offset into entryptr struct where the boolean field to write is located
 */
-static gboolean
+STATIC gboolean
 handle_generic_datalist(NetplanParser *npp, yaml_node_t* node, const char* key_prefix, void* entryptr, const void* data, GError** error)
 {
     guint offset = GPOINTER_TO_UINT(data);
@@ -539,7 +539,7 @@ handle_generic_datalist(NetplanParser *npp, yaml_node_t* node, const char* key_p
  * @data: offset into NetplanNetDefinition where the const char* field to write is
  *        located
  */
-static gboolean
+STATIC gboolean
 handle_netdef_str(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_str(npp, node, npp->current.netdef, data, error);
@@ -550,7 +550,7 @@ handle_netdef_str(NetplanParser* npp, yaml_node_t* node, const void* data, GErro
  * @data: offset into NetplanNetDefinition where the const char* field to write is
  *        located
  */
-static gboolean
+STATIC gboolean
 handle_netdef_id(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (!assert_valid_id(npp, node, error))
@@ -558,7 +558,7 @@ handle_netdef_id(NetplanParser* npp, yaml_node_t* node, const void* data, GError
     return handle_netdef_str(npp, node, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_embedded_switch_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (g_strcmp0(scalar(node), "switchdev") != 0 && g_strcmp0(scalar(node), "legacy") != 0)
@@ -567,7 +567,7 @@ handle_embedded_switch_mode(NetplanParser* npp, yaml_node_t* node, const void* d
     return handle_netdef_str(npp, node, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_ib_mode(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     if (g_strcmp0(scalar(node), "datagram") == 0)
@@ -587,7 +587,7 @@ handle_ib_mode(NetplanParser* npp, yaml_node_t* node, __unused const void* data,
  * @data: offset into NetplanNetDefinition where the NetplanNetDefinition* field to write is
  *        located
  */
-static gboolean
+STATIC gboolean
 handle_netdef_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, __unused GError** error)
 {
     guint offset = GPOINTER_TO_UINT(data);
@@ -616,7 +616,7 @@ handle_netdef_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, __
  * @data: offset into NetplanVxlan where the NetplanNetDefinition* field to
  *        write is located
  */
-static gboolean
+STATIC gboolean
 handle_vxlan_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, __unused GError** error)
 {
     guint offset = GPOINTER_TO_UINT(data);
@@ -639,7 +639,7 @@ handle_vxlan_id_ref(NetplanParser* npp, yaml_node_t* node, const void* data, __u
  * @data: offset into NetplanNetDefinition where the const char* field to write is
  *        located
  */
-static gboolean
+STATIC gboolean
 handle_netdef_mac(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_mac(npp, node, npp->current.netdef, data, error);
@@ -649,7 +649,7 @@ handle_netdef_mac(NetplanParser* npp, yaml_node_t* node, const void* data, GErro
  * Generic handler for setting a npp->current.netdef gboolean field from a scalar node
  * @data: offset into NetplanNetDefinition where the gboolean field to write is located
  */
-static gboolean
+STATIC gboolean
 handle_netdef_bool(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_bool(npp, node, npp->current.netdef, data, error);
@@ -659,7 +659,7 @@ handle_netdef_bool(NetplanParser* npp, yaml_node_t* node, const void* data, GErr
  * Generic handler for tri-state settings that can bei "UNSET", "TRUE", or "FALSE".
  * @data: offset into NetplanNetDefinition where the guint field to write is located
  */
-static gboolean
+STATIC gboolean
 handle_netdef_tristate(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_tristate(npp, node, npp->current.netdef, data, error);
@@ -669,13 +669,13 @@ handle_netdef_tristate(NetplanParser* npp, yaml_node_t* node, const void* data, 
  * Generic handler for setting a npp->current.netdef guint field from a scalar node
  * @data: offset into NetplanNetDefinition where the guint field to write is located
  */
-static gboolean
+STATIC gboolean
 handle_netdef_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_guint(npp, node, npp->current.netdef, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_netdef_ip4(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     guint offset = GPOINTER_TO_UINT(data);
@@ -706,7 +706,7 @@ handle_netdef_ip4(NetplanParser* npp, yaml_node_t* node, const void* data, GErro
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_netdef_ip6(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     guint offset = GPOINTER_TO_UINT(data);
@@ -737,7 +737,7 @@ handle_netdef_ip6(NetplanParser* npp, yaml_node_t* node, const void* data, GErro
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_netdef_addrgen(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     g_assert(npp->current.netdef);
@@ -750,7 +750,7 @@ handle_netdef_addrgen(NetplanParser* npp, yaml_node_t* node, __unused const void
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_netdef_addrtok(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_assert(npp->current.netdef);
@@ -760,14 +760,14 @@ handle_netdef_addrtok(NetplanParser* npp, yaml_node_t* node, const void* data, G
     return ret;
 }
 
-static gboolean
+STATIC gboolean
 handle_netdef_map(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* data, GError** error)
 {
     g_assert(npp->current.netdef);
     return handle_generic_map(npp, node, key_prefix, npp->current.netdef, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_netdef_backend_settings_str(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     npp->current.netdef->has_backend_settings_nm = TRUE;
@@ -778,7 +778,7 @@ handle_netdef_backend_settings_str(NetplanParser* npp, yaml_node_t* node, const 
  * Check if the passthrough key format is incorrect and remove it from the list.
  * user_data is expected to contain a pointer to the GData list.
  */
-static void
+STATIC void
 validate_kf_group_key(GQuark key_id, __unused gpointer value, gpointer user_data)
 {
     GData** list = user_data;
@@ -791,7 +791,7 @@ validate_kf_group_key(GQuark key_id, __unused gpointer value, gpointer user_data
     g_strfreev(group_key);
 }
 
-static gboolean
+STATIC gboolean
 handle_netdef_passthrough_datalist(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* data, GError** error)
 {
     g_assert(npp->current.netdef);
@@ -809,7 +809,7 @@ handle_netdef_passthrough_datalist(NetplanParser* npp, yaml_node_t* node, const 
     return ret;
 }
 
-static gboolean
+STATIC gboolean
 handle_veth_peer(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     NetplanNetDefinition* netdef = npp->current.netdef;
@@ -842,7 +842,7 @@ handle_veth_peer(NetplanParser* npp, yaml_node_t* node, __unused const void* dat
  * Grammar and handlers for network config "match" entry
  ****************************************************/
 
-static gboolean
+STATIC gboolean
 handle_match_driver(NetplanParser* npp, yaml_node_t* node, __unused const char* key_prefix, __unused const void* _, GError** error)
 {
     gboolean ret = FALSE;
@@ -880,7 +880,7 @@ handle_match_driver(NetplanParser* npp, yaml_node_t* node, __unused const char* 
     return ret;
 }
 
-static const mapping_entry_handler match_handlers[] = {
+STATIC const mapping_entry_handler match_handlers[] = {
     {"driver", YAML_NO_NODE, {.variable=handle_match_driver}, NULL},
     {"macaddress", YAML_SCALAR_NODE, {.generic=handle_netdef_mac}, netdef_offset(match.mac)},
     {"name", YAML_SCALAR_NODE, {.generic=handle_netdef_id}, netdef_offset(match.original_name)},
@@ -891,7 +891,7 @@ static const mapping_entry_handler match_handlers[] = {
  * Grammar and handlers for network config "auth" entry
  ****************************************************/
 
-static gboolean
+STATIC gboolean
 handle_auth_str(NetplanParser* npp, yaml_node_t* node, const void* data, __unused GError** error)
 {
     g_assert(npp->current.auth);
@@ -903,7 +903,7 @@ handle_auth_str(NetplanParser* npp, yaml_node_t* node, const void* data, __unuse
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_auth_key_management(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanAuthenticationSettings* auth = npp->current.auth;
@@ -942,7 +942,7 @@ handle_auth_key_management(NetplanParser* npp, yaml_node_t* node, __unused const
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_auth_method(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanAuthenticationSettings* auth = npp->current.auth;
@@ -962,7 +962,7 @@ handle_auth_method(NetplanParser* npp, yaml_node_t* node, __unused const void* _
     return TRUE;
 }
 
-static const mapping_entry_handler auth_handlers[] = {
+STATIC const mapping_entry_handler auth_handlers[] = {
     {"key-management", YAML_SCALAR_NODE, {.generic=handle_auth_key_management}, NULL},
     {"method", YAML_SCALAR_NODE, {.generic=handle_auth_method}, NULL},
     {"identity", YAML_SCALAR_NODE, {.generic=handle_auth_str}, auth_offset(identity)},
@@ -991,14 +991,14 @@ get_default_backend_for_type(NetplanBackend global_backend, __unused NetplanDefT
     return NETPLAN_BACKEND_NETWORKD;
 }
 
-static gboolean
+STATIC gboolean
 handle_ap_backend_settings_str(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     npp->current.netdef->has_backend_settings_nm = TRUE;
     return handle_generic_str(npp, node, npp->current.access_point, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_access_point_datalist(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* data, GError** error)
 {
     g_assert(npp->current.access_point);
@@ -1016,25 +1016,25 @@ handle_access_point_datalist(NetplanParser* npp, yaml_node_t* node, const char* 
     return ret;
 }
 
-static gboolean
+STATIC gboolean
 handle_access_point_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_guint(npp, node, npp->current.access_point, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_access_point_mac(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_mac(npp, node, npp->current.access_point, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_access_point_bool(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_bool(npp, node, npp->current.access_point, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_access_point_password(NetplanParser* npp, yaml_node_t* node, __unused const void* _, __unused GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
@@ -1050,7 +1050,7 @@ handle_access_point_password(NetplanParser* npp, yaml_node_t* node, __unused con
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_access_point_auth(NetplanParser* npp, yaml_node_t* node, __unused const char* key_prefix, __unused const void* _, GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
@@ -1066,7 +1066,7 @@ handle_access_point_auth(NetplanParser* npp, yaml_node_t* node, __unused const c
     return ret;
 }
 
-static gboolean
+STATIC gboolean
 handle_access_point_mode(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
@@ -1082,7 +1082,7 @@ handle_access_point_mode(NetplanParser* npp, yaml_node_t* node, __unused const v
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_access_point_band(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
@@ -1096,7 +1096,7 @@ handle_access_point_band(NetplanParser* npp, yaml_node_t* node, __unused const v
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_tunnel_key_flags(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
@@ -1157,7 +1157,7 @@ static const mapping_entry_handler wifi_access_point_handlers[] = {
 /**
  * Parse scalar node's string into a netdef_backend.
  */
-static gboolean
+STATIC gboolean
 parse_renderer(NetplanParser* npp, yaml_node_t* node, NetplanBackend* backend, GError** error)
 {
     if (strcmp(scalar(node), "networkd") == 0)
@@ -1170,7 +1170,7 @@ parse_renderer(NetplanParser* npp, yaml_node_t* node, NetplanBackend* backend, G
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_netdef_renderer(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (npp->current.netdef->type == NETPLAN_DEF_TYPE_VLAN) {
@@ -1183,7 +1183,7 @@ handle_netdef_renderer(NetplanParser* npp, yaml_node_t* node, __unused const voi
     return parse_renderer(npp, node, &npp->current.netdef->backend, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_accept_ra(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     gboolean ret = handle_generic_bool(npp, node, npp->current.netdef, data, error);
@@ -1194,7 +1194,7 @@ handle_accept_ra(NetplanParser* npp, yaml_node_t* node, const void* data, GError
     return ret;
 }
 
-static gboolean
+STATIC gboolean
 handle_activation_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (g_strcmp0(scalar(node), "manual") && g_strcmp0(scalar(node), "off"))
@@ -1203,7 +1203,7 @@ handle_activation_mode(NetplanParser* npp, yaml_node_t* node, const void* data, 
     return handle_netdef_str(npp, node, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_match(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     npp->current.netdef->has_match = TRUE;
@@ -1224,7 +1224,7 @@ NETPLAN_WIFI_WOWLAN_TYPES[] = {
     {NULL},
 };
 
-static gboolean
+STATIC gboolean
 handle_wowlan(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
@@ -1247,7 +1247,7 @@ handle_wowlan(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GEr
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_auth(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     gboolean ret;
@@ -1262,7 +1262,7 @@ handle_auth(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unu
     return ret;
 }
 
-static gboolean
+STATIC gboolean
 handle_address_option_lifetime(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (g_ascii_strcasecmp(scalar(node), "0") != 0 &&
@@ -1272,7 +1272,7 @@ handle_address_option_lifetime(NetplanParser* npp, yaml_node_t* node, const void
     return handle_generic_str(npp, node, npp->current.addr_options, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_address_option_label(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_generic_str(npp, node, npp->current.addr_options, data, error);
@@ -1289,7 +1289,7 @@ const mapping_entry_handler address_option_handlers[] = {
  * @entryptr: pointer to the beginning of the do-be-modified data structure
  * @data: offset into entryptr struct where the array to write is located
  */
-static gboolean
+STATIC gboolean
 handle_generic_addresses(NetplanParser* npp, yaml_node_t* node, gboolean check_zero_prefix, GArray** ip4, GArray** ip6, GError** error)
 {
     g_assert(ip4);
@@ -1392,13 +1392,13 @@ skip_ip6:
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_addresses(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     return handle_generic_addresses(npp, node, TRUE, &(npp->current.netdef->ip4_addresses), &(npp->current.netdef->ip6_addresses), error);
 }
 
-static gboolean
+STATIC gboolean
 handle_gateway4(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!is_ip4_address(scalar(node)))
@@ -1410,7 +1410,7 @@ handle_gateway4(NetplanParser* npp, yaml_node_t* node, __unused const void* _, G
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_gateway6(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!is_ip6_address(scalar(node)))
@@ -1422,7 +1422,7 @@ handle_gateway6(NetplanParser* npp, yaml_node_t* node, __unused const void* _, G
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_wifi_access_points(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* data, GError** error)
 {
     GHashTable* access_points = g_hash_table_new(g_str_hash, g_str_equal);
@@ -1498,7 +1498,7 @@ handle_wifi_access_points(NetplanParser* npp, yaml_node_t* node, const char* key
  * but set npp->current.netdef's ID in all listed interfaces' "bond" or "bridge" field.
  * @data: ignored
  */
-static gboolean
+STATIC gboolean
 handle_bridge_interfaces(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     /* all entries must refer to already defined IDs */
@@ -1534,7 +1534,7 @@ handle_bridge_interfaces(NetplanParser* npp, yaml_node_t* node, __unused const v
  * @data: offset into NetplanNetDefinition where the const char* field to write is
  *        located
  */
-static gboolean
+STATIC gboolean
 handle_bond_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (!(strcmp(scalar(node), "balance-rr") == 0 ||
@@ -1563,7 +1563,7 @@ handle_bond_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError
  * Handler for bond "interfaces:" list.
  * @data: ignored
  */
-static gboolean
+STATIC gboolean
 handle_bond_interfaces(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     /* all entries must refer to already defined IDs */
@@ -1596,7 +1596,7 @@ handle_bond_interfaces(NetplanParser* npp, yaml_node_t* node, __unused const voi
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_nameservers_search(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
@@ -1617,7 +1617,7 @@ handle_nameservers_search(NetplanParser* npp, yaml_node_t* node, __unused const 
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_nameservers_addresses(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
@@ -1649,7 +1649,7 @@ handle_nameservers_addresses(NetplanParser* npp, yaml_node_t* node, __unused con
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_link_local(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     gboolean ipv4 = FALSE;
@@ -1686,7 +1686,7 @@ NETPLAN_OPTIONAL_ADDRESS_TYPES[] = {
     {NULL},
 };
 
-static gboolean
+STATIC gboolean
 handle_optional_addresses(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
@@ -1709,7 +1709,7 @@ handle_optional_addresses(NetplanParser* npp, yaml_node_t* node, __unused const 
 }
 
 /* TODO: unify optional_addresses/wowlan_types, using flags */
-static gboolean
+STATIC gboolean
 handle_vxlan_flags(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_assert(npp->current.vxlan);
@@ -1765,21 +1765,21 @@ handle_vxlan_flags(NetplanParser* npp, yaml_node_t* node, const void* data, GErr
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_vxlan_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_assert(npp->current.vxlan);
     return handle_generic_guint(npp, node, npp->current.vxlan, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_vxlan_tristate(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_assert(npp->current.vxlan);
     return handle_generic_tristate(npp, node, npp->current.vxlan, data, error);
 }
 
-static int
+STATIC int
 get_ip_family(const char* address)
 {
     g_autofree char *ip_str;
@@ -1799,7 +1799,7 @@ get_ip_family(const char* address)
     return -1;
 }
 
-static gboolean
+STATIC gboolean
 check_and_set_family(gint family, gint* dest)
 {
     if (*dest != -1 && *dest != family)
@@ -1812,14 +1812,14 @@ check_and_set_family(gint family, gint* dest)
 
 /* TODO: (cyphermox) Refactor the functions below. There's a lot of room for reuse. */
 
-static gboolean
+STATIC gboolean
 handle_routes_bool(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_assert(npp->current.route);
     return handle_generic_bool(npp, node, npp->current.route, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_routes_scope(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     NetplanIPRoute* route = npp->current.route;
@@ -1835,7 +1835,7 @@ handle_routes_scope(NetplanParser* npp, yaml_node_t* node, __unused const void* 
     return yaml_error(npp, node, error, "invalid route scope '%s'", route->scope);
 }
 
-static gboolean
+STATIC gboolean
 handle_routes_type(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     NetplanIPRoute* route = npp->current.route;
@@ -1862,7 +1862,7 @@ handle_routes_type(NetplanParser* npp, yaml_node_t* node, __unused const void* d
     return yaml_error(npp, node, error, "invalid route type '%s'", route->type);
 }
 
-static gboolean
+STATIC gboolean
 handle_routes_ip(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     NetplanIPRoute* route = npp->current.route;
@@ -1883,7 +1883,7 @@ handle_routes_ip(NetplanParser* npp, yaml_node_t* node, const void* data, GError
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_routes_destination(NetplanParser *npp, yaml_node_t *node, __unused const void *data, GError **error)
 {
     const char *addr = scalar(node);
@@ -1893,7 +1893,7 @@ handle_routes_destination(NetplanParser *npp, yaml_node_t *node, __unused const 
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_ip_rule_ip(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     NetplanIPRule* ip_rule = npp->current.ip_rule;
@@ -1914,21 +1914,21 @@ handle_ip_rule_ip(NetplanParser* npp, yaml_node_t* node, const void* data, GErro
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_ip_rule_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_assert(npp->current.ip_rule);
     return handle_generic_guint(npp, node, npp->current.ip_rule, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_routes_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_assert(npp->current.route);
     return handle_generic_guint(npp, node, npp->current.route, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_ip_rule_tos(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     NetplanIPRule* ip_rule = npp->current.ip_rule;
@@ -1942,7 +1942,7 @@ handle_ip_rule_tos(NetplanParser* npp, yaml_node_t* node, const void* data, GErr
  * Grammar and handlers for network config "bridge_params" entry
  ****************************************************/
 
-static gboolean
+STATIC gboolean
 handle_bridge_path_cost(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* data, GError** error)
 {
     for (yaml_node_pair_t* entry = node->data.mapping.pairs.start; entry < node->data.mapping.pairs.top; entry++) {
@@ -1986,7 +1986,7 @@ handle_bridge_path_cost(NetplanParser* npp, yaml_node_t* node, const char* key_p
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_bridge_port_priority(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* data, GError** error)
 {
     for (yaml_node_pair_t* entry = node->data.mapping.pairs.start; entry < node->data.mapping.pairs.top; entry++) {
@@ -2044,7 +2044,7 @@ static const mapping_entry_handler bridge_params_handlers[] = {
     {NULL}
 };
 
-static gboolean
+STATIC gboolean
 handle_bridge(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     npp->current.netdef->custom_bridging = TRUE;
@@ -2071,7 +2071,7 @@ static const mapping_entry_handler routes_handlers[] = {
     {NULL}
 };
 
-static gboolean
+STATIC gboolean
 handle_routes(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!npp->current.netdef->routes)
@@ -2161,7 +2161,7 @@ static const mapping_entry_handler ip_rules_handlers[] = {
     {NULL}
 };
 
-static gboolean
+STATIC gboolean
 handle_ip_rules(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
@@ -2207,7 +2207,7 @@ handle_ip_rules(NetplanParser* npp, yaml_node_t* node, __unused const void* _, G
  * Grammar and handlers for bond parameters
  ****************************************************/
 
-static gboolean
+STATIC gboolean
 handle_arp_ip_targets(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!npp->current.netdef->bond_params.arp_ip_targets) {
@@ -2243,7 +2243,7 @@ handle_arp_ip_targets(NetplanParser* npp, yaml_node_t* node, __unused const void
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_bond_primary_member(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     NetplanNetDefinition *component;
@@ -2270,7 +2270,7 @@ handle_bond_primary_member(NetplanParser* npp, yaml_node_t* node, const void* da
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_bond_lacp_rate(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (!(strcmp(scalar(node), "slow") == 0 || strcmp(scalar(node), "fast") == 0))
@@ -2309,7 +2309,7 @@ static const mapping_entry_handler bond_params_handlers[] = {
     {NULL}
 };
 
-static gboolean
+STATIC gboolean
 handle_vrf_interfaces(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     /* all entries must refer to already defined IDs */
@@ -2332,7 +2332,7 @@ handle_vrf_interfaces(NetplanParser* npp, yaml_node_t* node, __unused const void
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_vxlan_source_port(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     assert_type(npp, node, YAML_SEQUENCE_NODE);
@@ -2359,13 +2359,13 @@ handle_vxlan_source_port(NetplanParser* npp, yaml_node_t* node, __unused const v
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_bonding(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     return process_mapping(npp, node, key_prefix, bond_params_handlers, NULL, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_dhcp_identifier(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     g_free(npp->current.netdef->dhcp_identifier);
@@ -2386,7 +2386,7 @@ handle_dhcp_identifier(NetplanParser* npp, yaml_node_t* node, __unused const voi
  * Grammar and handlers for tunnels
  ****************************************************/
 
-static gboolean
+STATIC gboolean
 handle_tunnel_addr(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_autofree char* addr = NULL;
@@ -2409,7 +2409,7 @@ handle_tunnel_addr(NetplanParser* npp, yaml_node_t* node, const void* data, GErr
     return yaml_error(npp, node, error, "malformed address '%s', must be X.X.X.X or X:X:X:X:X:X:X:X", scalar(node));
 }
 
-static gboolean
+STATIC gboolean
 handle_tunnel_mode(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     const char *key = scalar(node);
@@ -2434,7 +2434,7 @@ static const mapping_entry_handler tunnel_keys_handlers[] = {
     {NULL}
 };
 
-static gboolean
+STATIC gboolean
 handle_tunnel_key_mapping(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     gboolean ret = FALSE;
@@ -2460,7 +2460,7 @@ handle_tunnel_key_mapping(NetplanParser* npp, yaml_node_t* node, const char* key
  * Handler for setting a NetplanWireguardPeer string field from a scalar node
  * @data: pointer to the const char* field to write
  */
-static gboolean
+STATIC gboolean
 handle_wireguard_peer_str(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_assert(npp->current.wireguard_peer);
@@ -2471,21 +2471,21 @@ handle_wireguard_peer_str(NetplanParser* npp, yaml_node_t* node, const void* dat
  * Handler for setting a NetplanWireguardPeer string field from a scalar node
  * @data: pointer to the guint field to write
  */
-static gboolean
+STATIC gboolean
 handle_wireguard_peer_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     g_assert(npp->current.wireguard_peer);
     return handle_generic_guint(npp, node, npp->current.wireguard_peer, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_wireguard_allowed_ips(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     return handle_generic_addresses(npp, node, FALSE, &(npp->current.wireguard_peer->allowed_ips),
                                     &(npp->current.wireguard_peer->allowed_ips), error);
 }
 
-static gboolean
+STATIC gboolean
 handle_wireguard_endpoint(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     g_autofree char* endpoint = NULL;
@@ -2535,7 +2535,7 @@ static const mapping_entry_handler wireguard_peer_keys_handlers[] = {
     {NULL}
 };
 
-static gboolean
+STATIC gboolean
 handle_wireguard_peer_key_mapping(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     return process_mapping(npp, node, key_prefix, wireguard_peer_keys_handlers, NULL, error);
@@ -2549,7 +2549,7 @@ const mapping_entry_handler wireguard_peer_handlers[] = {
     {NULL}
 };
 
-static gboolean
+STATIC gboolean
 handle_wireguard_peers(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     if (!npp->current.netdef->wireguard_peers)
@@ -2587,7 +2587,7 @@ handle_wireguard_peers(NetplanParser* npp, yaml_node_t* node, __unused const voi
  * Grammar and handlers for network devices
  ****************************************************/
 
-static gboolean
+STATIC gboolean
 handle_ovs_bond_lacp(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BOND)
@@ -2599,7 +2599,7 @@ handle_ovs_bond_lacp(NetplanParser* npp, yaml_node_t* node, const void* data, GE
     return handle_netdef_str(npp, node, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_ovs_bridge_bool(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
@@ -2608,7 +2608,7 @@ handle_ovs_bridge_bool(NetplanParser* npp, yaml_node_t* node, const void* data, 
     return handle_netdef_bool(npp, node, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_ovs_bridge_fail_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
@@ -2620,7 +2620,7 @@ handle_ovs_bridge_fail_mode(NetplanParser* npp, yaml_node_t* node, const void* d
     return handle_netdef_str(npp, node, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_ovs_protocol(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
     const char* deprecated[] = { "OpenFlow16" };
@@ -2660,7 +2660,7 @@ handle_ovs_protocol(NetplanParser* npp, yaml_node_t* node, void* entryptr, const
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_ovs_bridge_protocol(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
@@ -2669,7 +2669,7 @@ handle_ovs_bridge_protocol(NetplanParser* npp, yaml_node_t* node, const void* da
     return handle_ovs_protocol(npp, node, npp->current.netdef, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_ovs_bridge_controller_connection_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
@@ -2681,7 +2681,7 @@ handle_ovs_bridge_controller_connection_mode(NetplanParser* npp, yaml_node_t* no
     return handle_netdef_str(npp, node, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_ovs_bridge_controller_addresses(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     if (npp->current.netdef->type != NETPLAN_DEF_TYPE_BRIDGE)
@@ -2759,7 +2759,7 @@ static const mapping_entry_handler ovs_backend_settings_handlers[] = {
     {NULL}
 };
 
-static gboolean
+STATIC gboolean
 handle_ovs_backend(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     GList* values = NULL;
@@ -2991,7 +2991,7 @@ static const mapping_entry_handler tunnel_def_handlers[] = {
  * Grammar and handlers for network node
  ****************************************************/
 
-static gboolean
+STATIC gboolean
 handle_network_version(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     long mangled_version;
@@ -3003,7 +3003,7 @@ handle_network_version(NetplanParser* npp, yaml_node_t* node, __unused const voi
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 handle_network_renderer(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     gboolean res = parse_renderer(npp, node, &npp->global_backend, error);
@@ -3017,19 +3017,19 @@ handle_network_renderer(NetplanParser* npp, yaml_node_t* node, __unused const vo
     return res;
 }
 
-static gboolean
+STATIC gboolean
 handle_network_ovs_settings_global(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* data, GError** error)
 {
     return handle_generic_map(npp, node, key_prefix, &npp->global_ovs_settings, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_network_ovs_settings_global_protocol(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     return handle_ovs_protocol(npp, node, &npp->global_ovs_settings, data, error);
 }
 
-static gboolean
+STATIC gboolean
 handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
 {
     yaml_node_t* port = NULL;
@@ -3107,7 +3107,7 @@ handle_network_ovs_settings_global_ports(NetplanParser* npp, yaml_node_t* node, 
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 node_is_nulled_out(yaml_document_t* doc, yaml_node_t* node, const char* key_prefix, GHashTable* null_fields)
 {
     if (node->type != YAML_MAPPING_NODE)
@@ -3138,7 +3138,7 @@ node_is_nulled_out(yaml_document_t* doc, yaml_node_t* node, const char* key_pref
  * Callback for a net device type entry like "ethernets:" in "network:"
  * @data: netdef_type (as pointer)
  */
-static gboolean
+STATIC gboolean
 handle_network_type(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* data, GError** error)
 {
     for (yaml_node_pair_t* entry = node->data.mapping.pairs.start; entry < node->data.mapping.pairs.top; entry++) {
@@ -3278,7 +3278,7 @@ static const mapping_entry_handler ovs_global_ssl_handlers[] = {
     {NULL}
 };
 
-static gboolean
+STATIC gboolean
 handle_ovs_global_ssl(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, __unused const void* _, GError** error)
 {
     gboolean ret;
@@ -3330,7 +3330,7 @@ static const mapping_entry_handler root_handlers[] = {
  * Post-process some specific missing interfaces that are not required
  * to exist but are needed in order to generate backend configuration.
  */
-static void
+STATIC void
 process_missing_ids(NetplanParser* npp, __unused GError** error)
 {
     GHashTableIter iter;
@@ -3371,7 +3371,7 @@ process_missing_ids(NetplanParser* npp, __unused GError** error)
 /**
  * Handle multiple-pass parsing of the yaml document.
  */
-static gboolean
+STATIC gboolean
 process_document(NetplanParser* npp, GError** error)
 {
     gboolean ret;
@@ -3427,7 +3427,7 @@ cleanup:
     return ret;
 }
 
-static gboolean
+STATIC gboolean
 _netplan_parser_load_single_file(NetplanParser* npp, const char *opt_filepath, yaml_document_t *doc, GError** error)
 {
     int ret = FALSE;
@@ -3494,7 +3494,7 @@ netplan_parser_load_yaml(NetplanParser* npp, const char* filename, GError** erro
     return _netplan_parser_load_single_file(npp, filename, doc, error);
 }
 
-static gboolean
+STATIC gboolean
 finish_iterator(const NetplanParser* npp, NetplanNetDefinition* nd, GError **error)
 {
     /* Take more steps to make sure we always have a backend set for netdefs */
@@ -3507,7 +3507,7 @@ finish_iterator(const NetplanParser* npp, NetplanNetDefinition* nd, GError **err
     return validate_backend_rules(npp, nd, error) && validate_sriov_rules(npp, nd, error);
 }
 
-static gboolean
+STATIC gboolean
 insert_kv_into_hash(void *key, void *value, void *hash)
 {
     g_hash_table_insert(hash, key, value);
@@ -3673,7 +3673,7 @@ netplan_parser_clear(NetplanParser** npp_p)
  * Overrides (depending on YAML hierarchy) can only happen on global values
  * (like "renderer") or on the individual netdef level.
  * @return the Netdef-ID/keyword or NULL */
-static gboolean
+STATIC gboolean
 is_netdef_id_or_global_value(const char* full_key)
 {
     g_autofree gchar* key = g_strstrip(g_strdup(full_key)); // strip leading '\t'
@@ -3704,7 +3704,7 @@ cleanup:
     return ret;
 }
 
-static void
+STATIC void
 extract_null_fields(yaml_document_t* doc, yaml_node_t* node, GHashTable* null_fields, char* key_prefix, const char* origin_hint)
 {
     yaml_node_pair_t* entry;

--- a/src/sriov.c
+++ b/src/sriov.c
@@ -26,7 +26,7 @@
 #include "util-internal.h"
 #include "sriov.h"
 
-static gboolean
+STATIC gboolean
 write_sriov_rebind_systemd_unit(const GString* pfs, const char* rootdir, GError** error)
 {
     g_autofree gchar* id_escaped = NULL;

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -278,6 +278,12 @@ struct netplan_state_iterator {
 #define NETPLAN_IP_RULE_FW_MARK_UNSPEC 0
 #define NETPLAN_IP_RULE_TOS_UNSPEC G_MAXUINT
 
+#if defined(UNITTESTS)
+#define STATIC
+#else
+#define STATIC static
+#endif
+
 void
 reset_netdef(NetplanNetDefinition* netdef, NetplanDefType type, NetplanBackend renderer);
 

--- a/src/types.c
+++ b/src/types.c
@@ -29,7 +29,7 @@
 /* Helper function to free a GArray after applying a destructor to its
  * elements. Note that in the most trivial case (g_free) we should probably
  * have used a GPtrArray directly... */
-static void
+STATIC void
 free_garray_with_destructor(GArray** array, void (destructor)(void *))
 {
     if (*array) {
@@ -44,7 +44,7 @@ free_garray_with_destructor(GArray** array, void (destructor)(void *))
 
 /* Helper function to free a GHashTable after applying a simple destructor to its
  * elements. */
-static void
+STATIC void
 free_hashtable_with_destructor(GHashTable** hash, void (destructor)(void *)) {
     if (*hash) {
         GHashTableIter iter;
@@ -69,7 +69,7 @@ free_address_options(void* ptr)
     g_free(opts);
 }
 
-static void
+STATIC void
 free_route(void* ptr)
 {
     NetplanIPRoute* route = ptr;
@@ -81,7 +81,7 @@ free_route(void* ptr)
     g_free(route);
 }
 
-static void
+STATIC void
 free_ip_rules(void* ptr)
 {
     NetplanIPRule* rule = ptr;
@@ -90,7 +90,7 @@ free_ip_rules(void* ptr)
     g_free(rule);
 }
 
-static void
+STATIC void
 free_wireguard_peer(void* ptr)
 {
     NetplanWireguardPeer* wg = ptr;
@@ -101,7 +101,7 @@ free_wireguard_peer(void* ptr)
     g_free(wg);
 }
 
-static void
+STATIC void
 reset_auth_settings(NetplanAuthenticationSettings* auth)
 {
     FREE_AND_NULLIFY(auth->identity);
@@ -137,7 +137,7 @@ reset_ovs_settings(NetplanOVSSettings* settings)
     FREE_AND_NULLIFY(settings->controller.connection_mode);
 }
 
-static void
+STATIC void
 reset_dhcp_overrides(NetplanDHCPOverrides* overrides)
 {
     overrides->use_dns = TRUE;
@@ -162,7 +162,7 @@ reset_ip_rule(NetplanIPRule* ip_rule)
 }
 
 /* Reset a backend settings object. */
-static void
+STATIC void
 reset_backend_settings(NetplanBackendSettings* settings)
 {
     FREE_AND_NULLIFY(settings->name);
@@ -172,7 +172,7 @@ reset_backend_settings(NetplanBackendSettings* settings)
     g_datalist_clear(&settings->passthrough);
 }
 
-static void
+STATIC void
 reset_private_netdef_data(struct private_netdef_data* data) {
     if (!data)
         return;

--- a/src/util.c
+++ b/src/util.c
@@ -238,7 +238,7 @@ file_error:
 // LCOV_EXCL_STOP
 }
 
-static gboolean
+STATIC gboolean
 copy_yaml_subtree(yaml_parser_t *parser, yaml_emitter_t *emitter, GError** error) {
 	yaml_event_t event;
     int map_count = 0, seq_count = 0;
@@ -278,7 +278,7 @@ copy_yaml_subtree(yaml_parser_t *parser, yaml_emitter_t *emitter, GError** error
  * Given a YAML tree and a YAML path (array of keys with NULL as the last array element),
  * emits the subtree matching the path, while emitting the rest of the data into the void.
  */
-static gboolean
+STATIC gboolean
 emit_yaml_subtree(yaml_parser_t *parser, yaml_emitter_t *emitter, char** yaml_path, GError** error) {
 	yaml_event_t event;
     /* If the path component is NULL, we're done with the trimming, we can just copy the whole subtree */
@@ -1084,7 +1084,7 @@ netplan_state_iterator_has_next(const NetplanStateIterator* iter)
     return _iter->next != NULL;
 }
 
-static const char*
+STATIC const char*
 normalize_ip_address(const char* addr, const guint family)
 {
     if (!g_strcmp0(addr, "default")) {

--- a/src/validation.c
+++ b/src/validation.c
@@ -158,7 +158,7 @@ validate_ovs_target(gboolean host_first, gchar* s) {
     return FALSE;
 }
 
-static gboolean
+STATIC gboolean
 validate_interface_name_length(const NetplanNetDefinition* netdef)
 {
     gboolean validation = TRUE;
@@ -187,7 +187,7 @@ validate_interface_name_length(const NetplanNetDefinition* netdef)
 /************************************************
  * Validation for grammar and backend rules.
  ************************************************/
-static gboolean
+STATIC gboolean
 validate_tunnel_key(const NetplanParser* npp, yaml_node_t* node, gchar* key, GError** error)
 {
     /* Tunnel key should be a number or dotted quad, except for wireguard. */
@@ -201,7 +201,7 @@ validate_tunnel_key(const NetplanParser* npp, yaml_node_t* node, gchar* key, GEr
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 validate_tunnel_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml_node_t* node, GError** error)
 {
     if (nd->tunnel.mode == NETPLAN_TUNNEL_MODE_UNKNOWN)
@@ -276,7 +276,7 @@ validate_tunnel_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, yaml
     return TRUE;
 }
 
-static gboolean
+STATIC gboolean
 validate_tunnel_backend_rules(const NetplanParser* npp, NetplanNetDefinition* nd, yaml_node_t* node, GError** error)
 {
     /* Backend-specific validation rules for tunnels */
@@ -548,7 +548,7 @@ struct _defroute_entry {
     const char *netdef_id;
 };
 
-static void
+STATIC void
 defroute_err(struct _defroute_entry *entry, const char *new_netdef_id, GError **error) {
     char table_name[128] = {};
     char metric_name[128] = {};
@@ -575,7 +575,7 @@ defroute_err(struct _defroute_entry *entry, const char *new_netdef_id, GError **
             new_netdef_id);
 }
 
-static gboolean
+STATIC gboolean
 check_defroute(struct _defroute_entry *candidate,
                GSList **entries,
                GError **error)

--- a/tests/ctests/meson.build
+++ b/tests/ctests/meson.build
@@ -16,11 +16,13 @@ foreach name, should_fail: tests
     '@0@.c'.format(name),
     include_directories: [inc, inc_internal],
     dependencies: [cmocka, glib, gio, yaml, uuid],
+    link_with: libnetplan_testing,
     c_args: [
       '-DFIXTURESDIR="' + meson.project_source_root() + '/tests/ctests/fixtures"',
       '-Wno-deprecated-declarations',
       '-D_GNU_SOURCE',
       ],
+    install: false,
     )
   test(name, exe, should_fail: should_fail)
 endforeach

--- a/tests/ctests/test_netplan_error.c
+++ b/tests/ctests/test_netplan_error.c
@@ -7,14 +7,8 @@
 
 #include "netplan.h"
 #include "parse.h"
-
-#include "error.c"
-#include "names.c"
-#include "netplan.c"
-#include "validation.c"
-#include "types.c"
-#include "util.c"
-#include "parse.c"
+#include "util.h"
+#include "util-internal.h"
 
 void
 test_netplan_error_message(__unused void** state)

--- a/tests/ctests/test_netplan_keyfile.c
+++ b/tests/ctests/test_netplan_keyfile.c
@@ -8,15 +8,7 @@
 #include "netplan.h"
 #include "parse-nm.h"
 #include "parse.h"
-
-#include "error.c"
-#include "names.c"
-#include "netplan.c"
-#include "validation.c"
-#include "types.c"
-#include "util.c"
-#include "parse.c"
-#include "parse-nm.c"
+#include "util-internal.h"
 
 #include "test_utils.h"
 #include "test_utils_keyfile.h"

--- a/tests/ctests/test_netplan_misc.c
+++ b/tests/ctests/test_netplan_misc.c
@@ -3,20 +3,16 @@
 #include <stddef.h>
 #include <setjmp.h>
 
+#include <sys/stat.h>
+#include <netinet/in.h>
+
 #include <cmocka.h>
 
 #include "netplan.h"
 #include "parse.h"
+#include "util-internal.h"
 #include "types-internal.h"
 #include "types.h"
-
-#include "error.c"
-#include "names.c"
-#include "validation.c"
-#include "types.c"
-#include "util.c"
-#include "parse.c"
-#include "netplan.c"
 
 #include "test_utils.h"
 

--- a/tests/ctests/test_netplan_nm.c
+++ b/tests/ctests/test_netplan_nm.c
@@ -6,15 +6,7 @@
 #include <cmocka.h>
 
 #include "netplan.h"
-
-#include "error.c"
-#include "names.c"
-#include "netplan.c"
-#include "validation.c"
-#include "types.c"
-#include "util.c"
-#include "parse.c"
-#include "nm.c"
+#include "util-internal.h"
 
 #include "test_utils.h"
 

--- a/tests/ctests/test_netplan_openvswitch.c
+++ b/tests/ctests/test_netplan_openvswitch.c
@@ -6,16 +6,8 @@
 #include <cmocka.h>
 
 #include "netplan.h"
-
-#include "error.c"
-#include "names.c"
-#include "netplan.c"
-#include "validation.c"
-#include "types.c"
-#include "util.c"
-#include "parse.c"
-#include "networkd.c"
-#include "openvswitch.c"
+#include "util-internal.h"
+#include "validation.h"
 
 #include "test_utils.h"
 

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -9,14 +9,7 @@
 #include "netplan.h"
 #include "parse.h"
 #include "util.h"
-
-#include "error.c"
-#include "names.c"
-#include "netplan.c"
-#include "validation.c"
-#include "types.c"
-#include "util.c"
-#include "parse.c"
+#include "util-internal.h"
 
 #include "test_utils.h"
 

--- a/tests/ctests/test_netplan_state.c
+++ b/tests/ctests/test_netplan_state.c
@@ -7,14 +7,7 @@
 
 #include "netplan.h"
 #include "parse.h"
-
-#include "error.c"
-#include "names.c"
-#include "netplan.c"
-#include "validation.c"
-#include "types.c"
-#include "util.c"
-#include "parse.c"
+#include "util-internal.h"
 
 #include "test_utils.h"
 

--- a/tests/ctests/test_netplan_validation.c
+++ b/tests/ctests/test_netplan_validation.c
@@ -7,14 +7,8 @@
 
 #include "netplan.h"
 #include "parse.h"
-
-#include "error.c"
-#include "names.c"
-#include "netplan.c"
-#include "validation.c"
-#include "types.c"
-#include "util.c"
-#include "parse.c"
+#include "util-internal.h"
+#include "validation.h"
 
 #include "test_utils.h"
 

--- a/tests/ctests/test_utils.h
+++ b/tests/ctests/test_utils.h
@@ -8,6 +8,19 @@
 #include "util.h"
 #include "types-internal.h"
 
+gboolean
+process_document(NetplanParser*, GError**);
+gboolean
+load_yaml_from_fd(int, yaml_document_t*, GError**);
+gboolean
+load_yaml(const char*, yaml_document_t*, GError**);
+const char*
+normalize_ip_address(const char*, const guint);
+char*
+write_ovs_bond_interfaces(const NetplanState*, const NetplanNetDefinition*, GString*, GError**);
+gboolean
+validate_interface_name_length(const NetplanNetDefinition*);
+
 // LCOV_EXCL_START
 NetplanState *
 load_fixture_to_netplan_state(const char* filename)


### PR DESCRIPTION
With these changes, a copy of libnetplan without static functions will be build. All the test files will be linked against this separate library. With that, there is no need to include the C files in the test files anymore.

To make this possible, all the static keywords in function declarations were replaced with a macro that will be defined at compilation time.


## Description

My goal is to make #425 easier to be implemented. Also, refactoring the C code is less likely to break the build of test files...

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

