### PR TITLE
meson: Build using Python 3.10 limited API (LP: #2050881)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,6 +58,7 @@ jobs:
     # Installs the build dependencies
     - name: Install build depends
       run: |
+        echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
         sudo sed -i 's/Types: deb/Types: deb deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         sudo apt update
         sudo apt install meson python3-coverage python3-pytest python3-pytest-cov libcmocka-dev python3-cffi libpython3-dev

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -21,7 +21,7 @@ jobs:
           - fedora:latest
           - almalinux:10-kitten
           - almalinux:10
-          - almalinux:9
+          # - almalinux:9  # lacking meson >= 1.3.0
     container:
       image: ${{ matrix.container }}
     steps:

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project('netplan', 'c',
             'warning_level=2',
             'werror=true',
         ],
-        meson_version: '>= 0.61.0',
+        meson_version: '>= 1.3.0',
 )
 
 glib = dependency('glib-2.0')

--- a/python-cffi/netplan/meson.build
+++ b/python-cffi/netplan/meson.build
@@ -24,6 +24,7 @@ cffi_pyext = python.extension_module(
     link_with: [libnetplan],
     subdir: 'netplan',
     install: true,
+    limited_api: '3.10',
 )
 
 bindings_sources = [

--- a/rpm/netplan.spec
+++ b/rpm/netplan.spec
@@ -25,7 +25,7 @@ URL:            http://netplan.io/
 Source0:        https://github.com/canonical/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc
-BuildRequires:  meson
+BuildRequires:  meson >= 1.3
 BuildRequires:  pkgconfig(bash-completion)
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(gio-2.0)


### PR DESCRIPTION
## Description
Building a `/usr/lib/python3/dist-packages/netplan/_netplan_cffi.abi3.so` binary module for `python3-netplan` (instead of  `_netplan_cffi.cpython-311-x86_64-linux-gnu.so`/`_netplan_cffi.cpython-312-x86_64-linux-gnu.so`), making transitions and increasing Python compatibility.

This requires meson >= 1.3.0

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#2050881

