### PR TITLE
ci: migrate to Ubuntu 24.04

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
+          sudo add-apt-repository -y -n -s ppa:slyon/netplan-ci
           sudo apt update
           sudo apt install autopkgtest ubuntu-dev-tools devscripts openvswitch-switch linux-modules-extra-$(uname -r)
       # work around LP: #1878225 as fallback
@@ -47,6 +48,7 @@ jobs:
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
           sed -i 's|  python3-gi,|  python3-gi, python3-packaging,|' debian/tests/control  # needed for the 'routing' test (nm_version)
+          sed -i 's|bytecompile=-1|bytecompile=-1 -Dtesting=false|' debian/rules  # drop after v1.1
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"
@@ -54,4 +56,4 @@ jobs:
       - name: Run autopkgtest (incl. build)
         run: |
           autopkgtest . \
-            -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/noble/amd64
+            -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 -- lxd autopkgtest/ubuntu/noble/amd64

--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   lxd-ubuntu-jammy:
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -34,37 +34,24 @@ jobs:
       - name: Install dependencies
         run: |
           echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
-          sudo add-apt-repository -y -u -s ppa:slyon/netplan-ci
           sudo apt update
           sudo apt install autopkgtest ubuntu-dev-tools devscripts openvswitch-switch linux-modules-extra-$(uname -r)
       # work around LP: #1878225 as fallback
       - name: Preparing autopkgtest-build-lxd
         run: |
           sudo patch /usr/bin/autopkgtest-build-lxd .github/workflows/snapd.patch
-          autopkgtest-build-lxd ubuntu-daily:jammy
+          autopkgtest-build-lxd ubuntu-daily:noble
       - name: Prepare test
         run: |
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
-          # usrmerge-fix
-          echo "" >> debian/rules
-          echo "execute_after_dh_auto_install:" >> debian/rules
-          echo "	sh -c \"mkdir -p debian/tmp/usr/lib/systemd/system-generators; rm -rf debian/tmp/lib; ln -sf /usr/libexec/netplan/generate debian/tmp/usr/lib/systemd/system-generators/netplan\"" >> debian/rules
-          # usrmerge-fix-end
-          sed -i 's| systemd-dev|# DELETED: systemd-dev|' debian/control
           sed -i 's|  python3-gi,|  python3-gi, python3-packaging,|' debian/tests/control  # needed for the 'routing' test (nm_version)
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"
-          dch -v "$VER" "Autopkgtest CI testing (Jammy)"
+          dch -v "$VER" "Autopkgtest CI testing (Noble)"
       - name: Run autopkgtest (incl. build)
         run: |
-          # using --setup-commands temporarily to install:
-          # cmocka/pytest/rich/ethtool until they become proper test-deps
-          # The netplan-ci PPA is used here temporally to fix some quirks:
-          # - A bug with veths and network-manager 1.36. See LP: #2032824
-          # - A bug with gre6/vti6 and systemd-networkd 249.11. See LP: #2037667
           autopkgtest . \
-            --setup-commands='sudo add-apt-repository -y -u -s ppa:slyon/netplan-ci' \
-            -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/jammy/amd64
+            -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxd autopkgtest/ubuntu/noble/amd64

--- a/.github/workflows/build-abi.yml
+++ b/.github/workflows/build-abi.yml
@@ -17,7 +17,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -29,11 +29,9 @@ jobs:
       - name: Install build depends
         run: |
           echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
-          sudo add-apt-repository -y -u -s ppa:slyon/netplan-ci
           sudo apt update
           sudo apt install abigail-tools ubuntu-dev-tools devscripts equivs
           pull-lp-source netplan.io
-          sed -i 's| systemd-dev|# DELETED: systemd-dev|' netplan.io-*/debian/control
           mk-build-deps -i -B -s sudo netplan.io-*/debian/control
 
       # Runs the build

--- a/.github/workflows/check-address-sanitizer.yml
+++ b/.github/workflows/check-address-sanitizer.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   memory-sanitizer:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
@@ -25,11 +25,9 @@ jobs:
       - name: Install build depends
         run: |
           echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
-          sudo add-apt-repository -y -u -s ppa:slyon/netplan-ci
           sudo apt update
           sudo apt -y install curl expect ubuntu-dev-tools devscripts equivs
           pull-lp-source netplan.io
-          sed -i 's| systemd-dev|# DELETED: systemd-dev|' netplan.io-*/debian/control
           mk-build-deps -i -B -s sudo netplan.io-*/debian/control
 
       - name: Run unit tests

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -13,7 +13,7 @@ jobs:
   # This workflow contains a single job called "test-and-coverage"
   test-and-coverage:
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -26,15 +26,11 @@ jobs:
       - name: Install build depends
         run: |
           echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
-          sudo add-apt-repository -y -u -s ppa:slyon/netplan-ci
           sudo apt update
           sudo apt install curl expect ubuntu-dev-tools devscripts equivs gcovr
           pull-lp-source netplan.io
-          sed -i 's| systemd-dev|# DELETED: systemd-dev|' netplan.io-*/debian/control
           mk-build-deps -i -B -s sudo netplan.io-*/debian/control
           rm -rf netplan.io-*/
-          wget http://archive.ubuntu.com/ubuntu/pool/universe/g/gcovr/gcovr_5.2-1_all.deb
-          sudo dpkg -i gcovr*.deb # we need newer gcovr to make the gcovr.cfg:exclude setting work
 
       # Runs the unit tests with coverage
       - name: Run unit tests

--- a/.github/workflows/check-wording.yaml
+++ b/.github/workflows/check-wording.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -58,7 +58,7 @@ jobs:
     # Installs the build dependencies
     - name: Install build depends
       run: |
-        sudo sed -i '/deb-src/s/^# //' /etc/apt/sources.list
+        sudo sed -i 's/Types: deb/Types: deb deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
         sudo apt update
         sudo apt install meson python3-coverage python3-pytest python3-pytest-cov libcmocka-dev python3-cffi libpython3-dev
         sudo apt build-dep netplan.io

--- a/.github/workflows/config-fuzzing.yml
+++ b/.github/workflows/config-fuzzing.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   config-fuzzer:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
@@ -25,13 +25,10 @@ jobs:
       - name: Install build depends
         run: |
           echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
-          # This PPA is needed here due to meson
-          sudo add-apt-repository -y -u -s ppa:slyon/netplan-ci
           sudo apt update
           sudo apt -y install curl expect ubuntu-dev-tools devscripts equivs
           sudo snap install node --classic
           pull-lp-source netplan.io
-          sed -i 's| systemd-dev|# DELETED: systemd-dev|' netplan.io-*/debian/control
           # Workaround for https://bugs.launchpad.net/bugs/2048768
           sudo sysctl vm.mmap_rnd_bits=28
           mk-build-deps -i -B -s sudo netplan.io-*/debian/control

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,18 +7,16 @@ on:
 jobs:
   coverity:
     if: github.repository == 'canonical/netplan'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
-          sudo add-apt-repository -y -u -s ppa:slyon/netplan-ci
           sudo apt update
           sudo apt -y install curl ubuntu-dev-tools equivs
           pull-lp-source netplan.io
-          sed -i 's| systemd-dev|# DELETED: systemd-dev|' netplan.io-*/debian/control
           mk-build-deps -i -B -s sudo netplan.io-*/debian/control
       - name: Download Coverity
         run: |

--- a/.github/workflows/debci.yml
+++ b/.github/workflows/debci.yml
@@ -29,7 +29,7 @@ jobs:
       # it's needed (will be auto-loaded) by routing.test_vrf_basic
       - name: Install dependencies
         run: |
-          sudo add-apt-repository -y -n -u -s ppa:slyon/netplan-ci
+          sudo add-apt-repository -y -n -s ppa:slyon/netplan-ci
           sudo apt update
           sudo apt install debci lxc lxc-templates debian-archive-keyring autopkgtest ubuntu-dev-tools devscripts linux-modules-extra-$(uname -r) #openvswitch-switch
       # See: https://discourse.ubuntu.com/t/containers-lxc/11526 (Apparmor section)

--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   lxd-network-manager:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -40,9 +40,6 @@ jobs:
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
-          # usrmerge-fix
-          sed -i 's|rm debian/tmp/lib/netplan/generate|sh -c "mkdir -p debian/tmp/usr/lib/systemd/system-generators; rm -rf debian/tmp/lib; ln -sf /usr/libexec/netplan/generate debian/tmp/usr/lib/systemd/system-generators/netplan"|' debian/rules
-          # usrmerge-fix-end
           echo "3.0 (native)" > debian/source/format  # force native build
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision

--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -33,6 +33,7 @@ jobs:
       # it's needed (will be auto-loaded) by routing.test_vrf_basic
       - name: Install dependencies
         run: |
+          sudo add-apt-repository -y -n -s ppa:slyon/netplan-ci
           sudo apt update
           sudo apt install autopkgtest ubuntu-dev-tools devscripts openvswitch-switch linux-modules-extra-$(uname -r)
       - name: Prepare test
@@ -41,6 +42,7 @@ jobs:
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
           echo "3.0 (native)" > debian/source/format  # force native build
+          sed -i 's|bytecompile=-1|bytecompile=-1 -Dtesting=false|' debian/rules  # drop after v1.1
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"
@@ -66,6 +68,5 @@ jobs:
           pull-lp-source network-manager noble
           sudo autopkgtest -U \
             --copy=debian/artifacts:/root/ --setup-commands='dpkg -i /root/*.deb' \
-            --env=DEB_BUILD_OPTIONS=nocheck \
             --apt-pocket=proposed=src:network-manager \
             network-manager_*.dsc -- lxd autopkgtest/ubuntu/noble/amd64 || test $? -eq 2  # allow for skipped tests (exit code = 2)

--- a/.github/workflows/snapd.patch
+++ b/.github/workflows/snapd.patch
@@ -1,9 +1,9 @@
-@@ -70,6 +70,8 @@
+@@ -119,6 +119,8 @@
  
      sleep 5
-     if "$COMMAND" exec "$CONTAINER" -- systemctl mask serial-getty@getty.service; then
-+       "$COMMAND" exec "$CONTAINER" -- systemctl mask snapd.service
-+       "$COMMAND" exec "$CONTAINER" -- systemctl mask snapd.seeded.service
-        "$COMMAND" exec "$CONTAINER" -- reboot
+     if "$COMMAND" exec "${REMOTE:+$REMOTE:}$CONTAINER" -- systemctl mask serial-getty@getty.service; then
++        "$COMMAND" exec "${REMOTE:+$REMOTE:}$CONTAINER" -- systemctl mask snapd.service
++        "$COMMAND" exec "${REMOTE:+$REMOTE:}$CONTAINER" -- systemctl mask snapd.seeded.service
+         safe_reboot
      fi
  

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   spread:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: canonical/setup-lxd@v0.1.1
       - uses: actions/checkout@v3

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1644,13 +1644,13 @@ _netplan_networkd_write_wait_online(const NetplanState* np_state, const char* ro
     // wait for all link-local (degraded/carrier) interface
     if (linklocal_str->len > 0) {
         g_string_append_printf(content, "ExecStart=/lib/systemd/systemd-networkd-wait-online%s\n", linklocal_str->str);
-        g_string_free(linklocal_str, TRUE);
     }
+    g_string_free(linklocal_str, TRUE);
     // wait for any routable interface
     if (routable_str->len > 0) {
         g_string_append_printf(content, "ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable%s\n", routable_str->str);
-        g_string_free(routable_str, TRUE);
     }
+    g_string_free(routable_str, TRUE);
 
     g_autofree char* new_content = _netplan_scrub_systemd_unit_contents(content->str);
     g_string_free(content, TRUE);


### PR DESCRIPTION
Move to Ubuntu 24.04 and drop the workarounds that were needed to run the tests on 22.04.

Note: I mistakenly thought it was already available after finding some github action commits adding Noble to the list of runners. But it's still in the roadmap https://github.com/github/roadmap/issues/958

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

