### PR TITLE
Update examples.md

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -324,7 +324,7 @@ network:
       link: enp0s25
 ```
 
-Then libvirtd would be configured to use this bridge by adding the following content to a new XML file under `/etc/libvirtd/qemu/networks/`. The name of the bridge in the &lt;bridge&gt; tag as well as in &lt;name&gt; need to match the name of the bridge device configured using Netplan:
+Then libvirtd would be configured to use this bridge by adding the following content to a new XML file under `/etc/libvirt/qemu/networks/`. The name of the bridge in the &lt;bridge&gt; tag as well as in &lt;name&gt; need to match the name of the bridge device configured using Netplan:
 
 ```xml
 <network>


### PR DESCRIPTION
## Description
In the [how-to-create-a-bridge-with-a-vlan-for-libvirtd](https://github.com/canonical/netplan/blob/main/doc/examples.md#how-to-create-a-bridge-with-a-vlan-for-libvirtd) section, the correct path to where libvirtd creates the config file is `/etc/libvirt/qemu/networks/`

Apologies if this is not the correct process to report this. I found there was no tag to report documentation errors on Launchpad.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

