### PR TITLE
Create individual netplan-networkd-wait-online@.service units (LP: #2060311)

### DIFF
--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -31,6 +31,7 @@ jobs:
           sudo apt install curl expect ubuntu-dev-tools devscripts equivs gcovr
           pull-lp-source netplan.io
           sed -i 's| systemd-dev|# DELETED: systemd-dev|' netplan.io-*/debian/control
+          echo 'lib/systemd/system/*' >> netplan.io-*/debian/netplan-generator.install
           mk-build-deps -i -B -s sudo netplan.io-*/debian/control
           rm -rf netplan.io-*/
           wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcovr/gcovr_5.2-1_all.deb

--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -43,6 +43,7 @@ jobs:
           # usrmerge-fix
           sed -i 's|rm debian/tmp/lib/netplan/generate|sh -c "mkdir -p debian/tmp/usr/lib/systemd/system-generators; rm -rf debian/tmp/lib; ln -sf /usr/libexec/netplan/generate debian/tmp/usr/lib/systemd/system-generators/netplan"|' debian/rules
           # usrmerge-fix-end
+          echo 'usr/lib/systemd/system/*' >> debian/netplan-generator.install
           echo "3.0 (native)" > debian/source/format  # force native build
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,3 @@
+install_data(
+    'netplan-networkd-wait-online@.service',
+    install_dir: systemd.get_variable(pkgconfig: 'systemd_system_unit_dir'))

--- a/data/netplan-networkd-wait-online@.service
+++ b/data/netplan-networkd-wait-online@.service
@@ -1,0 +1,26 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Wait for Network Interface %i to be Configured
+Documentation=man:systemd-networkd-wait-online.service(8)
+ConditionCapability=CAP_NET_ADMIN
+DefaultDependencies=no
+Conflicts=shutdown.target
+BindsTo=systemd-networkd.service
+After=systemd-networkd.service
+Before=network-online.target shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i %i
+RemainAfterExit=yes
+
+[Install]
+WantedBy=network-online.target

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,7 @@ subdir('netplan_cli')
 subdir('python-cffi')
 subdir('examples')
 subdir('doc')
+subdir('data')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(

--- a/rpm/netplan.spec
+++ b/rpm/netplan.spec
@@ -88,6 +88,7 @@ Currently supported backends are NetworkManager and systemd-networkd.
 %{_datadir}/dbus-1/system-services/io.netplan.Netplan.service
 %{_datadir}/dbus-1/system.d/io.netplan.Netplan.conf
 %{_systemdgeneratordir}/%{name}
+/usr/lib/systemd/system/netplan*.service
 %{_mandir}/man5/%{name}.5*
 %{_mandir}/man8/%{name}*.8*
 %dir %{_sysconfdir}/%{name}

--- a/src/generate.c
+++ b/src/generate.c
@@ -75,21 +75,6 @@ enable_networkd(const char* generator_dir, const char* rootdir)
         // LCOV_EXCL_STOP
     }
 
-    // Mask the generic systemd-networkd-wait-online.service unit, to enforce
-    // "netplan-networkd-wait-online@IFACE.service" wait-online policy
-    g_autofree gchar* masking_link = NULL;
-    masking_link = g_build_path(G_DIR_SEPARATOR_S, rootdir ?: G_DIR_SEPARATOR_S,
-                                "run/systemd/system/systemd-networkd-wait-online.service",
-                                NULL);
-    g_debug("Masking systemd-networkd-wait-online.service via %s -> /dev/null", masking_link);
-    _netplan_safe_mkdir_p_dir(masking_link);
-    if (symlink("/dev/null", masking_link) < 0 && errno != EEXIST) {
-        // LCOV_EXCL_START
-        g_fprintf(stderr, "failed to create masking symlink: %m\n");
-        exit(1);
-        // LCOV_EXCL_STOP
-    }
-
     // Copy /usr/lib/systemd/system/systemd-networkd-wait-online@.service to
     // /run/systemd/system/netplan-networkd-wait-online@.service so we can make
     // it our own service.

--- a/src/generate.c
+++ b/src/generate.c
@@ -75,6 +75,21 @@ enable_networkd(const char* generator_dir, const char* rootdir)
         // LCOV_EXCL_STOP
     }
 
+    // Mask the generic systemd-networkd-wait-online.service unit, to enforce
+    // "netplan-networkd-wait-online@IFACE.service" wait-online policy
+    g_autofree gchar* masking_link = NULL;
+    masking_link = g_build_path(G_DIR_SEPARATOR_S, rootdir ?: G_DIR_SEPARATOR_S,
+                                "run/systemd/system/systemd-networkd-wait-online.service",
+                                NULL);
+    g_debug("Masking systemd-networkd-wait-online.service via %s -> /dev/null", masking_link);
+    _netplan_safe_mkdir_p_dir(masking_link);
+    if (symlink("/dev/null", masking_link) < 0 && errno != EEXIST) {
+        // LCOV_EXCL_START
+        g_fprintf(stderr, "failed to create masking symlink: %m\n");
+        exit(1);
+        // LCOV_EXCL_STOP
+    }
+
     // Copy /usr/lib/systemd/system/systemd-networkd-wait-online@.service to
     // /run/systemd/system/netplan-networkd-wait-online@.service so we can make
     // it our own service.

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1478,7 +1478,7 @@ _netplan_netdef_write_networkd(
         }
 
         // Create an enablement link for each interface in the <ifnames> vector
-        const char* target = "/run/systemd/system/netplan-networkd-wait-online@.service";
+        const char* target = "/lib/systemd/system/netplan-networkd-wait-online@.service";
         for (unsigned i = 0; ifnames[i]; ++i) {
             g_autofree char* link = NULL;
             link = g_strjoin(NULL, rootdir ?: "",
@@ -1511,7 +1511,6 @@ _netplan_networkd_cleanup(const char* rootdir)
     _netplan_unlink_glob(rootdir, "/run/systemd/system/network.target.wants/netplan-regdom.service");
     _netplan_unlink_glob(rootdir, "/run/systemd/system/netplan-regdom.service");
     _netplan_unlink_glob(rootdir, "/run/systemd/system/network-online.target.wants/netplan-networkd-wait-online@*.service");
-    _netplan_unlink_glob(rootdir, "/run/systemd/system/netplan-networkd-wait-online@.service");
     /* Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
      * upgraded system, we need to make sure to clean those up. */
     _netplan_unlink_glob(rootdir, "/run/systemd/system/systemd-networkd.service.wants/netplan-wpa@*.service");

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1478,11 +1478,11 @@ _netplan_netdef_write_networkd(
         }
 
         // Create an enablement link for each interface in the <ifnames> vector
-        const char* target = "/lib/systemd/system/systemd-networkd-wait-online@.service";
+        const char* target = "/run/systemd/system/netplan-networkd-wait-online@.service";
         for (unsigned i = 0; ifnames[i]; ++i) {
             g_autofree char* link = NULL;
             link = g_strjoin(NULL, rootdir ?: "",
-                             "/run/systemd/system/network-online.target.wants/systemd-networkd-wait-online@",
+                             "/run/systemd/system/network-online.target.wants/netplan-networkd-wait-online@",
                              ifnames[i], ".service", NULL);
             g_debug("Creating wait-online service enablement link %s", link);
             if (symlink(target, link) < 0 && errno != EEXIST) {
@@ -1510,8 +1510,8 @@ _netplan_networkd_cleanup(const char* rootdir)
     _netplan_unlink_glob(rootdir, "/run/udev/rules.d/99-netplan-*");
     _netplan_unlink_glob(rootdir, "/run/systemd/system/network.target.wants/netplan-regdom.service");
     _netplan_unlink_glob(rootdir, "/run/systemd/system/netplan-regdom.service");
-    // XXX: How can we make sure we do not clear non-netplan wait-online-enablement links here?
-    _netplan_unlink_glob(rootdir, "/run/systemd/system/network-online.target.wants/systemd-networkd-wait-online@*.service");
+    _netplan_unlink_glob(rootdir, "/run/systemd/system/network-online.target.wants/netplan-networkd-wait-online@*.service");
+    _netplan_unlink_glob(rootdir, "/run/systemd/system/netplan-networkd-wait-online@.service");
     /* Historically (up to v0.98) we had netplan-wpa@*.service files, in case of an
      * upgraded system, we need to make sure to clean those up. */
     _netplan_unlink_glob(rootdir, "/run/systemd/system/systemd-networkd.service.wants/netplan-wpa@*.service");

--- a/src/util.c
+++ b/src/util.c
@@ -955,7 +955,7 @@ netplan_netdef_match_interface(const NetplanNetDefinition* netdef, const char* n
         return !g_strcmp0(name, netdef->id);
 
     if (netdef->match.mac) {
-        if (g_ascii_strcasecmp(netdef->match.mac, mac))
+        if (g_ascii_strcasecmp(netdef->match.mac ?: "", mac ?: ""))
             return FALSE;
     }
 

--- a/tests/ctests/meson.build
+++ b/tests/ctests/meson.build
@@ -5,6 +5,7 @@ tests = {
   'test_netplan_misc': false,
   'test_netplan_validation': false,
   'test_netplan_keyfile': false,
+  'test_netplan_networkd': false,
   'test_netplan_nm': false,
   'test_netplan_openvswitch': false,
 }

--- a/tests/ctests/test_netplan_networkd.c
+++ b/tests/ctests/test_netplan_networkd.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "netplan.h"
+#include "util-internal.h"
+#include "networkd.c"
+
+#include "test_utils.h"
+
+void
+test_wait_online_utils(__unused void** state)
+{
+    char template[] = "/tmp/netplan.XXXXXX";
+    const char* rootdir = mkdtemp(template);
+
+    // create mock sysfs
+    g_autofree gchar* sys = g_strdup_printf("%s/sys", rootdir);
+    g_autofree gchar* sys_class = g_strdup_printf("%s/sys/class", rootdir);
+    g_autofree gchar* sys_class_net = g_strdup_printf("%s/sys/class/net", rootdir);
+    g_autofree gchar* eth99 = g_strdup_printf("%s/sys/class/net/eth99", rootdir);
+    g_autofree gchar* eth99_device = g_strdup_printf("%s/device", eth99);
+    g_autofree gchar* driver = g_strdup_printf("%s/device/driver", eth99);
+    g_autofree gchar* mac = g_strdup_printf("%s/address", eth99);
+    g_mkdir_with_parents(eth99_device, 0700);
+
+    // assert MAC address file
+    assert_true(g_file_set_contents(mac, "  aa:bb:cc:dd:ee:ff \r\n\n", -1, NULL));
+    g_autofree gchar* mac_value = _netplan_sysfs_get_mac_by_ifname("eth99", rootdir);
+    assert_string_equal(mac_value, "aa:bb:cc:dd:ee:ff");
+
+    // assert driver link
+    assert_int_equal(symlink("../somewhere/drivers/mock_drv", driver), 0);
+    g_autofree gchar* driver_value = _netplan_sysfs_get_driver_by_ifname("eth99", rootdir);
+    assert_string_equal(driver_value, "mock_drv");
+
+    // Cleanup
+    remove(mac);
+    remove(driver);
+    rmdir(eth99_device);
+    rmdir(eth99);
+    rmdir(sys_class_net);
+    rmdir(sys_class);
+    rmdir(sys);
+    rmdir(rootdir);
+}
+
+
+int
+setup(__unused void** state)
+{
+    return 0;
+}
+
+int
+tear_down(__unused void** state)
+{
+    return 0;
+}
+
+int
+main()
+{
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_wait_online_utils),
+    };
+
+    return cmocka_run_group_tests(tests, setup, tear_down);
+
+}

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -465,6 +465,8 @@ class TestBase(unittest.TestCase):
         self.assertEqual(set(os.listdir(self.workdir.name)) - {'lib'}, {'etc', 'run'})
         ovs_systemd_dir = set(os.listdir(systemd_dir))
         ovs_systemd_dir.remove('systemd-networkd.service.wants')
+        if 'network-online.target.wants' in ovs_systemd_dir:
+            ovs_systemd_dir.remove('network-online.target.wants')
         self.assertEqual(ovs_systemd_dir, {'netplan-ovs-' + f for f in file_contents_map})
         for fname, contents in file_contents_map.items():
             fname = 'netplan-ovs-' + fname

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -141,8 +141,6 @@ class TestConfigArgs(TestBase):
         service_dir = os.path.join(self.workdir.name, 'run', 'systemd', 'system')
         self.assertTrue(os.path.islink(os.path.join(
             outdir, 'multi-user.target.wants', 'systemd-networkd.service')))
-        self.assertTrue(os.path.isfile(os.path.join(
-            service_dir, 'netplan-networkd-wait-online@.service')))
         self.assertTrue(os.path.islink(os.path.join(
             service_dir, 'network-online.target.wants', 'netplan-networkd-wait-online@eth0.service')))
 

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -138,10 +138,13 @@ class TestConfigArgs(TestBase):
         os.unlink(n)
 
         # should auto-enable networkd and -wait-online
+        service_dir = os.path.join(self.workdir.name, 'run', 'systemd', 'system')
         self.assertTrue(os.path.islink(os.path.join(
             outdir, 'multi-user.target.wants', 'systemd-networkd.service')))
+        self.assertTrue(os.path.isfile(os.path.join(
+            service_dir, 'netplan-networkd-wait-online@.service')))
         self.assertTrue(os.path.islink(os.path.join(
-            outdir, 'network-online.target.wants', 'systemd-networkd-wait-online@eth0.service')))
+            service_dir, 'network-online.target.wants', 'netplan-networkd-wait-online@eth0.service')))
 
         # should be a no-op the second time while the stamp exists
         out = subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir],

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -141,7 +141,7 @@ class TestConfigArgs(TestBase):
         self.assertTrue(os.path.islink(os.path.join(
             outdir, 'multi-user.target.wants', 'systemd-networkd.service')))
         self.assertTrue(os.path.islink(os.path.join(
-            outdir, 'network-online.target.wants', 'systemd-networkd-wait-online.service')))
+            outdir, 'network-online.target.wants', 'systemd-networkd-wait-online@eth0.service')))
 
         # should be a no-op the second time while the stamp exists
         out = subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir],

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -35,9 +35,6 @@ class TestNetworkd(TestBase):
         self.assert_networkd({'eth0.network': '''[Match]
 Name=eth0
 
-[Link]
-RequiredForOnline=no
-
 [Network]
 DHCP=ipv6
 LinkLocalAddressing=ipv6
@@ -85,7 +82,6 @@ Name=eth0
 
 [Link]
 ActivationPolicy=always-down
-RequiredForOnline=no
 
 [Network]
 DHCP=ipv6
@@ -109,7 +105,6 @@ Name=eth0
 
 [Link]
 ActivationPolicy=manual
-RequiredForOnline=no
 
 [Network]
 DHCP=ipv6


### PR DESCRIPTION
## Description
This is in favor to RequiredForOnline=yes as the behavior of upstream (pure) systemd-networkd-wait-online.service is not mean to be used in this way.

If "RequiredForOnline=no" sd-networkd-wait-online will fully ignore the corresponding interface and it will block/delay network-online.target if no interfaces are "RequiredForOnline=yes" at all.

This is as per discussions in https://github.com/systemd/systemd/pull/32016

FR-7246

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#2060311

