### PR TITLE
Create custom systemd-networkd-wait-online.service override to wait on individual interfaces. (LP: #2060311)

### DIFF
--- a/netplan_cli/cli/commands/generate.py
+++ b/netplan_cli/cli/commands/generate.py
@@ -81,5 +81,12 @@ class NetplanGenerate(utils.NetplanCommand):
         if self.mapping:
             argv += ['--mapping', self.mapping]
         logging.debug('command generate: running %s', argv)
+        res = subprocess.call(argv)
+        # reload systemd, as we might have changed service units, such as
+        # /run/systemd/system/systemd-networkd-wait-online.service.d/10-netplan.conf
+        try:
+            utils.systemctl_daemon_reload()
+        except subprocess.CalledProcessError as e:
+            logging.warning(e)
         # FIXME: os.execv(argv[0], argv) would be better but fails coverage
-        sys.exit(subprocess.call(argv))
+        sys.exit(res)

--- a/netplan_cli/cli/utils.py
+++ b/netplan_cli/cli/utils.py
@@ -165,7 +165,7 @@ def systemctl_is_installed(unit_pattern):
 
 def systemctl_daemon_reload():
     '''Reload systemd unit files from disk and re-calculate its dependencies'''
-    subprocess.check_call(['systemctl', 'daemon-reload'])
+    subprocess.check_call(['systemctl', 'daemon-reload', '--no-ask-password'])
 
 
 def ip_addr_flush(iface):

--- a/src/generate.c
+++ b/src/generate.c
@@ -302,7 +302,10 @@ int main(int argc, char** argv)
     if (netplan_state_get_backend(np_state) == NETPLAN_BACKEND_NM || any_nm)
         _netplan_g_string_free_to_file(g_string_new(NULL), rootdir, "/run/NetworkManager/conf.d/10-globally-managed-devices.conf", NULL);
 
-    gboolean enable_wait_online = _netplan_networkd_write_wait_online(np_state, rootdir);
+    gboolean enable_wait_online = FALSE;
+    if (any_networkd)
+        enable_wait_online = _netplan_networkd_write_wait_online(np_state, rootdir);
+
     if (called_as_generator) {
         /* Ensure networkd starts if we have any configuration for it */
         if (any_networkd)

--- a/src/generate.c
+++ b/src/generate.c
@@ -63,7 +63,7 @@ reload_udevd(void)
  * Create enablement symlink for systemd-networkd.service.
  */
 static void
-enable_networkd(const char* generator_dir)
+enable_networkd(const char* generator_dir, gboolean enable_wait_online)
 {
     g_autofree char* link = g_build_path(G_DIR_SEPARATOR_S, generator_dir, "multi-user.target.wants", "systemd-networkd.service", NULL);
     g_debug("We created networkd configuration, adding %s enablement symlink", link);
@@ -75,13 +75,15 @@ enable_networkd(const char* generator_dir)
         // LCOV_EXCL_STOP
     }
 
-    g_autofree char* link2 = g_build_path(G_DIR_SEPARATOR_S, generator_dir, "network-online.target.wants", "systemd-networkd-wait-online.service", NULL);
-    _netplan_safe_mkdir_p_dir(link2);
-    if (symlink("/lib/systemd/system/systemd-networkd-wait-online.service", link2) < 0 && errno != EEXIST) {
-        // LCOV_EXCL_START
-        g_fprintf(stderr, "failed to create enablement symlink: %m\n");
-        exit(1);
-        // LCOV_EXCL_STOP
+    if (enable_wait_online) {
+        g_autofree char* link2 = g_build_path(G_DIR_SEPARATOR_S, generator_dir, "network-online.target.wants", "systemd-networkd-wait-online.service", NULL);
+        _netplan_safe_mkdir_p_dir(link2);
+        if (symlink("/lib/systemd/system/systemd-networkd-wait-online.service", link2) < 0 && errno != EEXIST) {
+            // LCOV_EXCL_START
+            g_fprintf(stderr, "failed to create enablement symlink: %m\n");
+            exit(1);
+            // LCOV_EXCL_STOP
+        }
     }
 }
 
@@ -300,10 +302,11 @@ int main(int argc, char** argv)
     if (netplan_state_get_backend(np_state) == NETPLAN_BACKEND_NM || any_nm)
         _netplan_g_string_free_to_file(g_string_new(NULL), rootdir, "/run/NetworkManager/conf.d/10-globally-managed-devices.conf", NULL);
 
+    gboolean enable_wait_online = _netplan_networkd_write_wait_online(np_state, rootdir);
     if (called_as_generator) {
         /* Ensure networkd starts if we have any configuration for it */
         if (any_networkd)
-            enable_networkd(files[0]);
+            enable_networkd(files[0], enable_wait_online);
 
         /* Leave a stamp file so that we don't regenerate the configuration
          * multiple times and userspace can wait for it to finish */
@@ -324,7 +327,8 @@ int main(int argc, char** argv)
         /* covered via 'cloud-init' integration test */
         if (any_networkd) {
             start_unit_jit("systemd-networkd.socket");
-            start_unit_jit("systemd-networkd-wait-online.service");
+            if (enable_wait_online)
+                start_unit_jit("systemd-networkd-wait-online.service");
             start_unit_jit("systemd-networkd.service");
         }
         g_autofree char* glob_run = g_build_path(G_DIR_SEPARATOR_S,

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1494,7 +1494,11 @@ _netplan_networkd_write_wait_online(const NetplanState* np_state, const char* ro
         if (!(def->optional || def->activation_mode)) {
             // Check if we have any IP configuration
             struct address_iter* addr_iter = _netplan_netdef_new_address_iter(def);
-            gboolean any_ips = _netplan_address_iter_next(addr_iter) != NULL || netplan_netdef_get_link_local_ipv4(def) || netplan_netdef_get_link_local_ipv6(def);
+            gboolean any_ips =    _netplan_address_iter_next(addr_iter) != NULL
+                               || netplan_netdef_get_dhcp4(def)
+                               || netplan_netdef_get_dhcp6(def)
+                               || netplan_netdef_get_link_local_ipv4(def)
+                               || netplan_netdef_get_link_local_ipv6(def);
             _netplan_address_iter_free(addr_iter);
 
             // no matching => single interface, ignoring non-existing interfaces

--- a/src/networkd.h
+++ b/src/networkd.h
@@ -37,5 +37,8 @@ _netplan_netdef_write_network_file(
         gboolean* has_been_written,
         GError** error);
 
+NETPLAN_INTERNAL gboolean
+_netplan_networkd_write_wait_online(const NetplanState* np_state, const char* rootdir);
+
 NETPLAN_INTERNAL void
 _netplan_networkd_cleanup(const char* rootdir);

--- a/src/util.c
+++ b/src/util.c
@@ -955,7 +955,7 @@ netplan_netdef_match_interface(const NetplanNetDefinition* netdef, const char* n
         return !g_strcmp0(name, netdef->id);
 
     if (netdef->match.mac) {
-        if (g_ascii_strcasecmp(netdef->match.mac, mac))
+        if (g_ascii_strcasecmp(netdef->match.mac ?: "", mac ?: ""))
             return FALSE;
     }
 

--- a/tests/cli_legacy.py
+++ b/tests/cli_legacy.py
@@ -98,8 +98,7 @@ class TestGenerate(unittest.TestCase):
     enlol: {dhcp4: yes}''')
         os.chmod(path_a, mode=0o600)
         os.chmod(path_b, mode=0o600)
-        out = subprocess.check_output(exe_cli + ['generate', '--root-dir', self.workdir.name], stderr=subprocess.STDOUT)
-        self.assertEqual(out, b'')
+        subprocess.check_call(exe_cli + ['generate', '--root-dir', self.workdir.name])
         self.assertEqual(os.listdir(os.path.join(self.workdir.name, 'run', 'systemd', 'network')),
                          ['10-netplan-enlol.network'])
 

--- a/tests/ctests/meson.build
+++ b/tests/ctests/meson.build
@@ -5,6 +5,7 @@ tests = {
   'test_netplan_misc': false,
   'test_netplan_validation': false,
   'test_netplan_keyfile': false,
+  'test_netplan_networkd': false,
   'test_netplan_nm': false,
   'test_netplan_openvswitch': false,
 }

--- a/tests/ctests/test_netplan_networkd.c
+++ b/tests/ctests/test_netplan_networkd.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "netplan.h"
+#include "util-internal.h"
+#include "networkd.c"
+
+#include "test_utils.h"
+
+void
+test_wait_online_utils(__unused void** state)
+{
+    char template[] = "/tmp/netplan.XXXXXX";
+    const char* rootdir = mkdtemp(template);
+
+    // create mock sysfs
+    g_autofree gchar* sys = g_strdup_printf("%s/sys", rootdir);
+    g_autofree gchar* sys_class = g_strdup_printf("%s/sys/class", rootdir);
+    g_autofree gchar* sys_class_net = g_strdup_printf("%s/sys/class/net", rootdir);
+    g_autofree gchar* eth99 = g_strdup_printf("%s/sys/class/net/eth99", rootdir);
+    g_autofree gchar* eth99_device = g_strdup_printf("%s/device", eth99);
+    g_autofree gchar* driver = g_strdup_printf("%s/device/driver", eth99);
+    g_autofree gchar* mac = g_strdup_printf("%s/address", eth99);
+    g_mkdir_with_parents(eth99_device, 0700);
+
+    // assert MAC address file
+    assert_true(g_file_set_contents(mac, "  aa:bb:cc:dd:ee:ff \r\n\n", -1, NULL));
+    g_autofree gchar* mac_value = _netplan_sysfs_get_mac_by_ifname("eth99", rootdir);
+    assert_string_equal(mac_value, "aa:bb:cc:dd:ee:ff");
+
+    // assert driver link
+    assert_int_equal(symlink("../somewhere/drivers/mock_drv", driver), 0);
+    g_autofree gchar* driver_value = _netplan_sysfs_get_driver_by_ifname("eth99", rootdir);
+    assert_string_equal(driver_value, "mock_drv");
+
+    // Cleanup
+    remove(mac);
+    remove(driver);
+    rmdir(eth99_device);
+    rmdir(eth99);
+    rmdir(sys_class_net);
+    rmdir(sys_class);
+    rmdir(sys);
+    rmdir(rootdir);
+}
+
+
+int
+setup(__unused void** state)
+{
+    return 0;
+}
+
+int
+tear_down(__unused void** state)
+{
+    return 0;
+}
+
+int
+main()
+{
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_wait_online_utils),
+    };
+
+    return cmocka_run_group_tests(tests, setup, tear_down);
+
+}

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -466,6 +466,8 @@ class TestBase(unittest.TestCase):
         self.assertEqual(set(os.listdir(self.workdir.name)) - {'lib'}, {'etc', 'run'})
         ovs_systemd_dir = set(os.listdir(systemd_dir))
         ovs_systemd_dir.remove('systemd-networkd.service.wants')
+        if 'systemd-networkd-wait-online.service.d' in ovs_systemd_dir:
+            ovs_systemd_dir.remove('systemd-networkd-wait-online.service.d')
         self.assertEqual(ovs_systemd_dir, {'netplan-ovs-' + f for f in file_contents_map})
         for fname, contents in file_contents_map.items():
             fname = 'netplan-ovs-' + fname

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -128,9 +128,9 @@ class TestConfigArgs(TestBase):
             f.write('''network:
   version: 2
   ethernets:
-    eth0:
+    eth99:
       dhcp4: true
-    eth1:
+    eth98:
       dhcp4: true
       optional: true
     lo:
@@ -144,10 +144,10 @@ class TestConfigArgs(TestBase):
         os.symlink(exe_generate, generator)
 
         subprocess.check_call([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir])
-        n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-eth0.network')
+        n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-eth99.network')
         self.assertTrue(os.path.exists(n))
         os.unlink(n)
-        n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-eth1.network')
+        n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-eth98.network')
         self.assertTrue(os.path.exists(n))
         os.unlink(n)
         n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-lo.network')
@@ -168,7 +168,7 @@ ConditionPathIsSymbolicLink=/run/systemd/generator/network-online.target.wants/s
 
 [Service]
 ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i lo:carrier -i eth0\n''')
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i lo:carrier\n''')  # eth99 does not exist on the system
 
         # should be a no-op the second time while the stamp exists
         out = subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir],

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -39,6 +39,10 @@ class TestConfigArgs(TestBase):
         self.assert_nm(None)
         self.assert_nm_udev(None)
         self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+        # should not touch -wait-online
+        service_dir = os.path.join(self.workdir.name, 'run', 'systemd', 'system')
+        override = os.path.join(service_dir, 'systemd-networkd-wait-online.service.d', '10-netplan.conf')
+        self.assertFalse(os.path.isfile(override))
 
     def test_empty_config(self):
         self.generate('')

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -134,7 +134,10 @@ class TestConfigArgs(TestBase):
       dhcp4: true
       optional: true
     lo:
-      addresses: ["127.0.0.1/8", "::1/128"]''')
+      addresses: ["127.0.0.1/8", "::1/128"]
+  bridges:
+    br0:
+      dhcp4: true''')
         os.chmod(conf, mode=0o600)
         outdir = os.path.join(self.workdir.name, 'out')
         os.mkdir(outdir)
@@ -153,6 +156,9 @@ class TestConfigArgs(TestBase):
         n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-lo.network')
         self.assertTrue(os.path.exists(n))
         os.unlink(n)
+        n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-br0.network')
+        self.assertTrue(os.path.exists(n))
+        os.unlink(n)
 
         # should auto-enable networkd and -wait-online
         service_dir = os.path.join(self.workdir.name, 'run', 'systemd', 'system')
@@ -168,7 +174,7 @@ ConditionPathIsSymbolicLink=/run/systemd/generator/network-online.target.wants/s
 
 [Service]
 ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i lo:carrier\n''')  # eth99 does not exist on the system
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i br0:degraded -i lo:carrier\n''')  # eth99 does not exist on the system
 
         # should be a no-op the second time while the stamp exists
         out = subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir],

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -129,8 +129,8 @@ class TestConfigArgs(TestBase):
     eth1:
       dhcp4: true
       optional: true
-    eth2:
-      dhcp4: true''')
+    lo:
+      addresses: ["127.0.0.1/8", "::1/128"]''')
         os.chmod(conf, mode=0o600)
         outdir = os.path.join(self.workdir.name, 'out')
         os.mkdir(outdir)
@@ -146,7 +146,7 @@ class TestConfigArgs(TestBase):
         n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-eth1.network')
         self.assertTrue(os.path.exists(n))
         os.unlink(n)
-        n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-eth2.network')
+        n = os.path.join(self.workdir.name, 'run', 'systemd', 'network', '10-netplan-lo.network')
         self.assertTrue(os.path.exists(n))
         os.unlink(n)
 
@@ -164,7 +164,7 @@ ConditionPathIsSymbolicLink=/run/systemd/generator/network-online.target.wants/s
 
 [Service]
 ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i eth0 -i eth2\n''')
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i lo:carrier -i eth0\n''')
 
         # should be a no-op the second time while the stamp exists
         out = subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir],

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -35,9 +35,6 @@ class TestNetworkd(TestBase):
         self.assert_networkd({'eth0.network': '''[Match]
 Name=eth0
 
-[Link]
-RequiredForOnline=no
-
 [Network]
 DHCP=ipv6
 LinkLocalAddressing=ipv6
@@ -85,7 +82,6 @@ Name=eth0
 
 [Link]
 ActivationPolicy=always-down
-RequiredForOnline=no
 
 [Network]
 DHCP=ipv6
@@ -109,7 +105,6 @@ Name=eth0
 
 [Link]
 ActivationPolicy=manual
-RequiredForOnline=no
 
 [Network]
 DHCP=ipv6

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -409,8 +409,12 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
       set-name: "findme"
     %(e2c)s:
       addresses: ["10.0.0.1/24"]
+  bridges:
+    br0:
+      addresses: ["10.0.0.2/24"]
+      interfaces: [%(e2c)s]
 ''' % {'r': self.backend, 'ec_mac': self.dev_e_client_mac, 'e2c': self.dev_e2_client})
-        self.generate_and_settle([self.dev_e2_client])
+        self.generate_and_settle([self.dev_e2_client, 'br0'])
         override = os.path.join('/run', 'systemd', 'system', 'systemd-networkd-wait-online.service.d', '10-netplan.conf')
         self.assertTrue(os.path.isfile(override))
 
@@ -424,7 +428,7 @@ ConditionPathIsSymbolicLink=/run/systemd/generator/network-online.target.wants/s
 
 [Service]
 ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i %s:degraded -i findme:carrier
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i %s:degraded -i br0:degraded -i findme:carrier
 ''' % self.dev_e2_client)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -380,7 +380,7 @@ class TestUtils(unittest.TestCase):
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         utils.systemctl_daemon_reload()
         self.assertEqual(self.mock_cmd.calls(), [
-            ['systemctl', 'daemon-reload']
+            ['systemctl', 'daemon-reload', '--no-ask-password']
         ])
 
     def test_ip_addr_flush(self):


### PR DESCRIPTION
## Description
Skip s-n-wait-online if we don't have any non-optional interfaces, using a "ConditionPathIsSymbolicLink=" checking Netplan's s-n-wait-online.service enablement symlink.

This is in favor to RequiredForOnline=yes as the behavior of upstream (pure)
systemd-networkd-wait-online.service is not mean to be used in this way.
    
If "RequiredForOnline=no" sd-networkd-wait-online will fully ignore the
corresponding interface and it will block/delay network-online.target if
no interfaces are "RequiredForOnline=yes" at all.
    
FR-7246

Note: This is a replacement for https://github.com/canonical/netplan/pull/455 that keeps compatibility with cloud-init, so it can still sort `After=systemd-networkd-wait-online.service` AND `Before=network-online.target`.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#2060311

