### PR TITLE
cli/sriov: remove unused code

### DIFF
--- a/netplan_cli/cli/sriov.py
+++ b/netplan_cli/cli/sriov.py
@@ -375,12 +375,6 @@ def apply_sriov_config(config_manager, rootdir='/'):
     Go through all interfaces, identify which ones are SR-IOV VFs, create
     them and perform all other necessary setup.
     """
-    parser = netplan.Parser()
-    parser.load_yaml_hierarchy(rootdir)
-
-    np_state = netplan.State()
-    np_state.import_parser_results(parser)
-
     config_manager.parse()
     interfaces = netifaces.interfaces()
     np_state = config_manager.np_state

--- a/tests/test_sriov.py
+++ b/tests/test_sriov.py
@@ -24,7 +24,6 @@ from subprocess import CalledProcessError
 from collections import defaultdict
 from unittest.mock import patch, mock_open, call
 
-import netplan
 import netplan_cli.cli.sriov as sriov
 
 from netplan_cli.configmanager import ConfigManager, ConfigurationError
@@ -578,7 +577,7 @@ class TestSRIOV(unittest.TestCase):
         gim.return_value = '00:01:02:03:04:05'
 
         # call method under test
-        with self.assertRaises(netplan.NetplanValidationException) as e:
+        with self.assertRaises(ConfigurationError) as e:
             sriov.apply_sriov_config(self.configmanager, rootdir=self.workdir.name)
 
         self.assertIn('vf1.15: missing \'id\' property', str(e.exception))


### PR DESCRIPTION
We are parsing all the configuration unnecessarily here. np_state is being overridden by the State instance from the config manager.

Fix a related unit test. The configuration is expected to fail but now it's failing in a different place and raising a different exception.


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

