### PR TITLE
added guide for contributing to the netplan documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,26 @@ An overview of the architecture can be found at [netplan.io/design](https://netp
 Find the full [documentation for Netplan](https://netplan.readthedocs.io) on "Read the Docs".
 
 To contribute documentation, these steps should get you started:
-* Fork and clone the repo:
-    ```shell
+1. Fork and clone the repo:
+    ```
     git clone git@github.com:your_user_name/netplan.git
     ```
-* Create a new branch:
-    ```shell
+2. Create a new branch:
+    ```
     git checkout -b <your_branch_name>
     ```
-* Navigate to the `doc/` directory and make your contribution:
-    ```shell
+3. Navigate to the `doc/` directory and make your contribution:
+    ```
     cd doc
     ```
-* View your documentation in the browser by running the `make` command from within the `doc/` directory:
-    ```shell
+4. View your documentation in the browser by running the `make` command from within the `doc/` directory:
+    ```
     make run
     ```
 
-* Test your contribution to ensure good quality.
+5. Test your contribution to ensure good quality.
 
-* Push your contribution to GitHub and create a pull request.
+6. Push your contribution to GitHub and create a pull request.
 
 If you face issues, refer to our [comprehensive contribution guide](https://netplan.readthedocs.io/en/stable/contribute-docs/).
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,33 @@ An overview of the architecture can be found at [netplan.io/design](https://netp
 
 Find the full [documentation for Netplan](https://netplan.readthedocs.io) on "Read the Docs".
 
+To contribute documentation, these steps should get you started:
+* Fork and clone the repo:
+    ```shell
+    git clone git@github.com:your_user_name/netplan.git
+    ```
+* Create a new branch:
+    ```shell
+    git checkout -b <your_branch_name>
+    ```
+* Navigate to the `doc/` directory and make your contribution:
+    ```shell
+    cd doc
+    ```
+* View your documentation in the browser by running the `make` command from within the `doc/` directory:
+    ```shell
+    make run
+    ```
+
+* Test your contribution to ensure good quality.
+
+* Push your contribution to GitHub and create a pull request.
+
+If you face issues, refer to our [comprehensive contribution guide](https://netplan.readthedocs.io/en/stable/contribute-docs/).
+
 # Build using Meson
 
-Steps to build netplan using the [Meson](https://mesonbuild.com) build system inside the `build/` directory:
+Steps to build Netplan using the [Meson](https://mesonbuild.com) build system inside the `build/` directory:
 
 * meson setup build --prefix=/usr [-Db_coverage=true]
 * meson compile -C build

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -59,7 +59,7 @@ The Netplan documentation is built with Sphinx using the reStructuredText and Ma
 We also use our Sphinx documentation starter pack for our documentation. You can [read about it](https://github.com/canonical/sphinx-docs-starter-pack) to properly understand how it works.
 
 ## Testing the Documentation
-You should test the documentation before you make your pull request. These are some commands you should run `within` the `doc/` directory to test the documentation locally:
+Test the documentation before submitting a pull request. Run the following commands from within the `doc/` directory to test the documentation locally:
 
 |command  |use|
 |---------|-----|

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -53,7 +53,7 @@ Follow these steps to build the documentation on your local machine.
     ```shell
     make run
     ```
-    After you run the command, visit `http://127.0.0.1:8000` to view the documentation on your local machine.
+    After you run the command, visit `http://127.0.0.1:8000` in your browser to view the local copy of the documentation.
 
     You can also find all the HTML files in the `.build/` directory.
 

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -57,7 +57,7 @@ Follow these steps to build the documentation on your local machine.
 
     You can find all the HTML files in the `.build/` directory.
 
-    We use the `autobuild` module so that any edits you make (and save) as you work are applied and the documentation refreshes immediately.
+    We use the Sphinx `autobuild` module, so that any edits you make (and save) as you work are applied, and the documentation refreshes immediately.
 
 ## Documentation Format
 The Netplan documentation is built with Sphinx using the reStructuredText and Markdown mark-up languages. If you're new to reStructuredText, read our [reStructuredText style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/).

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -55,7 +55,7 @@ Follow these steps to build the documentation on your local machine.
     We use the `autobuild` module so that any edits you make (and save) as you work are applied and the documentation refreshes immediately.
 
 ## Documentation Format
-The Netplan documentation is built with Sphinx using some Restructured Text formatting and Markdown. If you're new to Restructured Text, read our [style guide on how we use it at Ubuntu](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/).
+The Netplan documentation is built with Sphinx using the reStructuredText and Markdown mark-up languages. If you're new to reStructuredText, read our [reStructuredText style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/).
 We also use our Sphinx documentation starter pack for our documentation. You can [read about it](https://github.com/canonical/sphinx-docs-starter-pack) to properly understand how it works.
 
 ## Testing the Documentation

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -22,7 +22,7 @@ changes as [pull requests](https://github.com/canonical/netplan/pulls), putting
 the `documentation` label for better visibility.
 
 ## Directory structure
-All the documentation files are located in the `doc/` directory. The `doc/` directory contains sub-directories corresponding to different Diátaxis sections. So you should find the following folders inside the `doc/` directory:
+All the documentation files are located in the `doc/` directory. The `doc/` directory contains sub-directories corresponding to different [Diátaxis](https://diataxis.fr/) sections:
 * `tutorial`
 * `explanation`
 * `howto`

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -21,7 +21,7 @@ To follow a Git development workflow, checkout the
 changes as [pull requests](https://github.com/canonical/netplan/pulls), putting
 the `documentation` label for better visibility.
 
-## Folder Structure
+## Directory structure
 All the documentation files are located in the `doc/` directory. The `doc/` directory contains sub-directories corresponding to different Diátaxis sections. So you should find the following folders inside the `doc/` directory:
 * `tutorial`
 * `explanation`

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -59,7 +59,7 @@ Follow these steps to build the documentation on your local machine.
 
     We use the Sphinx `autobuild` module, so that any edits you make (and save) as you work are applied, and the documentation refreshes immediately.
 
-## Documentation Format
+## Documentation format
 The Netplan documentation is built with Sphinx using the reStructuredText and Markdown mark-up languages. If you're new to reStructuredText, read our [reStructuredText style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/).
 We also use our Sphinx documentation starter pack for our documentation. You can [read about it](https://github.com/canonical/sphinx-docs-starter-pack) to properly understand how it works.
 

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -8,7 +8,7 @@ to it.
 
 ## Modifying documentation online
 
-Each documentation page rendered on the web contains an **Edit this **page** link at the top-right of every page. Clicking this button will lead you to the GitHub
+Each documentation page rendered on the web contains an **Edit this page** link in the top-right corner. Clicking this button leads you to the GitHub
 web editor where you can propose changes to the corresponding page.
 
 Please remember to first check the [latest version](https://netplan.readthedocs.io/en/latest/)

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -43,7 +43,7 @@ Follow these steps to build the documentation on your local machine.
     cd netplan/doc
     ```
 
-3. Install `make` on your machine if you don't have it.
+4. Install `make` on your machine if you don't have it:
     ```shell
     sudo apt-get install make
     ```

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -3,7 +3,7 @@ This guide provides all the information necessary to contribute to the Netplan d
 
 ## Reporting an issue
 
-If you find any issue in Netplan documentation please [file a bug report](https://bugs.launchpad.net/netplan/+filebug?field.tags=documentation) about it in our bug tracker on Launchpad. Remember to add a `documentation`` tag
+To report an issue in Netplan documentation, [file a bug](https://bugs.launchpad.net/netplan/+filebug?field.tags=documentation) about it in our bug tracker on Launchpad. Remember to add a `documentation`` tag.
 to it.
 
 ## Modifying documentation online

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -30,7 +30,7 @@ All the documentation files are located in the `doc/` directory. The `doc/` dire
 
 Add new articles in the appropriate directory. You can read about [how Ubuntu implements Diátaxis for documentation](https://ubuntu.com/blog/diataxis-a-new-foundation-for-canonical-documentation).
 
-## How to Build the Documentation
+## Building the documentation
 Follow these steps to build the documentation on your local machine.
 1. To build this documentation, first create a fork of the [Netplan repository](https://github.com/canonical/netplan) and clone that into your machine. For example:
     ```shell

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -16,7 +16,7 @@ of our documentation and make your proposal based on that revision.
 
 ## Contributing on GitHub
 
-If you want to follow a Git development workflow, you can also check out the
+To follow a Git development workflow, checkout the
 [Netplan repository](https://github.com/canonical/netplan) and contribute your
 changes as [pull requests](https://github.com/canonical/netplan/pulls), putting
 the `documentation` label for better visibility.

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -11,15 +11,14 @@ to it.
 Each documentation page rendered on the web contains an **Edit this page** link in the top-right corner. Clicking this button leads you to the GitHub
 web editor where you can propose changes to the corresponding page.
 
-Please remember to first check the [latest version](https://netplan.readthedocs.io/en/latest/)
+Remember to first check the [latest version](https://netplan.readthedocs.io/en/latest/)
 of our documentation and make your proposal based on that revision.
 
 ## Contributing on GitHub
 
 To follow a Git development workflow, `checkout` the
 [Netplan repository](https://github.com/canonical/netplan) and contribute your
-changes as [pull requests](https://github.com/canonical/netplan/pulls), putting
-the `documentation` label for better visibility.
+changes as [pull requests](https://github.com/canonical/netplan/pulls).
 
 ## Directory structure
 All the documentation files are located in the `doc/` directory. The `doc/` directory contains sub-directories corresponding to different [Diátaxis](https://diataxis.fr/) sections:
@@ -35,7 +34,7 @@ Follow these steps to build the documentation on your local machine.
 1. Fork the [Netplan repository](https://github.com/canonical/netplan). Visit [Fork a repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) for instructions.
 
 2. Clone the repository to your machine:
-    ```shell
+    ```
     git clone git@github.com:your_user_name/netplan.git
     ```
 3. Navigate to the `doc/` directory within the cloned repository:
@@ -44,7 +43,7 @@ Follow these steps to build the documentation on your local machine.
     ```
 
 4. Install `make` on your machine if you don't have it:
-    ```shell
+    ```
     sudo apt-get install make
     ```
     :::{note}
@@ -52,7 +51,7 @@ Follow these steps to build the documentation on your local machine.
     :::
 
 5. Within the `doc/` directory, run the `make` command to build and serve the documentation:
-    ```shell
+    ```
     make run
     ```
     After you run the command, visit `http://127.0.0.1:8000` in your browser to view the local copy of the documentation.

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -38,7 +38,10 @@ Follow these steps to build the documentation on your local machine.
     ```shell
     git clone git@github.com:your_user_name/netplan.git
     ```
-2. Navigate to the `doc/` directory and open it in your code editor.
+3. Navigate to the `doc/` directory within the cloned repository:
+    ```
+    cd netplan/doc
+    ```
 
 3. Install `make` on your machine if you don't have it.
     ```shell

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -61,7 +61,6 @@ Follow these steps to build the documentation on your local machine.
 
 ## Documentation format
 The Netplan documentation is built with Sphinx using the reStructuredText and Markdown mark-up languages. If you're new to reStructuredText, read our [reStructuredText style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/).
-We also use our Sphinx documentation starter pack for our documentation. You can [read about it](https://github.com/canonical/sphinx-docs-starter-pack) to properly understand how it works.
 
 ## Testing the Documentation
 Test the documentation before submitting a pull request. Run the following commands from within the `doc/` directory to test the documentation locally:

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -65,3 +65,8 @@ You should test the documentation before you make your pull request. These are s
 |---------|-----|
 |`make spelling`| Checks for spelling errors. This commands checks the HTML files in the `_build` directory. You should fix any errors in the corresponding Markdown file.|
 | `make linkcheck`| Checks for broken links|
+
+**NOTE**: For the `make spelling` command to work, you must have `aspell` installed. You can install it with this command:
+```shell
+sudo apt-get install aspell
+```

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -67,8 +67,9 @@ Test the documentation before submitting a pull request. Run the following comma
 
 |command  |use|
 |---------|-----|
-|`make spelling`| Checks for spelling errors. This commands checks the HTML files in the `_build` directory. You should fix any errors in the corresponding Markdown file.|
-| `make linkcheck`| Checks for broken links|
+| `make spelling` | Check for spelling errors. This command checks the HTML files in the `_build` directory. Fix any errors in the corresponding Markdown file.|
+| `make linkcheck`| Check for broken links|
+| `make woke` | Check for non-inclusive language |
 
 :::{note}
 For the `make spelling` command to work, you must have `aspell` installed. You can install it with `sudo apt-get install aspell`.

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -34,7 +34,7 @@ If you're adding a new article, include it in the appropriate Diátaxis director
 Follow these steps to build the documentation on your local machine.
 1. To build this documentation, first create a fork of the [Netplan repository](https://github.com/canonical/netplan) and clone that into your machine. For example:
     ```shell
-    git clone git@github.com:ade555/netplan.git
+    git clone git@github.com:your_user_name/netplan.git
     ```
 2. Navigate to the `doc/` directory and open it in your code editor.
 

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -55,7 +55,7 @@ Follow these steps to build the documentation on your local machine.
     ```
     After you run the command, visit `http://127.0.0.1:8000` in your browser to view the local copy of the documentation.
 
-    You can also find all the HTML files in the `.build/` directory.
+    You can find all the HTML files in the `.build/` directory.
 
     We use the `autobuild` module so that any edits you make (and save) as you work are applied and the documentation refreshes immediately.
 

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -49,7 +49,7 @@ Follow these steps to build the documentation on your local machine.
     ```
     **NOTE**: The `make` command is compatible with Unix systems. If you're on Windows, you can [install Ubuntu with WSL to follow along](https://github.com/canonical/open-documentation-academy/blob/main/getting-started/start_with_WSL.md).
 
-4. Within the `doc/` directory, run this command to build and serve the documentation:
+5. Within the `doc/` directory, run the `make` command to build and serve the documentation:
     ```shell
     make run
     ```

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -66,7 +66,6 @@ Test the documentation before submitting a pull request. Run the following comma
 |`make spelling`| Checks for spelling errors. This commands checks the HTML files in the `_build` directory. You should fix any errors in the corresponding Markdown file.|
 | `make linkcheck`| Checks for broken links|
 
-**NOTE**: For the `make spelling` command to work, you must have `aspell` installed. You can install it with this command:
-```shell
-sudo apt-get install aspell
-```
+:::{note}
+For the `make spelling` command to work, you must have `aspell` installed. You can install it with `sudo apt-get install aspell`.
+:::

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -16,7 +16,7 @@ of our documentation and make your proposal based on that revision.
 
 ## Contributing on GitHub
 
-To follow a Git development workflow, checkout the
+To follow a Git development workflow, `checkout` the
 [Netplan repository](https://github.com/canonical/netplan) and contribute your
 changes as [pull requests](https://github.com/canonical/netplan/pulls), putting
 the `documentation` label for better visibility.
@@ -47,7 +47,9 @@ Follow these steps to build the documentation on your local machine.
     ```shell
     sudo apt-get install make
     ```
-    **NOTE**: The `make` command is compatible with Unix systems. If you're on Windows, you can [install Ubuntu with WSL to follow along](https://github.com/canonical/open-documentation-academy/blob/main/getting-started/start_with_WSL.md).
+    :::{note}
+    The `make` command is compatible with Unix systems. If you're on Windows, you can [install Ubuntu with WSL to follow along](https://github.com/canonical/open-documentation-academy/blob/main/getting-started/start_with_WSL.md).
+    :::
 
 5. Within the `doc/` directory, run the `make` command to build and serve the documentation:
     ```shell
@@ -62,7 +64,7 @@ Follow these steps to build the documentation on your local machine.
 ## Documentation format
 The Netplan documentation is built with Sphinx using the reStructuredText and Markdown mark-up languages. If you're new to reStructuredText, read our [reStructuredText style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/).
 
-## Testing the Documentation
+## Testing the documentation
 Test the documentation before submitting a pull request. Run the following commands from within the `doc/` directory to test the documentation locally:
 
 |command  |use|

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -3,7 +3,7 @@ This guide provides all the information necessary to contribute to the Netplan d
 
 ## Reporting an issue
 
-To report an issue in Netplan documentation, [file a bug](https://bugs.launchpad.net/netplan/+filebug?field.tags=documentation) about it in our bug tracker on Launchpad. Remember to add a `documentation`` tag.
+To report an issue in Netplan documentation, [file a bug](https://bugs.launchpad.net/netplan/+filebug?field.tags=documentation) about it in our bug tracker on Launchpad. Remember to add a `documentation` tag.
 to it.
 
 ## Modifying documentation online

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -28,7 +28,7 @@ All the documentation files are located in the `doc/` directory. The `doc/` dire
 * `howto`
 * `reference`
 
-If you're adding a new article, include it in the appropriate Diátaxis directory. You can read about [how Ubuntu implements Diátaxis for documentation](https://ubuntu.com/blog/diataxis-a-new-foundation-for-canonical-documentation).
+Add new articles in the appropriate directory. You can read about [how Ubuntu implements Diátaxis for documentation](https://ubuntu.com/blog/diataxis-a-new-foundation-for-canonical-documentation).
 
 ## How to Build the Documentation
 Follow these steps to build the documentation on your local machine.

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -32,7 +32,9 @@ Add new articles in the appropriate directory. You can read about [how Ubuntu im
 
 ## Building the documentation
 Follow these steps to build the documentation on your local machine.
-1. To build this documentation, first create a fork of the [Netplan repository](https://github.com/canonical/netplan) and clone that into your machine. For example:
+1. Fork the [Netplan repository](https://github.com/canonical/netplan). Visit [Fork a repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) for instructions.
+
+2. Clone the repository to your machine:
     ```shell
     git clone git@github.com:your_user_name/netplan.git
     ```

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -1,5 +1,5 @@
 # How to contribute documentation
-This guide aims to help you with all the information necessary to contribute to the Netplan documentation, especially if you're contributing for the first time.
+This guide provides all the information necessary to contribute to the Netplan documentation, especially if you're contributing for the first time.
 
 ## Reporting an issue
 
@@ -22,40 +22,46 @@ changes as [pull requests](https://github.com/canonical/netplan/pulls), putting
 the `documentation` label for better visibility.
 
 ## Folder Structure
-All the documentation files are located in the `doc/` directory. The `doc/` directory contains sub-directories corresponding to different Diataxis sections. So you should find the following folders inside the `doc/` directory:
+All the documentation files are located in the `doc/` directory. The `doc/` directory contains sub-directories corresponding to different Diátaxis sections. So you should find the following folders inside the `doc/` directory:
 * `tutorial`
 * `explanation`
 * `howto`
 * `reference`
 
-If you're adding a new article, ensure you include it in the appropriate Diataxis directory. You can read about [how Ubuntu implements Diataxis for documentation](https://ubuntu.com/blog/diataxis-a-new-foundation-for-canonical-documentation).
+If you're adding a new article, include it in the appropriate Diátaxis directory. You can read about [how Ubuntu implements Diátaxis for documentation](https://ubuntu.com/blog/diataxis-a-new-foundation-for-canonical-documentation).
 
 ## How to Build the Documentation
-These steps will show you how to build the documentation on your local machine.
+Follow these steps to build the documentation on your local machine.
 1. To build this documentation, first create a fork of the [Netplan repository](https://github.com/canonical/netplan) and clone that into your machine. For example:
     ```shell
     git clone git@github.com:ade555/netplan.git
     ```
-2. Navigate to the `doc/` directory as you'll mostly be working here. Open this directory in your code editor.
+2. Navigate to the `doc/` directory and open it in your code editor.
 
 3. Install `make` on your machine if you don't have it.
     ```shell
     sudo apt-get install make
     ```
-    **NOTE**: The `make` command is compatible with Unix systems. If you're on Windows, you can [install Ubuntu with WSL by following this guide](https://github.com/canonical/open-documentation-academy/blob/main/getting-started/start_with_WSL.md).
+    **NOTE**: The `make` command is compatible with Unix systems. If you're on Windows, you can [install Ubuntu with WSL to follow along](https://github.com/canonical/open-documentation-academy/blob/main/getting-started/start_with_WSL.md).
 
 4. Within the `doc/` directory, run this command to build and serve the documentation:
     ```shell
     make run
     ```
-    This command will install all the necessary packages and set up a Python virtual environment inside the `doc/.sphinx/` directory. 
+    After you run the command, visit `http://127.0.0.1:8000` to view the documentation on your local machine.
 
-    After you run the command, the documentation will be served on your system's local machine via `http://127.0.0.1:8000`.
+    You can also find all the HTML files in the `.build/` directory.
 
-    You can also find the HTML files in the `.build/` directory.
-
-    We use the autobuild module so that any edits you make (and save) as you work will be applied and the documentation refreshed immediately.
+    We use the `autobuild` module so that any edits you make (and save) as you work are applied and the documentation refreshes immediately.
 
 ## Documentation Format
 The Netplan documentation is built with Sphinx using some Restructured Text formatting and Markdown. If you're new to Restructured Text, read our [style guide on how we use it at Ubuntu](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/).
 We also use our Sphinx documentation starter pack for our documentation. You can [read about it](https://github.com/canonical/sphinx-docs-starter-pack) to properly understand how it works.
+
+## Testing the Documentation
+You should test the documentation before you make your pull request. These are some commands you should run `within` the `doc/` directory to test the documentation locally:
+
+|command  |use|
+|---------|-----|
+|`make spelling`| Checks for spelling errors. This commands checks the HTML files in the `_build` directory. You should fix any errors in the corresponding Markdown file.|
+| `make linkcheck`| Checks for broken links|

--- a/doc/contribute-docs.md
+++ b/doc/contribute-docs.md
@@ -1,25 +1,61 @@
 # How to contribute documentation
+This guide aims to help you with all the information necessary to contribute to the Netplan documentation, especially if you're contributing for the first time.
 
 ## Reporting an issue
 
-If you find any issue in Netplan documentation please [file a bugreport](https://bugs.launchpad.net/netplan/+filebug?field.tags=documentation)
-about it in our bug tracker on Launchpad. Remember adding a `documentation` tag
+If you find any issue in Netplan documentation please [file a bug report](https://bugs.launchpad.net/netplan/+filebug?field.tags=documentation) about it in our bug tracker on Launchpad. Remember to add a `documentation`` tag
 to it.
 
 ## Modifying documentation online
 
-Each documentation page rendered on the web contains an **Edit this page** link
-in the top-right of every page. Clicking this button will lead you to the GitHub
+Each documentation page rendered on the web contains an **Edit this **page** link at the top-right of every page. Clicking this button will lead you to the GitHub
 web editor where you can propose changes to the corresponding page.
 
 Please remember to first check the [latest version](https://netplan.readthedocs.io/en/latest/)
 of our documentation and make your proposal based on that revision.
 
-## Creating a pull request
+## Contributing on GitHub
 
-If you want to follow a Git development workflow, you can also checkout the
+If you want to follow a Git development workflow, you can also check out the
 [Netplan repository](https://github.com/canonical/netplan) and contribute your
 changes as [pull requests](https://github.com/canonical/netplan/pulls), putting
 the `documentation` label for better visibility.
 
-See the `doc/` and `examples/` directories for relevant files.
+## Folder Structure
+All the documentation files are located in the `doc/` directory. The `doc/` directory contains sub-directories corresponding to different Diataxis sections. So you should find the following folders inside the `doc/` directory:
+* `tutorial`
+* `explanation`
+* `howto`
+* `reference`
+
+If you're adding a new article, ensure you include it in the appropriate Diataxis directory. You can read about [how Ubuntu implements Diataxis for documentation](https://ubuntu.com/blog/diataxis-a-new-foundation-for-canonical-documentation).
+
+## How to Build the Documentation
+These steps will show you how to build the documentation on your local machine.
+1. To build this documentation, first create a fork of the [Netplan repository](https://github.com/canonical/netplan) and clone that into your machine. For example:
+    ```shell
+    git clone git@github.com:ade555/netplan.git
+    ```
+2. Navigate to the `doc/` directory as you'll mostly be working here. Open this directory in your code editor.
+
+3. Install `make` on your machine if you don't have it.
+    ```shell
+    sudo apt-get install make
+    ```
+    **NOTE**: The `make` command is compatible with Unix systems. If you're on Windows, you can [install Ubuntu with WSL by following this guide](https://github.com/canonical/open-documentation-academy/blob/main/getting-started/start_with_WSL.md).
+
+4. Within the `doc/` directory, run this command to build and serve the documentation:
+    ```shell
+    make run
+    ```
+    This command will install all the necessary packages and set up a Python virtual environment inside the `doc/.sphinx/` directory. 
+
+    After you run the command, the documentation will be served on your system's local machine via `http://127.0.0.1:8000`.
+
+    You can also find the HTML files in the `.build/` directory.
+
+    We use the autobuild module so that any edits you make (and save) as you work will be applied and the documentation refreshed immediately.
+
+## Documentation Format
+The Netplan documentation is built with Sphinx using some Restructured Text formatting and Markdown. If you're new to Restructured Text, read our [style guide on how we use it at Ubuntu](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide/).
+We also use our Sphinx documentation starter pack for our documentation. You can [read about it](https://github.com/canonical/sphinx-docs-starter-pack) to properly understand how it works.

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -609,7 +609,7 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
 
 ## DHCP Overrides
 Several DHCP behaviour overrides are available. Most currently only have any
-effect when using the networkd back end, with the exception of `use-routes`
+effect when using the `networkd` back end, with the exception of `use-routes`
 and `route-metric`.
 
 Overrides only have an effect if the corresponding `dhcp4` or `dhcp6` is


### PR DESCRIPTION
modified the doc/contribute-docs.md file to include information about building the documentation locally and other information to successfully contribute to the documentation


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

