### PR TITLE
Fix logging setup when python-rich is not present

### DIFF
--- a/netplan_cli/cli/core.py
+++ b/netplan_cli/cli/core.py
@@ -49,10 +49,10 @@ class Netplan(utils.NetplanCommand):
         self.parse_args()
 
         if self.debug:
-            logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s')
+            logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(message)s', force=True)
             os.environ['G_MESSAGES_DEBUG'] = 'all'
         else:
-            logging.basicConfig(level=logging.INFO, format='%(message)s')
+            logging.basicConfig(level=logging.INFO, format='%(message)s', force=True)
 
         try:
             self.run_command()


### PR DESCRIPTION
## Description
Hi, while packaging netplan 0.107 for Azure Linux I ran into this small bug when running checks. This seems like the most trivial fix.

tl;dr: when python-rich is not present the logger will not be configured correctly. More specifically:
- The logging level will be `WARNING` instead of `INFO`
- Passing `--debug` has no effect.

### Explanation

When python-rich is not present, the import in [netplan_cli/cli/commands/status.py#L35](https://github.com/canonical/netplan/blob/45f7cd1569896d9e316c130bf5c60b7ccfc8211d/netplan_cli/cli/commands/status.py#L35) will fail, causing the `except` clause to run which calls `logging.debug(...)` in [netplan_cli/cli/commands/status.py#L47](https://github.com/canonical/netplan/blob/45f7cd1569896d9e316c130bf5c60b7ccfc8211d/netplan_cli/cli/commands/status.py#L47)

However, because this is evaluated when the modules are being imported, this happens before the code in [netplan_cli/cli/core.py#L51](https://github.com/canonical/netplan/blob/45f7cd1569896d9e316c130bf5c60b7ccfc8211d/netplan_cli/cli/core.py#L51C1-L55C74) that calls `logging.basicConfig(...)`.

Because the root logger has not been initialized, the call to `logging.debug(...)` in `status.py` does a hidden call to `basicConfig()` so that the log can go somewhere: https://github.com/python/cpython/blob/5dc8c84d397110f9edfa56793ad8887b1f176d79/Lib/logging/__init__.py#L2181

This hidden call to `basicConfig()` creates a handler on the root logger. (The root logger is set up to `WARNING` by default, so this log will never show up under normal conditions.)

When `basicConfig(...)` is called in `core.py`, the call will have no effect because a handler already exists. From the docs:
> This function does nothing if the root logger already has handlers configured, unless the keyword argument force is set to True.
(https://docs.python.org/3/library/logging.html#logging.basicConfig)

Hence this PR to use `force=True` and avoid the issue.

Another possible solution is to remove the call from `status.py`, which will not be seen anyway.

Thanks for your time. :)

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

