### PR TITLE
parse: fix redefinition of gateway(4|6)

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -49,9 +49,7 @@
 #define vxlan_offset(field) GUINT_TO_POINTER(offsetof(NetplanVxlan, field))
 
 /* convenience macro to avoid strdup'ing a string into a field if it's already set. */
-#define set_str_if_null(dst, src) { if (dst) {\
-    g_assert_cmpstr(src, ==, dst); \
-} else { \
+#define set_str_if_null(dst, src) { if (dst == NULL) {\
     dst = g_strdup(src); \
 } }
 
@@ -1455,6 +1453,10 @@ handle_gateway4(NetplanParser* npp, yaml_node_t* node, __unused const void* _, G
 {
     if (!is_ip4_address(scalar(node)))
         return yaml_error(npp, node, error, "invalid IPv4 address '%s'", scalar(node));
+    if (npp->current.netdef->gateway4) {
+        g_free(npp->current.netdef->gateway4);
+        npp->current.netdef->gateway4 = NULL;
+    }
     set_str_if_null(npp->current.netdef->gateway4, scalar(node));
     mark_data_as_dirty(npp, &npp->current.netdef->gateway4);
     g_warning("`gateway4` has been deprecated, use default routes instead.\n"
@@ -1467,6 +1469,10 @@ handle_gateway6(NetplanParser* npp, yaml_node_t* node, __unused const void* _, G
 {
     if (!is_ip6_address(scalar(node)))
         return yaml_error(npp, node, error, "invalid IPv6 address '%s'", scalar(node));
+    if (npp->current.netdef->gateway6) {
+        g_free(npp->current.netdef->gateway6);
+        npp->current.netdef->gateway6 = NULL;
+    }
     set_str_if_null(npp->current.netdef->gateway6, scalar(node));
     mark_data_as_dirty(npp, &npp->current.netdef->gateway6);
     g_warning("`gateway6` has been deprecated, use default routes instead.\n"

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -1825,3 +1825,43 @@ network={
   psk="bbbbbbbb"
 }
 """)
+
+    def test_gateway6_redefinition_works(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: [2001:FFfe::1/62]
+      gateway6: 2001:FFfe::2''', confs={'b': '''network:
+  ethernets:
+    engreen:
+      gateway6: 2001:FFfe::34'''}, expect_fail=False)
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=2001:FFfe::1/62
+Gateway=2001:FFfe::34
+'''})
+
+    def test_gateway4_redefinition_works(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: [192.168.0.1/24]
+      gateway4: 192.168.0.123''', confs={'b': '''network:
+  ethernets:
+    engreen:
+      gateway4: 192.168.0.254'''}, expect_fail=False)
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=192.168.0.1/24
+Gateway=192.168.0.254
+'''})


### PR DESCRIPTION
Options gateway4 and gateway6 were not being properly redefined when a merge happens. Redefinition was causing a crash due to an assert in the set_str_if_null macro.

While this assertion helped identifying the merge issue, I believe it's not the best place to keep it so I'm removing it from the macro and making the macro do only what it name suggests it does.

This macro is used in other places but this problem seems to not happen there as far as I can see.

Add a couple of unit test to check the merge is working.


## Description

Reproducer:

```yaml
network:
  ethernets:
    eth0:
      addresses:
        - 192.168.0.1/24
      gateway4: 192.168.0.123
    eth0:
      gateway4: 192.168.0.111
```
```
$ netplan generate --root-dir /tmp/fakeroot4

** (generate:190262): WARNING **: 18:08:41.479: `gateway4` has been deprecated, use default routes instead.
See the 'Default routes' section of the documentation for more details.
**
ERROR:../src/parse.c:1434:handle_gateway4: assertion failed (scalar(node) == npp->current.netdef->gateway4): ("192.168.0.111" == "192.168.0.123")
Bail out! ERROR:../src/parse.c:1434:handle_gateway4: assertion failed (scalar(node) == npp->current.netdef->gateway4): ("192.168.0.111" == "192.168.0.123")
```
## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

