### PR TITLE
CI: fix NetworkManager autopkgtest not using deb822

### DIFF
--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Preparing autopkgtest-build-lxd
         run: |
           sudo patch /usr/bin/autopkgtest-build-lxd .github/workflows/snapd.patch
-          autopkgtest-build-lxd ubuntu-daily:noble
+          MIRROR=http://archive.ubuntu.com/ubuntu autopkgtest-build-lxd ubuntu-daily:noble # LP: #2052639
       - name: Run autopkgtest
         run: |
           # using --setup-commands temporarily to install:


### PR DESCRIPTION
## Description
CI: fix NetworkManager autopkgtest not using deb822

See:
* https://bugs.launchpad.net/ubuntu/+source/autopkgtest/+bug/2052639
* https://salsa.debian.org/ci-team/autopkgtest/-/merge_requests/287

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

