### PR TITLE
ATTN: parse/bonds: handle same primary in multiple bonds

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2314,8 +2314,9 @@ handle_bond_primary_member(NetplanParser* npp, yaml_node_t* node, const void* da
 
         ref_ptr = ((char**) ((void*) component + GPOINTER_TO_UINT(data)));
         if (*ref_ptr) {
-            return yaml_error(npp, node, error, "%s: interface '%s' is already a primary of another bond",
-                              npp->current.netdef->id, *ref_ptr);
+            NetplanNetDefinition* bond = _netplan_parser_find_bond_for_primary_member(npp, *ref_ptr);
+            return yaml_error(npp, node, error, "%s: interface '%s' is already a primary of %s",
+                              npp->current.netdef->id, *ref_ptr, bond->id);
         }
         *ref_ptr = g_strdup(scalar(node));
         npp->current.netdef->bond_params.primary_member = g_strdup(scalar(node));

--- a/src/parse.c
+++ b/src/parse.c
@@ -2313,6 +2313,10 @@ handle_bond_primary_member(NetplanParser* npp, yaml_node_t* node, const void* da
                               npp->current.netdef->id, npp->current.netdef->bond_params.primary_member);
 
         ref_ptr = ((char**) ((void*) component + GPOINTER_TO_UINT(data)));
+        if (*ref_ptr) {
+            return yaml_error(npp, node, error, "%s: interface '%s' is already a primary of another bond",
+                              npp->current.netdef->id, *ref_ptr);
+        }
         *ref_ptr = g_strdup(scalar(node));
         npp->current.netdef->bond_params.primary_member = g_strdup(scalar(node));
         mark_data_as_dirty(npp, ref_ptr);

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -78,6 +78,9 @@ netplan_netdef_new(NetplanParser* npp, const char* id, NetplanDefType type, Netp
 const char *
 netplan_parser_get_filename(NetplanParser* npp);
 
+NetplanNetDefinition*
+_netplan_parser_find_bond_for_primary_member(const NetplanParser* npp, const char* primary);
+
 gboolean
 has_openvswitch(const NetplanOVSSettings* ovs, NetplanBackend backend, GHashTable *ovs_ports);
 

--- a/src/util.c
+++ b/src/util.c
@@ -1184,3 +1184,23 @@ _is_valid_macaddress(const char* value)
 
     return regexec(&re, value, 0, NULL, 0) == 0;
 }
+
+/* Given a netdef ID, look for the netdef representing a bond device that has it as primary member */
+NetplanNetDefinition*
+_netplan_parser_find_bond_for_primary_member(const NetplanParser* npp, const char* primary)
+{
+    GList* iter = npp->ordered;
+    NetplanNetDefinition* netdef = NULL;
+
+    while (iter) {
+        netdef = iter->data;
+        if (netdef->type == NETPLAN_DEF_TYPE_BOND) {
+            if (!g_strcmp0(netdef->bond_params.primary_member, primary)) {
+                break;
+            }
+        }
+        iter = iter->next;
+    }
+
+    return netdef;
+}

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -980,7 +980,7 @@ class TestConfigErrors(TestBase):
     bond1:
       parameters:
         primary: eno1''', expect_fail=True)
-        self.assertIn("bond1: interface 'eno1' is already a primary of another bond", err)
+        self.assertIn("bond1: interface 'eno1' is already a primary of bond0", err)
 
     def test_bond_bridge_cross_assignments1(self):
         err = self.generate('''network:

--- a/tests/generator/test_bonds.py
+++ b/tests/generator/test_bonds.py
@@ -968,6 +968,20 @@ class TestConfigErrors(TestBase):
       interfaces: [eno1]''', expect_fail=True)
         self.assertIn("bond1: interface 'eno1' is already assigned to bond bond0", err)
 
+    def test_bond_primary_multiple_assignments(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    eno1: {}
+  bonds:
+    bond0:
+      parameters:
+        primary: eno1
+    bond1:
+      parameters:
+        primary: eno1''', expect_fail=True)
+        self.assertIn("bond1: interface 'eno1' is already a primary of another bond", err)
+
     def test_bond_bridge_cross_assignments1(self):
         err = self.generate('''network:
   version: 2


### PR DESCRIPTION
Error out if an interface is declared as primary of multiple bonds. Besides being wrong it's causing a memory leak.


## Description

Found with https://github.com/daniloegea/netplan-fuzz

Test case:

```yaml
network:
  version: 2
  ethernets:
    eno1: {}
  bonds:
    bond0:
      parameters:
        primary: eno1
    bond1:
      parameters:
        primary: eno1
```

Result

```
$ ./build/src/generate --root-dir /tmp/fakeroot

=================================================================
==1732948==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x711093a8bb27 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x711093794ed9 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x62ed9) (BuildId: ab12e476c12cb3b1fbdd6b86b800846e3dd61000)
    #2 0x7110937aa8a8 in g_strdup (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x788a8) (BuildId: ab12e476c12cb3b1fbdd6b86b800846e3dd61000)
    #3 0x7110939154b9 in g_strdup_inline /usr/include/glib-2.0/glib/gstrfuncs.h:321
    #4 0x7110939154b9 in handle_bond_primary_member ../src/parse.c:2316
    #5 0x711093906547 in process_mapping ../src/parse.c:316
    #6 0x711093915fef in handle_bonding ../src/parse.c:2417
    #7 0x711093906336 in process_mapping ../src/parse.c:310
    #8 0x71109391b5b7 in handle_network_type ../src/parse.c:3302
    #9 0x711093906336 in process_mapping ../src/parse.c:310
    #10 0x7110939063bf in process_mapping ../src/parse.c:312
    #11 0x71109391c4c0 in process_document ../src/parse.c:3446
    #12 0x71109391cb46 in _netplan_parser_load_single_file ../src/parse.c:3504
    #13 0x71109391cebc in netplan_parser_load_yaml ../src/parse.c:3543
    #14 0x7110939356a0 in netplan_parser_load_yaml_hierarchy ../src/util.c:661
    #15 0x5a1f00e1f5ec in main ../src/generate.c:252
    #16 0x7110933131c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #17 0x71109331328a in __libc_start_main_impl ../csu/libc-start.c:360
    #18 0x5a1f00e1d984 in _start (/workspace/netplan-daniloegea/build/src/generate+0x4984) (BuildId: f5aec88fce01a307e0e73c220482bbfa56019c2f)

SUMMARY: AddressSanitizer: 5 byte(s) leaked in 1 allocation(s).
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

