### PR TITLE
parse-nm: add a workaround for the DoT DNS option (LP: #2055148)

### DIFF
--- a/.github/workflows/snapd.patch
+++ b/.github/workflows/snapd.patch
@@ -1,9 +1,9 @@
 @@ -70,6 +70,8 @@
  
      sleep 5
-     if lxc exec "$CONTAINER" -- systemctl mask serial-getty@getty.service; then
-+       lxc exec "$CONTAINER" -- systemctl mask snapd.service
-+       lxc exec "$CONTAINER" -- systemctl mask snapd.seeded.service
-        lxc exec "$CONTAINER" -- reboot
+     if "$COMMAND" exec "$CONTAINER" -- systemctl mask serial-getty@getty.service; then
++       "$COMMAND" exec "$CONTAINER" -- systemctl mask snapd.service
++       "$COMMAND" exec "$CONTAINER" -- systemctl mask snapd.seeded.service
+        "$COMMAND" exec "$CONTAINER" -- reboot
      fi
  

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -2355,3 +2355,42 @@ route1_options=table=1000
 method=link-local\n'''.format(UUID), expect_fail=True)
 
         self.assertIn('missing \'table\' property', out)
+
+    def test_nameserver_with_DoT_lp2055148(self):
+        self.generate_from_keyfile('''[connection]
+id=ethernet-eth123
+uuid={}
+type=ethernet
+interface-name=eth123
+
+[ethernet]
+
+[ipv4]
+dns=8.8.8.8;1.1.1.1#lxd;192.168.0.1#domain.local;
+method=auto
+
+[ipv6]
+addr-gen-mode=default
+method=auto
+
+[proxy]\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  ethernets:
+    NM-{}:
+      renderer: NetworkManager
+      match:
+        name: "eth123"
+      dhcp4: true
+      dhcp6: true
+      wakeonlan: true
+      networkmanager:
+        uuid: "{}"
+        name: "ethernet-eth123"
+        passthrough:
+          ethernet._: ""
+          ipv4.dns: "8.8.8.8;1.1.1.1#lxd;192.168.0.1#domain.local;"
+          ipv6.addr-gen-mode: "default"
+          ipv6.ip6-privacy: "-1"
+          proxy._: ""
+'''.format(UUID, UUID)})


### PR DESCRIPTION
Netplan doesn't support DNS options such as SNI. When we parse a nameserver entry with the SNI server name, example: 1.2.3.4#name.domain, the string is added to the list of nameservers without proper parsing/validation.

This is a workaround for LP#2055148.


## Description

Example:

```
[connection]
id=ethernet-eth123
uuid=572506e3-ab77-4c62-be96-b565984d90b3
type=ethernet
interface-name=eth123

[ethernet]

[ipv4]
dns=8.8.8.8;1.1.1.1#lxd;192.168.0.1#domain.local;
method=auto

[ipv6]
addr-gen-mode=default
dns=::1;abcd::1#domain.local;
method=auto

[proxy]
```

YAML without this patch:

```
$ LD_LIBRARY_PATH=build/src/ PYTHONPATH="$(pwd):$(pwd)/build/python-cffi"  python3 tools/keyfile_to_yaml.py /tmp/nm1.nmconnection
network:
  version: 2
  ethernets:
    NM-572506e3-ab77-4c62-be96-b565984d90b3:
      renderer: NetworkManager
      match:
        name: "eth123"
      nameservers:
        addresses:
        - 8.8.8.8
        - 1.1.1.1#lxd
        - 192.168.0.1#domain.local
        - ::1
        - abcd::1#domain.local
      dhcp4: true
      dhcp6: true
      wakeonlan: true
      networkmanager:
        uuid: "572506e3-ab77-4c62-be96-b565984d90b3"
        name: "ethernet-eth123"
        passthrough:
          ethernet._: ""
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
```

YAML with this patch:
```
$ LD_LIBRARY_PATH=build/src/ PYTHONPATH="$(pwd):$(pwd)/build/python-cffi"  python3 tools/keyfile_to_yaml.py /tmp/nm1.nmconnection
network:
  version: 2
  ethernets:
    NM-572506e3-ab77-4c62-be96-b565984d90b3:
      renderer: NetworkManager
      match:
        name: "eth123"
      dhcp4: true
      dhcp6: true
      wakeonlan: true
      networkmanager:
        uuid: "572506e3-ab77-4c62-be96-b565984d90b3"
        name: "ethernet-eth123"
        passthrough:
          ethernet._: ""
          ipv4.dns: "8.8.8.8;1.1.1.1#lxd;192.168.0.1#domain.local;"
          ipv6.addr-gen-mode: "default"
          ipv6.dns: "::1;abcd::1#domain.local;"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
```

Here is a test with Network Manager and combinations of IPv4 and IPv6 with and without the SNI string:

```
root@test:~# nmcli con add type dummy ifname dummy0 ipv4.dns 1.1.1.1,192.168.0.1#test.lxd ipv6.dns ::1,abcd::1#test.lxd
Connection 'dummy-dummy0' (be1d82a1-fa3a-4587-b100-196376c0da3a) successfully added.
root@test:~# nmcli con add type dummy ifname dummy1 ipv4.dns 1.1.1.1,192.168.0.1#test.lxd ipv6.dns ::1,abcd::1
Connection 'dummy-dummy1' (6cf3a6c9-716c-462a-bf6f-0509406d90a0) successfully added.
root@test:~# nmcli con add type dummy ifname dummy2 ipv4.dns 1.1.1.1,192.168.0.1 ipv6.dns ::1,abcd::1#test.lxd
Connection 'dummy-dummy2' (04f55279-cd31-49b6-bcfa-b01e3354b85b) successfully added.
root@test:~# nmcli con add type dummy ifname dummy3 ipv4.dns 1.1.1.1,192.168.0.1 ipv6.dns ::1,abcd::1
Connection 'dummy-dummy3' (2eb2a6af-5c92-44c9-b978-15ac262c73a7) successfully added.

root@test:~# netplan get
network:
  version: 2
  renderer: networkd
  ethernets:
    enp5s0:
      dhcp4: true
      dhcp6: false
      link-local:
      - ipv4
      - ipv6
  dummy-devices:
    NM-04f55279-cd31-49b6-bcfa-b01e3354b85b:
      renderer: NetworkManager
      nameservers:
        addresses:
        - 1.1.1.1
        - 192.168.0.1
      dhcp4: true
      dhcp6: true
      networkmanager:
        uuid: "04f55279-cd31-49b6-bcfa-b01e3354b85b"
        name: "dummy-dummy2"
        passthrough:
          connection.interface-name: "dummy2"
          dummy._: ""
          ipv6.addr-gen-mode: "default"
          ipv6.dns: "::1;abcd::1#test.lxd;"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
    NM-2eb2a6af-5c92-44c9-b978-15ac262c73a7:
      renderer: NetworkManager
      nameservers:
        addresses:
        - 1.1.1.1
        - 192.168.0.1
        - ::1
        - abcd::1
      dhcp4: true
      dhcp6: true
      networkmanager:
        uuid: "2eb2a6af-5c92-44c9-b978-15ac262c73a7"
        name: "dummy-dummy3"
        passthrough:
          connection.interface-name: "dummy3"
          dummy._: ""
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
    NM-6cf3a6c9-716c-462a-bf6f-0509406d90a0:
      renderer: NetworkManager
      nameservers:
        addresses:
        - ::1
        - abcd::1
      dhcp4: true
      dhcp6: true
      networkmanager:
        uuid: "6cf3a6c9-716c-462a-bf6f-0509406d90a0"
        name: "dummy-dummy1"
        passthrough:
          connection.interface-name: "dummy1"
          dummy._: ""
          ipv4.dns: "1.1.1.1;192.168.0.1#test.lxd;"
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
    NM-be1d82a1-fa3a-4587-b100-196376c0da3a:
      renderer: NetworkManager
      dhcp4: true
      dhcp6: true
      networkmanager:
        uuid: "be1d82a1-fa3a-4587-b100-196376c0da3a"
        name: "dummy-dummy0"
        passthrough:
          connection.interface-name: "dummy0"
          dummy._: ""
          ipv4.dns: "1.1.1.1;192.168.0.1#test.lxd;"
          ipv6.addr-gen-mode: "default"
          ipv6.dns: "::1;abcd::1#test.lxd;"
          ipv6.ip6-privacy: "-1"
          proxy._: ""
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

