### PR TITLE
CI: adopt autopkgtest for 1.0-1 on 22.04

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -46,7 +46,9 @@ jobs:
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
           # usrmerge-fix
-          sed -i 's|rm debian/tmp/lib/netplan/generate|sh -c "mkdir -p debian/tmp/usr/lib/systemd/system-generators; rm -rf debian/tmp/lib; ln -sf /usr/libexec/netplan/generate debian/tmp/usr/lib/systemd/system-generators/netplan"|' debian/rules
+          echo "" >> debian/rules
+          echo "execute_after_dh_auto_install:" >> debian/rules
+          echo "	sh -c \"mkdir -p debian/tmp/usr/lib/systemd/system-generators; rm -rf debian/tmp/lib; ln -sf /usr/libexec/netplan/generate debian/tmp/usr/lib/systemd/system-generators/netplan\"" >> debian/rules
           # usrmerge-fix-end
           sed -i 's| systemd-dev|# DELETED: systemd-dev|' debian/control
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag


### PR DESCRIPTION
## Description
See also: https://launchpad.net/~slyon/+archive/ubuntu/netplan-ci/+sourcepub/15854943/+listing-archive-extra

Backported meson 1.2 to gain `python.bytecompile`: https://github.com/mesonbuild/meson/pull/11530/commits/0e7fb07f915b7a2b04df209fbacd92aca19c87af

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

