### PR TITLE
tests: import the config fuzzing tests

### DIFF
--- a/.github/workflows/config-fuzzing.yml
+++ b/.github/workflows/config-fuzzing.yml
@@ -1,0 +1,43 @@
+name: Configuration fuzzing
+
+# This action will compile netplan with ASAN (address sanitizer),
+# generate random netplan YAML and call netplan generate against each
+# one of them.
+# The job will fail if issues are detected.
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    branches: [ '**' ]
+    paths-ignore:
+      - 'doc/**'
+
+jobs:
+  config-fuzzer:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install build depends
+        run: |
+          echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
+          # This PPA is needed here due to meson
+          sudo add-apt-repository -y -u -s ppa:slyon/netplan-ci
+          sudo apt update
+          sudo apt -y install curl expect ubuntu-dev-tools devscripts equivs
+          sudo snap install node --classic
+          pull-lp-source netplan.io
+          sed -i 's| systemd-dev|# DELETED: systemd-dev|' netplan.io-*/debian/control
+          # Workaround for https://bugs.launchpad.net/bugs/2048768
+          sudo sysctl vm.mmap_rnd_bits=28
+          mk-build-deps -i -B -s sudo netplan.io-*/debian/control
+
+      - name: Fuzzer Runner
+        run: |
+          cd tests/config_fuzzer
+          unbuffer bash runner.sh ../../ 1000
+

--- a/tests/config_fuzzer/README.md
+++ b/tests/config_fuzzer/README.md
@@ -1,0 +1,55 @@
+config_fuzzer uses [json-schema-faker](https://github.com/json-schema-faker/json-schema-faker) to generate random Netplan YAML files from a JSON schema.
+
+## How to use it
+
+* Clone Netplan and install the dependencies
+```
+git clone https://github.com/canonical/netplan.git
+cd netplan/tests/config_fuzzer
+npm install
+```
+
+You will also need to install `nodejs` and `npm`.
+
+* Run it
+```
+node index.js
+```
+
+A bunch of YAML files will be created in the directory `fakedata`.
+
+You can create more YAMLs per device type with:
+
+```
+node index.js 100
+```
+
+In this example, 100 YAMLs per device type will be created.
+
+* Run netplan against the YAMLs
+
+```
+mkdir -p fakeroot/etc/netplan
+cp fakedata/someyaml.yaml fakeroot/etc/netplan/
+netplan generate --root-dir fakeroot
+```
+
+* Using the runner.sh script
+
+You can also automatically test netplan against all the generated YAML files:
+
+```
+bash runner.sh /path/to/netplan_source_code 100
+```
+
+This script will build netplan, generate the random YAMLs and test the netplan generator against each one of them.
+
+This script will do these things in this order:
+
+ * Build Netplan with ASAN enabled
+ * Build the tools/keyfile_to_yaml with ASAN from Netplan
+ * Install the node modules
+ * Generate a number of random Netplan YAMLs
+ * Call `netplan generate` for each one of them separately
+ * If it results in NetworkManager files, try to load them with the keyfile_to_yaml tool
+ * Call netplan generate again for the YAMLs created by the keyfile_to_yaml tool

--- a/tests/config_fuzzer/index.js
+++ b/tests/config_fuzzer/index.js
@@ -1,0 +1,244 @@
+import writeYamlFile from 'write-yaml-file';
+import { JSONSchemaFaker } from "json-schema-faker";
+import { faker } from '@faker-js/faker';
+
+import * as fs from 'node:fs';
+
+import ethernets_schema from './schemas/ethernets.js';
+import wifis_schema from './schemas/wifis.js';
+import vrfs_schema from './schemas/vrfs.js';
+import vlans_schema from './schemas/vlans.js';
+import bridges_schema from './schemas/bridges.js';
+import bonds_schema from './schemas/bonds.js';
+import nmdevices_schema from './schemas/nm-devices.js';
+import { wireguard_schema, sit_schema, vxlan_schema } from './schemas/tunnels.js';
+import modems_schema from './schemas/modems.js';
+import openvswitch_schema from './schemas/openvswitch.js'
+import dummy_devices_schema from './schemas/dummy-devices.js';
+import virtual_ethernets_schema from './schemas/virtual-ethernets.js';
+
+import { randomBytes } from "node:crypto";
+
+JSONSchemaFaker.extend('faker', () => {
+    faker.macaddress = {
+        mac: _ => {
+            var items = [faker.internet.mac(), "permanent", "random", "stable", "preserve"];
+            return items[Math.floor(Math.random() * 1000) % 4];
+        }
+    },
+    faker.ipv4 = {
+        withprefix: _ => {
+            return faker.internet.ipv4() + '/24';
+        }
+    }
+    faker.ipv6 = {
+        withprefix: _ => {
+            return faker.internet.ipv6() + '/64';
+        }
+    }
+    faker.ipv4_or_ipv6 = {
+        withprefix: _ => {
+            if (Math.floor(Math.random() * 1000) % 2 == 0) {
+                return faker.internet.ipv6() + '/64';
+            } else {
+                return faker.internet.ipv4() + '/24';
+            }
+        },
+        withoutprefix: _ => {
+            if (Math.floor(Math.random() * 1000) % 2 == 0) {
+                return faker.internet.ipv6();
+            } else {
+                return faker.internet.ipv4();
+            }
+        },
+        withport: _ => {
+            var port = Math.floor(Math.random() * 65536);
+            if (Math.floor(Math.random() * 1000) % 2 == 0) {
+                return faker.internet.ipv6() + ":" + port.toString();
+            } else {
+                return faker.internet.ipv4() + ":" + port.toString();
+            }
+        }
+    }
+    faker.openvswitch = {
+        controller_address: _ => {
+            var number = Math.floor(Math.random() * 65536) % 6;
+            if (number == 0) {
+                return "unix:" + faker.system.filePath();
+            } else if (number == 1) {
+                return "punix:" + faker.system.filePath();
+            } else if (number == 2) {
+                return "tcp:" + faker.internet.ipv4() + ":" + faker.internet.port();
+            } else if (number == 3) {
+                return "ptcp:" + faker.internet.port() + ":" + faker.internet.ipv4();
+            } else if (number == 4) {
+                return "ssl:" + faker.internet.ipv4() + ":" + faker.internet.port();
+            } else if (number == 5) {
+                return "pssl:" + faker.internet.port() + ":" + faker.internet.ipv4();
+            }
+        }
+    }
+    return faker;
+});
+
+
+function apply_fixes(object, object_type) {
+    var renderer = ""
+    if (!("network" in object) || !(object_type in object["network"])) {
+        return;
+    }
+
+    if ("renderer" in object) {
+        renderer = object["renderer"];
+    }
+
+    var interfaces = object["network"][object_type]
+
+    if ("renderer" in object["network"]) {
+        renderer = object["network"]["renderer"];
+    }
+
+    Object.keys(interfaces).forEach(function (key) {
+        var has_address_options = false;
+
+        if (key != "renderer") {
+            var iface = interfaces[key];
+
+            if ("renderer" in iface) {
+                renderer = iface["renderer"];
+            }
+
+            /*
+            If addresses as objects were generated, set the renderer to networkd.
+            NetworkManager doesn't support addresses options
+            */
+            if ("addresses" in iface) {
+                Object.keys(iface["addresses"]).forEach(function (key) {
+                    if (typeof iface["addresses"][key] === 'object') {
+                        interfaces["renderer"] = "networkd";
+                        object["network"]["renderer"] = "networkd";
+                        iface["renderer"] = "networkd";
+                        renderer = "networkd";
+                        has_address_options = true;
+                        return;
+                    }
+                });
+            }
+
+            /*
+            If it has the networkmanager property and the renderer is not NetworkManager delete it
+            */
+            if ("networkmanager" in iface && renderer != "NetworkManager") {
+                delete object["network"][object_type][key]["networkmanager"];
+            } else {
+                /*
+                If the interface doesn't have addresses options, make sure the interface itself has renderer: NetworkManager
+                */
+                if (has_address_options == false) {
+                    iface["renderer"] = "NetworkManager";
+                }
+            }
+
+            if (object_type == "wifis") {
+                if ("access-points" in iface) {
+                    Object.keys(iface["access-points"]).forEach(function (ap_key) {
+                        if ("networkmanager" in iface["access-points"][ap_key] && renderer != "NetworkManager") {
+                            delete object["network"][object_type][key]["access-points"][ap_key]["networkmanager"];
+                        } else {
+                            /*
+                            If the interface doesn't have addresses options, make sure the interface itself has renderer: NetworkManager
+                            */
+                            if (has_address_options == false) {
+                                iface["renderer"] = "NetworkManager";
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    });
+}
+
+
+function getRandomFilename() {
+    return randomBytes(32).toString('hex') + '.yaml';
+}
+
+function writeSchema(schema) {
+    var filename = getRandomFilename();
+    writeYamlFile.sync(`${destDir}/${filename}`, schema, {mode: 0o600});
+}
+
+function generateYAML(schema) {
+    return JSONSchemaFaker.generate(schema);
+}
+
+const destDir = "fakedata";
+fs.mkdirSync(destDir, { recursive: true });
+
+var numberOfFiles = 1;
+
+if (process.argv.length == 3) {
+    numberOfFiles = parseInt(process.argv[2]);
+}
+
+while (numberOfFiles > 0) {
+
+    numberOfFiles = numberOfFiles - 1;
+
+    var schema = generateYAML(ethernets_schema);
+    apply_fixes(schema, "ethernets");
+    writeSchema(schema);
+
+    schema = generateYAML(wifis_schema);
+    apply_fixes(schema, "wifis");
+    writeSchema(schema);
+
+    schema = generateYAML(vrfs_schema);
+    apply_fixes(schema, "vrfs");
+    writeSchema(schema);
+
+    schema = generateYAML(vlans_schema);
+    apply_fixes(schema, "vlans");
+    writeSchema(schema);
+
+    schema = generateYAML(bridges_schema);
+    apply_fixes(schema, "bridges");
+    writeSchema(schema);
+
+    schema = generateYAML(bonds_schema);
+    apply_fixes(schema, "bonds");
+    writeSchema(schema);
+
+    schema = generateYAML(wireguard_schema);
+    apply_fixes(schema, "tunnels");
+    writeSchema(schema);
+
+    schema = generateYAML(sit_schema);
+    apply_fixes(schema, "tunnels");
+    writeSchema(schema);
+
+    schema = generateYAML(vxlan_schema);
+    apply_fixes(schema, "vxlans");
+    writeSchema(schema);
+
+    schema = generateYAML(nmdevices_schema);
+    apply_fixes(schema, "nmdevices");
+    writeSchema(schema);
+
+    schema = generateYAML(modems_schema);
+    apply_fixes(schema, "modems");
+    writeSchema(schema);
+
+    schema = generateYAML(openvswitch_schema);
+    apply_fixes(schema, "ovs");
+    writeSchema(schema);
+
+    schema = generateYAML(dummy_devices_schema);
+    apply_fixes(schema, "dummy-devices");
+    writeSchema(schema);
+
+    schema = generateYAML(virtual_ethernets_schema);
+    apply_fixes(schema, "virtual-ethernets");
+    writeSchema(schema);
+}

--- a/tests/config_fuzzer/package.json
+++ b/tests/config_fuzzer/package.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "@faker-js/faker": "^8.4.1",
+    "json-schema-faker": "^0.5.6",
+    "write-yaml-file": "^5.0.0"
+  },
+  "name": "netplan_fuzzer",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "run": "node index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/tests/config_fuzzer/runner.sh
+++ b/tests/config_fuzzer/runner.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+NETPLANPATH=$1
+NUMBER_OF_YAMLS_PER_TYPE=$2
+
+if [ -z ${NUMBER_OF_YAMLS_PER_TYPE} ]
+then
+    echo "Usage: $0 <netplan source path> <number of YAMLs per netdef type>"
+    exit 1
+fi
+
+RESULTS_DIR="results_$(date "+%Y%m%d%H%M")"
+FAKEDATADIR=fakedata
+CC=gcc
+BUILDDIR=${NETPLANPATH}/_fuzzer_build
+NETPLAN_GENERATE_PATH=${BUILDDIR}/src/generate
+
+export G_DEBUG=fatal_criticals
+export LD_LIBRARY_PATH=${BUILDDIR}/src
+
+mkdir ${RESULTS_DIR} || true
+
+if [ ! -d ${BUILDDIR} ]
+then
+    meson setup --prefix=/usr -Db_sanitize=address ${BUILDDIR} ${NETPLANPATH}
+fi
+meson compile -C ${BUILDDIR}
+
+${CC} ${NETPLANPATH}/tools/keyfile_to_yaml.c -o keyfile_to_yaml \
+    $(pkg-config --cflags --libs glib-2.0) \
+    -I${NETPLANPATH}/include -L${BUILDDIR}/src -lnetplan \
+    -fsanitize=address,undefined -g
+
+npm install
+
+echo "$(date) - Generating fake data"
+node index.js ${NUMBER_OF_YAMLS_PER_TYPE}
+echo "$(date) - Done"
+
+echo "$(date) - Testing generator + keyfile loader..."
+
+error=0
+
+for yaml in ${FAKEDATADIR}/*.yaml
+do
+
+    rm -rf fakeroot fakeroot2
+    mkdir -p fakeroot/etc/netplan fakeroot2/etc/netplan
+    cp ${yaml} fakeroot/etc/netplan/
+
+    OUTPUT=$(${NETPLAN_GENERATE_PATH} --root-dir fakeroot 2>&1)
+    code=$?
+    if [ $code -eq 139 ] || [ $code -eq 245 ] || [ $code -eq 133 ]
+    then
+        dir=${RESULTS_DIR}/crash_$(date "+%Y%m%d%H.%N")
+        echo "GENERATE CRASHED: ${OUTPUT}"
+        echo "YAML THE CAUSED THE CRASH:"
+        cat ${yaml}
+        echo "GENERATE: Saving crash to ${dir}"
+        cp -r fakeroot ${dir}
+        error=1
+    fi
+
+    if grep 'detected memory leaks' <<< "$OUTPUT" > /dev/null
+    then
+        dir=${RESULTS_DIR}/crash_$(date "+%Y%m%d%H.%N")
+        echo "GENERATE MEMORY LEAK DETECTED: ${OUTPUT}"
+        echo "YAML THE CAUSED THE MEMORY LEAK:"
+        cat ${yaml}
+        echo "GENERATE: Saving memory leak to ${dir}"
+        cp -r fakeroot ${dir}
+        error=1
+    fi
+
+    echo "YAML: ${yaml}" >> "${RESULTS_DIR}"/generate.log
+    echo "${OUTPUT}" >> "${RESULTS_DIR}"/generate.log
+
+    if [ -d fakeroot/run ] && [ -d fakeroot/run/NetworkManager ]
+    then
+        for keyfile in $(find fakeroot/run/NetworkManager/system-connections/ -type f 2>/dev/null)
+        do
+            sed -i 's/\[connection\]/\[connection\]\nuuid=c87fb5fc-f607-45f3-8fcd-720b83a742e4/' "${keyfile}"
+            filename=$(basename ${keyfile})
+            ./keyfile_to_yaml ${keyfile} > fakeroot2/etc/netplan/${filename}.yaml 2>> ${RESULTS_DIR}/keyfile.log
+
+            code=$?
+            if [ $code -eq 1 ]
+            then
+                dir=${RESULTS_DIR}/keyfile_$(date "+%Y%m%d%H.%N")
+                echo "Keyfile loader failed: Saving test case to ${dir}"
+                cp -r fakeroot ${dir}
+            fi
+        done
+
+        OUTPUT=$(${NETPLAN_GENERATE_PATH} --root-dir fakeroot2 2>&1)
+        code=$?
+        if [ $code -eq 139 ] || [ $code -eq 245 ] || [ $code -eq 133 ]
+        then
+            dir=${RESULTS_DIR}/generate_from_keyfile_$(date "+%Y%m%d%H.%N")
+            echo "GENERATE FROM KEYFILE GENERATED YAMLS CRASHED: ${OUTPUT}"
+            echo "GENERATE: Saving crash to ${dir}"
+            cp -r fakeroot2 ${dir}
+            error=1
+        fi
+
+        if grep 'detected memory leaks' <<< "$OUTPUT" > /dev/null
+        then
+            dir=${RESULTS_DIR}/generate_from_keyfile_$(date "+%Y%m%d%H.%N")
+            echo "GENERATE FROM KEYFILE GENERATED YAML MEMORY LEAK DETECTED: ${OUTPUT}"
+            echo "GENERATE: Saving memory leak to ${dir}"
+            cp -r fakeroot2 ${dir}
+            error=1
+        fi
+        echo "${OUTPUT}" >> "${RESULTS_DIR}"/generate_from_keyfile.log
+
+    fi
+
+done
+
+echo "$(date) - Done"
+
+exit ${error}

--- a/tests/config_fuzzer/schemas/bonds.js
+++ b/tests/config_fuzzer/schemas/bonds.js
@@ -1,0 +1,217 @@
+import * as common from "./common.js";
+
+const bonds_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                ethernets: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "eth10": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth11": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth12": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth13": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth14": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth15": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth16": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                    },
+                    required: ["eth10", "eth11", "eth12", "eth13", "eth14", "eth15", "eth16"]
+                },
+                bonds: {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                ...common.common_properties,
+                                interfaces: {
+                                    type: "array",
+                                    uniqueItems: true,
+                                    items: {
+                                        type: "string",
+                                        enum: ["eth10", "eth11", "eth12"]
+                                    }
+                                },
+                                parameters: {
+                                    type: "object",
+                                    additionalProperties: false,
+                                    properties: {
+                                        "mode": {
+                                            type: "string",
+                                            enum: ["balance-rr", "active-backup", "balance-xor",
+                                            "broadcast", "802.3ad", "balance-tlb", "balance-alb"]
+                                        },
+                                        "lacp-rate": {
+                                            type: "string",
+                                            enum: ["fast", "slow"]
+                                        },
+                                        "mii-monitor-interval": {
+                                            type: "integer",
+                                            minimum: 0,
+                                        },
+                                        "min-links": {
+                                            type: "integer",
+                                            minimum: 0
+                                        },
+                                        "transmit-hash-policy": {
+                                            type: "string",
+                                            enum: ["layer2", "layer3+4", "layer2+3", "encap2+3", "encap3+4"]
+                                        },
+                                        "ad-select": {
+                                            type: "string",
+                                            enum: ["stable", "bandwidth", "count"]
+                                        },
+                                        "all-members-active": {
+                                            type: "boolean"
+                                        },
+                                        "arp-interval": {
+                                            type: "integer",
+                                            minimum: 0
+                                        },
+                                        "arp-ip-targets": {
+                                            type: "array",
+                                            items: {
+                                                type: "string",
+                                                faker: "internet.ipv4"
+                                            }
+                                        },
+                                        "arp-validate": {
+                                            type: "string",
+                                            enum: ["none", "active", "backup", "all"]
+                                        },
+                                        "arp-all-targets": {
+                                            type: "string",
+                                            enum: ["any", "all"]
+                                        },
+                                        "up-delay": {
+                                            type: "integer",
+                                            minimum: 0
+                                        },
+                                        "down-delay": {
+                                            type: "integer",
+                                            minimum: 0
+                                        },
+                                        "fail-over-mac-policy": {
+                                            type: "string",
+                                            enum: ["none", "active", "follow"]
+                                        },
+                                        "gratuitous-arp": {
+                                            type: "integer",
+                                            minimum: 0,
+                                            maximum: 255
+                                        },
+                                        "packets-per-member": {
+                                            type: "integer",
+                                            minimum: 0
+                                        },
+                                        "primary-reselect-policy": {
+                                            type: "string",
+                                            enum: ["always", "better", "failure"]
+                                        },
+                                        "resend-igmp": {
+                                            type: "integer",
+                                            minimum: 0,
+                                            maximum: 255
+                                        },
+                                        "learn-packet-interval": {
+                                            type: "integer",
+                                            minimum: 1,
+                                            maximum: 0x7fffffff
+                                        },
+                                        primary: {
+                                            type: "string",
+                                            enum: ["eth10", "eth11", "eth12"]
+                                        },
+                                    },
+                                    ...common.networkmanager_settings,
+                                }
+                            },
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["bonds", "ethernets"]
+        }
+    }
+}
+
+
+export default bonds_schema;

--- a/tests/config_fuzzer/schemas/bridges.js
+++ b/tests/config_fuzzer/schemas/bridges.js
@@ -1,0 +1,154 @@
+import * as common from "./common.js";
+
+const bridges_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                ethernets: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "eth0": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth1": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth2": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        }
+                    },
+                    required: ["eth0", "eth1", "eth2"]
+                },
+                bridges: {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                ...common.common_properties,
+                                interfaces: {
+                                    type: "array",
+                                    uniqueItems: true,
+                                    items: {
+                                        type: "string",
+                                        enum: ["eth0", "eth1", "eth2"]
+                                    }
+                                },
+                                parameters: {
+                                    type: "object",
+                                    additionalProperties: false,
+                                    properties: {
+                                        "ageing-time": {
+                                            type: "string"
+                                        },
+                                        "aging-time": {
+                                            type: "string"
+                                        },
+                                        priority: {
+                                            type: "integer",
+                                            minimum: 0,
+                                            maximum: 65535
+                                        },
+                                        "port-priority": {
+                                            type: "object",
+                                            additionalProperties: false,
+                                            properties: {
+                                                eth0: {
+                                                    type: "integer",
+                                                    minimum: 0,
+                                                    maximum: 63
+                                                },
+                                                eth1: {
+                                                    type: "integer",
+                                                    minimum: 0,
+                                                    maximum: 63
+                                                },
+                                                eth2: {
+                                                    type: "integer",
+                                                    minimum: 0,
+                                                    maximum: 63
+                                                },
+                                            }
+                                        },
+                                        "forward-delay": {
+                                            type: "string"
+                                        },
+                                        "hello-time": {
+                                            type: "string"
+                                        },
+                                        "max-age": {
+                                            type: "string"
+                                        },
+                                        "path-cost": {
+                                            type: "object",
+                                            additionalProperties: false,
+                                            properties: {
+                                                eth0: {
+                                                    type: "integer",
+                                                },
+                                                eth1: {
+                                                    type: "integer",
+                                                },
+                                                eth2: {
+                                                    type: "integer",
+                                                },
+                                            }
+                                        },
+                                        stp: {
+                                            type: "boolean"
+                                        }
+                                    }
+                                },
+                                ...common.networkmanager_settings,
+                                ...common.openvswitch_bridge_extras
+                            },
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["ethernets", "bridges"]
+        }
+    }
+}
+
+export default bridges_schema;

--- a/tests/config_fuzzer/schemas/common.js
+++ b/tests/config_fuzzer/schemas/common.js
@@ -1,0 +1,286 @@
+export const minMaxProperties = {
+    minProperties: 3,
+    maxProperties: 10,
+};
+
+export const routes = {
+    routes: {
+        type: "array",
+        items: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                from: {
+                    type: "string",
+                    faker: "ipv4.withprefix"
+                },
+                to: {
+                    type: "string",
+                    faker: "ipv4.withprefix"
+                },
+                via: {
+                    type: "string",
+                    faker: "internet.ipv4"
+                },
+                "on-link": {
+                    type: "boolean"
+                },
+                metric: {
+                    type: "integer",
+                    minimum: 0
+                },
+                type: {
+                    type: "string",
+                    enum: ["unicast", "anycast", "blackhole", "broadcast", "local", "multicast", "nat", "prohibit", "throw", "unreachable", "xresolve"]
+                },
+                scope: {
+                    type: "string",
+                    enum: ["global", "link", "host"]
+                },
+                table: {
+                    type: "integer",
+                    minimum: 0
+                },
+                mtu: {
+                    type: "integer",
+                    minimum: 0
+                },
+                "congestion-window": {
+                    type: "integer",
+                    minimum: 0
+                },
+                "advertised-receive-window": {
+                    type: "integer",
+                    minimum: 0
+                }
+
+            },
+            required: ["to", "via"]
+        }
+    }
+};
+export const routing_policy = {
+    "routing-policy": {
+        type: "array",
+        items: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                from: {
+                    type: "string",
+                    faker: "ipv4.withprefix"
+                },
+                to: {
+                    type: "string",
+                    faker: "ipv4.withprefix"
+                },
+                table: {
+                    type: "integer",
+                    minimum: 0,
+                },
+                priority: {
+                    type: "integer",
+                    minimum: 0,
+                },
+                mark: {
+                    type: "integer",
+                    minimum: 0,
+                },
+                "type-of-service": {
+                    type: "integer",
+                    minimum: 0,
+                    maximum: 255
+                }
+            },
+            required: ["to", "via"],
+        }
+    }
+};
+
+export const common_properties = {
+    dhcp4: {
+        type: "boolean"
+    },
+    dhcp6: {
+        type: "boolean"
+    },
+    critical: {
+        type: "boolean"
+    },
+    "dhcp-identifier": {
+        type: "string",
+        enum: ["duid", "mac"]
+    },
+    "accept-ra": {
+        type: "boolean"
+    },
+    gateway4: {
+        type: "string",
+        faker: "internet.ipv4"
+    },
+    gateway6: {
+        type: "string",
+        faker: "internet.ipv6"
+    },
+    addresses: {
+        type: "array",
+        items: {
+            anyOf: [
+                {
+                    type: "string",
+                    faker: "ipv4_or_ipv6.withprefix",
+                },
+                {
+                    type: "object",
+                    patternProperties: {
+                        "192\\.168\\.[1-9]{2}\\.0/24": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                lifetime: {
+                                    type: "string",
+                                    enum: ["forever", 0]
+                                },
+                                label: {
+                                    type: "string",
+                                    maxLength: 15,
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    nameservers: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+            search: {
+                type: "array",
+                items: {
+                    type: "string",
+                    faker: "internet.domainName",
+                }
+            },
+            addresses: {
+                type: "array",
+                items: {
+
+                    anyOf: [
+                        {
+                            type: "string",
+                            faker: "internet.ipv4",
+                            format: "ipv4"
+                        },
+                        {
+                            type: "string",
+                            faker: "internet.ipv6",
+                            format: "ipv6"
+                        }
+
+                    ]
+                }
+            }
+        }
+    },
+    ...routes,
+    ...routing_policy
+};
+
+export const networkmanager_settings = {
+    networkmanager: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+            uuid: {
+                type: "string"
+            },
+            name: {
+                type: "string"
+            },
+            passthrough: {
+                type: "object",
+                additionalProperties: true,
+                properties: {
+                    "connection.type": {
+                        type: "string"
+                    }
+                },
+            }
+        },
+        required: ["passthrough"]
+    }
+};
+
+export const openvswitch_bond_extras = {
+    openvswitch: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+            "external-ids": {
+                type: "object"
+            },
+            "other-config": {
+                type: "object"
+            },
+            lacp: {
+                type: "string",
+                enum: ["active", "passive", "off"]
+            },
+        },
+        required: ["passthrough"]
+    }
+};
+
+export const openvswitch_bridge_extras = {
+    openvswitch: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+            "external-ids": {
+                type: "object"
+            },
+            "other-config": {
+                type: "object"
+            },
+            "fail-mode": {
+                type: "string",
+                enum: ["standalone", "secure"]
+            },
+            "mcast-snooping": {
+                type: "boolean"
+            },
+            rstp: {
+                type: "boolean"
+            },
+            protocols: {
+                type: "array",
+                items: {
+                    type: "string",
+                    enum: ["OpenFlow10", "OpenFlow11", "OpenFlow12", "OpenFlow13", "OpenFlow14", "OpenFlow15"]
+                }
+            },
+            "controller": {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                    "addresses": {
+                        type: "array",
+                        items: {
+                            type: "string",
+                            faker: "openvswitch.controller_address"
+                        }
+                    },
+                    "connection-mode": {
+                        type: "string",
+                        enum: ["in-band", "out-of-band"]
+                    }
+
+                }
+            }
+        },
+    }
+};
+
+export default common_properties;

--- a/tests/config_fuzzer/schemas/dummy-devices.js
+++ b/tests/config_fuzzer/schemas/dummy-devices.js
@@ -1,0 +1,73 @@
+import * as common from "./common.js";
+
+const dummy_devices_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                "dummy-devices": {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                ...common.common_properties,
+                                optional: {
+                                    type: "boolean"
+                                },
+                                macaddress: {
+                                    type: "string",
+                                    faker: "macaddress.mac"
+                                },
+                                "ipv6-mtu": {
+                                    type: "integer",
+                                    minimum: 0
+                                },
+                                "ipv6-privacy": {
+                                    type: "boolean"
+                                },
+                                "link-local": {
+                                    type: "array",
+                                    items: [{
+                                        type: "string",
+                                        enum: ["ipv4", "ipv6"],
+                                    }
+                                    ]
+                                },
+                                "ignore-carrier": {
+                                    type: "boolean"
+                                },
+                                ...common.networkmanager_settings,
+                                ...common.openvswitch
+                            },
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["dummy-devices"]
+        }
+    }
+}
+
+
+export default dummy_devices_schema;

--- a/tests/config_fuzzer/schemas/ethernets.js
+++ b/tests/config_fuzzer/schemas/ethernets.js
@@ -1,0 +1,122 @@
+import * as common from "./common.js";
+
+const ethernets_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                ethernets: {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                ...common.common_properties,
+                                "match": {
+                                    type: "object",
+                                    additionalProperties: false,
+                                    properties: {
+                                        name: {
+                                            type: "string",
+                                            faker: "lorem.word"
+                                        },
+                                        driver: {
+                                            type: "string",
+                                            faker: "lorem.word"
+                                        },
+                                        macaddress: {
+                                            type: "string",
+                                            faker: "internet.mac"
+                                        }
+                                    },
+                                },
+                                "set-name": {
+                                    type: "string"
+                                },
+                                optional: {
+                                    type: "boolean"
+                                },
+                                wakeonlan: {
+                                    type: "boolean"
+                                },
+                                "emit-lldp": {
+                                    type: "boolean"
+                                },
+                                "receive-checksum-offload": {
+                                    type: "boolean"
+                                },
+                                "transmit-checksum-offload": {
+                                    type: "boolean"
+                                },
+                                "tcp-segmentation-offload": {
+                                    type: "boolean"
+                                },
+                                "tcp6-segmentation-offload": {
+                                    type: "boolean"
+                                },
+                                "generic-segmentation-offload": {
+                                    type: "boolean"
+                                },
+                                "generic-receive-offload": {
+                                    type: "boolean"
+                                },
+                                "large-receive-offload": {
+                                    type: "boolean"
+                                },
+                                macaddress: {
+                                    type: "string",
+                                    faker: "macaddress.mac"
+                                },
+                                "ipv6-mtu": {
+                                    type: "integer",
+                                    minimum: 0
+                                },
+                                "ipv6-privacy": {
+                                    type: "boolean"
+                                },
+                                "link-local": {
+                                    type: "array",
+                                    items: [{
+                                        type: "string",
+                                        enum: ["ipv4", "ipv6"],
+                                    }
+                                    ]
+                                },
+                                "ignore-carrier": {
+                                    type: "boolean"
+                                },
+                                ...common.networkmanager_settings,
+                                ...common.openvswitch
+                            },
+                            "required": ["match", "set-name"]
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["ethernets"]
+        }
+    }
+}
+
+
+export default ethernets_schema;

--- a/tests/config_fuzzer/schemas/modems.js
+++ b/tests/config_fuzzer/schemas/modems.js
@@ -1,0 +1,83 @@
+import * as common from "./common.js";
+
+const modems_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                modems: {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                renderer: {
+                                    type: "string",
+                                    enum: ["NetworkManager"]
+                                },
+                                mtu: {
+                                    type: "integer",
+                                    minimum: 0
+                                },
+                                apn: {
+                                    type: "string"
+                                },
+                                username: {
+                                    type: "string",
+                                    faker: "internet.email"
+                                },
+                                password: {
+                                    type: "string"
+                                },
+                                number: {
+                                    type: "integer"
+                                },
+                                "network-id": {
+                                    type: "string"
+                                },
+                                "device-id": {
+                                    type: "string"
+                                },
+                                pin: {
+                                    type: "integer"
+                                },
+                                "sim-id": {
+                                    type: "integer"
+                                },
+                                "sim-operator-id": {
+                                    type: "integer"
+                                },
+                                ...common.networkmanager_settings,
+                            },
+                            required: ["renderer"]
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["modems"]
+        }
+    }
+}
+
+
+export default modems_schema;

--- a/tests/config_fuzzer/schemas/nm-devices.js
+++ b/tests/config_fuzzer/schemas/nm-devices.js
@@ -1,0 +1,73 @@
+import common_properties, { minMaxProperties } from "./common.js";
+
+const nmdevices_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                "nm-devices": {
+                    type: "object",
+                    ...minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                renderer: {
+                                    type: "string",
+                                    enum: ["NetworkManager"]
+                                },
+                                networkmanager: {
+                                    type: "object",
+                                    additionalProperties: false,
+                                    properties: {
+                                        uuid: {
+                                            type: "string"
+                                        },
+                                        name: {
+                                            type: "string"
+                                        },
+                                        passthrough: {
+                                            type: "object",
+                                            additionalProperties: true,
+                                            properties: {
+                                                "connection.type": {
+                                                    type: "string"
+                                                }
+                                            },
+                                            required: ["connection.type"]
+                                        }
+                                    },
+                                    required: ["passthrough"]
+                                },
+                            },
+                            required: ["networkmanager"]
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["nm-devices"]
+        }
+    }
+}
+
+
+export default nmdevices_schema;

--- a/tests/config_fuzzer/schemas/openvswitch.js
+++ b/tests/config_fuzzer/schemas/openvswitch.js
@@ -1,0 +1,108 @@
+import * as common from "./common.js";
+
+const openvswitch_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                bridges: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "ovsbr0": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "interfaces": {
+                                    type: "array",
+                                    items: {
+                                        type: "string",
+                                        enum: ["port1"],
+                                    }
+                                }
+                            }
+                        },
+                        "ovsbr1": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "interfaces": {
+                                    type: "array",
+                                    items: {
+                                        type: "string",
+                                        enum: ["port2"],
+                                    }
+                                }
+                            }
+                        },
+                    },
+                    required: ["ovsbr0", "ovsbr1"]
+                },
+                openvswitch: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "external-ids": {
+                            type: "object",
+                        },
+                        "other-config": {
+                            type: "object",
+                        },
+                        protocols: {
+                            type: "array",
+                            items: {
+                                type: "string",
+                                enum: ["OpenFlow10", "OpenFlow11", "OpenFlow12", "OpenFlow13", "OpenFlow14", "OpenFlow15"]
+                            }
+                        },
+                        ssl: {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "ca-cert": {
+                                    type: "string",
+                                    faker: "system.filePath"
+                                },
+                                "certificate": {
+                                    type: "string",
+                                    faker: "system.filePath"
+                                },
+                                "private-key": {
+                                    type: "string",
+                                    faker: "system.filePath"
+                                },
+                            }
+                        },
+                        ports: {
+                            type: "array",
+                            maxItems: 1,
+                            minItems: 1,
+                            items: {
+                                type: "array",
+                                enum: [["port1", "port2"]]
+                                
+                            }
+                        }
+                    },
+                    required: ["ports"]
+                },
+            },
+            required: ["bridges", "openvswitch"]
+        }
+    }
+}
+
+
+export default openvswitch_schema;

--- a/tests/config_fuzzer/schemas/tunnels.js
+++ b/tests/config_fuzzer/schemas/tunnels.js
@@ -1,0 +1,303 @@
+import * as common from "./common.js";
+
+export const wireguard_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                ethernets: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "eth0": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth1": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth2": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        }
+                    },
+                    required: ["eth0", "eth1", "eth2"]
+                },
+                tunnels: {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                addresses: {
+                                    type: "array",
+                                    items: {
+                                        type: "string",
+                                        faker: "ipv4_or_ipv6.withprefix"
+                                    }
+                                },
+                                mode: {
+                                    type: "string",
+                                    enum: ["wireguard"]
+                                },
+                                key: {
+                                    type: "string",
+                                    enum: ["rlbInAj0qV69CysWPQY7KEBnKxpYCpaWqOs/dLevdWc="]
+                                },
+                                port: {
+                                    type: "integer",
+                                    minimum: 1,
+                                    maximum: 65535
+                                },
+                                peers: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        additionalProperties: false,
+                                        properties: {
+                                            endpoint: {
+                                                type: "string",
+                                                faker: "ipv4_or_ipv6.withport"
+                                            },
+                                            keepalive: {
+                                                type: "integer",
+                                                minimum: 0,
+                                                maximum: 65535
+                                            },
+                                            "allowed-ips": {
+                                                type: "array",
+                                                items: {
+                                                    type: "string",
+                                                    faker: "ipv4_or_ipv6.withprefix"
+                                                }
+                                            },
+                                            keys: {
+                                                type: "object",
+                                                additionalProperties: false,
+                                                properties: {
+                                                    public: {
+
+                                                        type: "string",
+                                                        enum: ["M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4="]
+
+                                                    },
+                                                    shared: {
+                                                        type: "string",
+                                                        enum: ["rlbInAj0qV69CysWPQY7KEBnKxpYCpaWqOs/dLevdWc="]
+                                                    },
+                                                },
+                                                required: ["public"]
+                                            }
+                                        },
+                                        required: ["keys", "allowed-ips"]
+                                    }
+                                },
+                                ...common.networkmanager_settings,
+                            },
+                            required: ["mode", "key", "peers"]
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["tunnels", "ethernets"]
+        }
+    }
+}
+
+export const sit_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                tunnels: {
+                    type: "object",
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                addresses: {
+                                    type: "array",
+                                    items: {
+                                        type: "string",
+                                        faker: "ipv4_or_ipv6.withprefix"
+                                    }
+                                },
+                                mode: {
+                                    type: "string",
+                                    enum: ["sit"]
+                                },
+                                remote: {
+                                    type: "string",
+                                    faker: "internet.ipv4"
+                                },
+                                local: {
+                                    type: "string",
+                                    faker: "internet.ipv4"
+                                },
+                                addresses: {
+                                    type: "array",
+                                    items: {
+                                        type: "string",
+                                        faker: "ipv6.withprefix",
+                                    },
+                                },
+                                ...common.routes
+                            },
+                            required: ["mode", "remote", "local"]
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["tunnels"]
+        }
+    }
+}
+
+export const vxlan_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                ethernets: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "eth0": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        }
+                    },
+                    required: ["eth0"]
+                },
+                tunnels: {
+                    type: "object",
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                mode: {
+                                    type: "string",
+                                    enum: ["vxlan"]
+                                },
+                                id: {
+                                    type: "integer",
+                                    minimum: 1,
+                                    maximum: 16777215
+                                },
+                                link: {
+                                    type: "string",
+                                    enum: ["eth0"]
+                                },
+                                local: {
+                                    type: "string",
+                                    faker: "internet.ipv4"
+                                },
+                                mtu: {
+                                    type: "integer",
+                                    minimum: 1
+                                },
+                                "accept-ra": {
+                                    type: "boolean"
+                                },
+                                "neigh-suppress": {
+                                    type: "boolean"
+                                },
+                                "mac-learning": {
+                                    type: "boolean"
+                                },
+                                port: {
+                                    type: "integer",
+                                    minimum: 0,
+                                    maximum: 65535
+                                }
+                            },
+                            required: ["mode", "id", "local"]
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["tunnels", "ethernets"]
+        }
+    }
+}
+
+export default wireguard_schema;

--- a/tests/config_fuzzer/schemas/virtual-ethernets.js
+++ b/tests/config_fuzzer/schemas/virtual-ethernets.js
@@ -1,0 +1,104 @@
+import * as common from "./common.js";
+
+const common_veth_properties = {
+    optional: {
+        type: "boolean"
+    },
+    macaddress: {
+        type: "string",
+        faker: "macaddress.mac"
+    },
+    "ipv6-privacy": {
+        type: "boolean"
+    },
+    "link-local": {
+        type: "array",
+        items: [{
+            type: "string",
+            enum: ["ipv4", "ipv6"],
+        }
+        ]
+    },
+    "ignore-carrier": {
+        type: "boolean"
+    },
+}
+
+const virtual_ethernets_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                "virtual-ethernets": {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "veth0": {
+                            additionalProperties: false,
+                            required: ["peer"],
+                            properties: {
+                                peer: {
+                                    type: "string",
+                                    enum: ["veth1"],
+                                },
+                                ...common.common_properties,
+                                ...common_veth_properties,
+                                ...common.networkmanager_settings,
+                                ...common.openvswitch
+                            },
+                        },
+                        "veth1": {
+                            additionalProperties: false,
+                            required: ["peer"],
+                            properties: {
+                                peer: {
+                                    type: "string",
+                                    enum: ["veth0"],
+                                },
+                                ...common.common_properties,
+                                ...common_veth_properties,
+                                ...common.networkmanager_settings,
+                                ...common.openvswitch
+                            },
+                        },
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                peer: {
+                                    type: "string",
+                                },
+                                ...common.common_properties,
+                                ...common_veth_properties,
+                                ...common.networkmanager_settings,
+                                ...common.openvswitch
+                            },
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}", "veth0", "veth1"]
+                },
+            },
+            required: ["virtual-ethernets"]
+        }
+    }
+}
+
+
+export default virtual_ethernets_schema;

--- a/tests/config_fuzzer/schemas/vlans.js
+++ b/tests/config_fuzzer/schemas/vlans.js
@@ -1,0 +1,91 @@
+import * as common from "./common.js";
+
+const vlans_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                ethernets: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "eth0": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth1": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth2": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        }
+                    },
+                    required: ["eth0", "eth1", "eth2"]
+                },
+                vlans: {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                ...common.common_properties,
+                                id: {
+                                    type: "integer",
+                                    minimum: 0,
+                                    maximum: 4094
+                                },
+                                link: {
+                                    type: "string",
+                                    enum: ["eth0", "eth1", "eth2"]
+                                },
+                                ...common.networkmanager_settings,
+                            },
+                            required: ["id", "link"]
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["ethernets", "vlans"]
+        }
+    }
+}
+
+
+export default vlans_schema;

--- a/tests/config_fuzzer/schemas/vrfs.js
+++ b/tests/config_fuzzer/schemas/vrfs.js
@@ -1,0 +1,185 @@
+import * as common from "./common.js";
+
+const vrfs_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                ethernets: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "eth0": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth1": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        },
+                        "eth2": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        }
+                    },
+                    required: ["eth0", "eth1", "eth2"]
+                },
+                vrfs: {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                table: {
+                                    type: "integer",
+                                    minimum: 100,
+                                    maximum: 100
+                                },
+                                interfaces: {
+                                    type: "array",
+                                    uniqueItems: true,
+                                    items: {
+                                        type: "string",
+                                        enum: ["eth0", "eth1", "eth2"]
+                                    }
+                                },
+                                routes: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        additionalProperties: false,
+                                        properties: {
+                                            from: {
+                                                type: "string",
+                                                faker: "ipv4.withprefix"
+                                            },
+                                            to: {
+                                                type: "string",
+                                                faker: "ipv4.withprefix"
+                                            },
+                                            via: {
+                                                type: "string",
+                                                faker: "internet.ipv4"
+                                            },
+                                            "on-link": {
+                                                type: "boolean"
+                                            },
+                                            metric: {
+                                                type: "integer",
+                                                minimum: 0
+                                            },
+                                            type: {
+                                                type: "string",
+                                                enum: ["unicast", "anycast", "blackhole", "broadcast", "local", "multicast", "nat", "prohibit", "throw", "unreachable", "xresolve"]
+                                            },
+                                            scope: {
+                                                type: "string",
+                                                enum: ["global", "link", "host"]
+                                            },
+                                            table: {
+                                                type: "integer",
+                                                minimum: 100,
+                                                maximum: 100
+                                            },
+                                            mtu: {
+                                                type: "integer",
+                                                minimum: 0
+                                            },
+                                            "congestion-window": {
+                                                type: "integer",
+                                                minimum: 0
+                                            },
+                                            "advertised-receive-window": {
+                                                type: "integer",
+                                                minimum: 0
+                                            }
+                            
+                                        },
+                                        required: ["to", "via"]
+                                    }
+                                },
+                                "routing-policy": {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        additionalProperties: false,
+                                        properties: {
+                                            from: {
+                                                type: "string",
+                                                faker: "ipv4.withprefix"
+                                            },
+                                            to: {
+                                                type: "string",
+                                                faker: "ipv4.withprefix"
+                                            },
+                                            table: {
+                                                type: "integer",
+                                                minimum: 100,
+                                                maximum: 100
+                                            },
+                                            priority: {
+                                                type: "integer",
+                                                minimum: 0,
+                                            },
+                                            mark: {
+                                                type: "integer",
+                                                minimum: 0,
+                                            },
+                                            "type-of-service": {
+                                                type: "integer",
+                                                minimum: 0,
+                                                maximum: 255
+                                            }
+                                        },
+                                        required: ["to", "via"],
+                                    }
+                                },
+                                ...common.networkmanager_settings,
+                            },
+                            required: ["table"]
+                        }
+                    },
+                    required: ["[azAZ09-]{1,15}"]
+                },
+            },
+            required: ["vrfs", "ethernets"]
+        }
+    }
+}
+
+
+export default vrfs_schema;

--- a/tests/config_fuzzer/schemas/wifis.js
+++ b/tests/config_fuzzer/schemas/wifis.js
@@ -1,0 +1,194 @@
+import * as common from "./common.js";
+
+const wifis_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd", "NetworkManager"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                wifis: {
+                    type: "object",
+                    ...common.minMaxProperties,
+                    properties: {
+                        renderer: {
+                            type: "string",
+                            enum: ["networkd", "NetworkManager"]
+                        },
+                    },
+                    patternProperties: {
+                        "[azAZ09-]{1,15}": {
+                            additionalProperties: false,
+                            properties: {
+                                ...common.common_properties,
+                                "match": {
+                                    type: "object",
+                                    additionalProperties: false,
+                                    properties: {
+                                        name: {
+                                            type: "string",
+                                            faker: "lorem.word"
+                                        },
+                                        driver: {
+                                            type: "string",
+                                            faker: "lorem.word"
+                                        },
+                                        macaddress: {
+                                            type: "string",
+                                            faker: "internet.mac"
+                                        }
+                                    },
+                                },
+                                "set-name": {
+                                    type: "string",
+                                },
+                                optional: {
+                                    type: "boolean"
+                                },
+                                "emit-lldp": {
+                                    type: "boolean"
+                                },
+                                "receive-checksum-offload": {
+                                    type: "boolean"
+                                },
+                                "transmit-checksum-offload": {
+                                    type: "boolean"
+                                },
+                                "tcp-segmentation-offload": {
+                                    type: "boolean"
+                                },
+                                "tcp6-segmentation-offload": {
+                                    type: "boolean"
+                                },
+                                "generic-segmentation-offload": {
+                                    type: "boolean"
+                                },
+                                "generic-receive-offload": {
+                                    type: "boolean"
+                                },
+                                "large-receive-offload": {
+                                    type: "boolean"
+                                },
+                                macaddress: {
+                                    type: "string",
+                                    faker: "macaddress.mac"
+                                },
+                                "ipv6-mtu": {
+                                    type: "integer",
+                                    minimum: 0
+                                },
+                                "ipv6-privacy": {
+                                    type: "boolean"
+                                },
+                                "link-local": {
+                                    type: "array",
+                                    items: [{
+                                        type: "string",
+                                        enum: ["ipv4", "ipv6"],
+                                    }
+                                    ]
+                                },
+                                "ignore-carrier": {
+                                    type: "boolean"
+                                },
+                                "access-points": {
+                                    type: "object",
+                                    ...common.minMaxProperties,
+                                    patternProperties: {
+                                        "[azAZ09 ]+": {
+                                            type: "object",
+                                            additionalProperties: false,
+                                            properties: {
+                                                password: {
+                                                    type: "string",
+                                                    "minLength": 8,
+                                                    "maxLength": 63
+                                                },
+                                                mode: {
+                                                    type: "string",
+                                                    enum: ["infrastructure", "ap", "adhoc"]
+                                                },
+                                                bssid: {
+                                                    type: "string",
+                                                    faker: "internet.mac"
+                                                },
+                                                band: {
+                                                    type: "string",
+                                                    enum: ["5GHz", "2.4GHz"]
+                                                },
+                                                channel: {
+                                                    type: "integer",
+                                                    enum: [11]
+                                                },
+                                                hidden: {
+                                                    type: "boolean"
+                                                },
+                                                auth: {
+                                                    type: "object",
+                                                    additionalProperties: false,
+                                                    properties: {
+                                                        "key-management": {
+                                                            type: "string",
+                                                            enum: ["none", "psk", "eap"]
+                                                        },
+                                                        password: {
+                                                            type: "string",
+                                                            "minLength": 8,
+                                                            "maxLength": 63
+                                                        },
+                                                        method: {
+                                                            type: "string",
+                                                            enum: ["tls", "peap", "ttls"]
+                                                        },
+                                                        identity: {
+                                                            type: "string"
+                                                        },
+                                                        "anonymous-identity": {
+                                                            type: "string",
+                                                        },
+                                                        "ca-certificate": {
+                                                            type: "string"
+                                                        },
+                                                        "client-certificate": {
+                                                            type: "string"
+                                                        },
+                                                        "client-key": {
+                                                            type: "string"
+                                                        },
+                                                        "client-key-password": {
+                                                            type: "string"
+                                                        },
+                                                        "phase2-auth": {
+                                                            type: "string"
+                                                        }
+                                                    }
+                                                },
+                                                ...common.networkmanager_settings
+                                            }
+                                        },
+                                    },
+                                    "required": ["[azAZ09 ]+"]
+                                },
+                            },
+                            "required": ["access-points", "match", "set-name"]
+                        }
+                    },
+                }
+            },
+            required: ["wifis"]
+        }
+
+    }
+}
+
+export default wifis_schema;


### PR DESCRIPTION
This is a project I've been working. It will use json schemas to generate random YAML files. It implements support for most of the interface types and properties support by Netplan. I used JavaScript (note that I don't have much experience with it :P) to use the [json-schema-faker](https://github.com/json-schema-faker/json-schema-faker) project.

The config_fuzzer will generate random netplan YAML files and use them to test libnetplan.

It also adds a new Github workflow to run the tests. If a crash or memory issue is detected, the workflow will fail in the end. It's being executed in this PR.

There is a lot of room for improvement but this is a good start.

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

