### PR TITLE
netplan status --diff fixes and improvements

### DIFF
--- a/include/netdef.h
+++ b/include/netdef.h
@@ -205,6 +205,16 @@ NETPLAN_PUBLIC gboolean
 netplan_netdef_get_link_local_ipv6(const NetplanNetDefinition* netdef);
 
 /**
+ * @brief   Query a @ref NetplanNetDefinition for the value of its `accept-ra` setting.
+ * @param[in] netdef The @ref NetplanNetDefinition to query
+ * @return           Indication if @p netdef is configured to accept Router Advertisements.
+ *                   Possible values are: 0) not set (will use kernel or back end defaults),
+ *                   1) enabled and 2) disabled.
+ */
+NETPLAN_PUBLIC int
+netplan_netdef_get_accept_ra(const NetplanNetDefinition* netdef);
+
+/**
  * @brief   Get the `macaddress` setting of a given @ref NetplanNetDefinition.
  * @details Copies a `NUL`-terminated string into a sized @p out_buffer. If the
  *          buffer is too small, its content is not `NUL`-terminated.

--- a/include/netdef.h
+++ b/include/netdef.h
@@ -227,5 +227,3 @@ netplan_netdef_get_accept_ra(const NetplanNetDefinition* netdef);
  */
 NETPLAN_PUBLIC ssize_t
 netplan_netdef_get_macaddress(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);
-
-

--- a/include/netdef.h
+++ b/include/netdef.h
@@ -217,3 +217,5 @@ netplan_netdef_get_link_local_ipv6(const NetplanNetDefinition* netdef);
  */
 NETPLAN_PUBLIC ssize_t
 netplan_netdef_get_macaddress(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);
+
+

--- a/netplan_cli/cli/commands/status.py
+++ b/netplan_cli/cli/commands/status.py
@@ -751,10 +751,14 @@ class NetplanStatus(utils.NetplanCommand):
     def plain_print(self, *args, **kwargs):
         if len(args):
             lst = list(args)
-            for tag in MATCH_TAGS.findall(lst[0]):
-                # remove matching opening and closing tag
-                lst[0] = lst[0].replace('[{}]'.format(tag), '')\
-                               .replace('[/{}]'.format(tag), '')
+            while True:
+                tags = MATCH_TAGS.findall(lst[0])
+                if not tags:
+                    break
+                for tag in tags:
+                    # remove matching opening and closing tag
+                    lst[0] = lst[0].replace('[{}]'.format(tag), '')\
+                                   .replace('[/{}]'.format(tag), '')
             return print(*lst, **kwargs)
         return print(*args, **kwargs)
 

--- a/netplan_cli/cli/state.py
+++ b/netplan_cli/cli/state.py
@@ -152,6 +152,8 @@ class Interface():
                 flags: list = []
                 if ipaddress.ip_address(addr['local']).is_link_local:
                     flags.append('link')
+                if addr.get('dynamic', False):
+                    flags.append('dynamic')
                 if self.routes:
                     for route in self.routes:
                         if ('from' in route and

--- a/netplan_cli/cli/state.py
+++ b/netplan_cli/cli/state.py
@@ -22,7 +22,7 @@ import ipaddress
 import json
 import logging
 import re
-import socket
+from socket import inet_ntop, AF_INET, AF_INET6
 import subprocess
 import sys
 from io import StringIO
@@ -107,7 +107,7 @@ class Interface():
                 if int(itr[0]) == int(self.idx):
                     ipfamily = itr[1]
                     dns = itr[2]
-                    self.dns_addresses.append(socket.inet_ntop(ipfamily, b''.join([v.to_bytes(1, 'big') for v in dns])))
+                    self.dns_addresses.append(inet_ntop(ipfamily, b''.join([v.to_bytes(1, 'big') for v in dns])))
         self.dns_search: list = None
         if resolved_data[1]:
             self.dns_search = []
@@ -153,7 +153,7 @@ class Interface():
                 for route in self.routes:
                     if (route.get('protocol') == 'ra'
                             and route.get('to') != 'default'
-                            and route.get('family') == 10):
+                            and route.get('family') == AF_INET6.value):
                         ra_networks.add(ipaddress.ip_interface(route['to']).network)
 
             self.addresses = []
@@ -519,10 +519,10 @@ class SystemConfigState():
         # IPv4: 2, IPv6: 10
         if data4:
             for route in data4:
-                route.update({'family': socket.AF_INET.value})
+                route.update({'family': AF_INET.value})
         if data6:
             for route in data6:
-                route.update({'family': socket.AF_INET6.value})
+                route.update({'family': AF_INET6.value})
         return (data4, data6)
 
     @classmethod

--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -123,6 +123,8 @@ ffibuilder.cdef("""
     int _netplan_state_get_vf_count_for_def(
         const NetplanState* np_state, const NetplanNetDefinition* netdef, NetplanError** error);
     ssize_t _netplan_netdef_get_bond_mode(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size);
+    ssize_t _netplan_netdef_get_gateway4(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);
+    ssize_t _netplan_netdef_get_gateway6(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);
 
     // Iterators (internal)
     struct netdef_pertype_iter* _netplan_state_new_netdef_pertype_iter(NetplanState* np_state, const char* def_type);

--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -111,6 +111,7 @@ ffibuilder.cdef("""
     gboolean netplan_netdef_get_dhcp6(const NetplanNetDefinition* netdef);
     gboolean netplan_netdef_get_link_local_ipv4(const NetplanNetDefinition* netdef);
     gboolean netplan_netdef_get_link_local_ipv6(const NetplanNetDefinition* netdef);
+    int netplan_netdef_get_accept_ra(const NetplanNetDefinition* netdef);
     ssize_t netplan_netdef_get_macaddress(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);
 
     // NetDefinition (internal)

--- a/python-cffi/netplan/netdef.py
+++ b/python-cffi/netplan/netdef.py
@@ -72,6 +72,14 @@ class NetDefinition():
         return _NetdefRouteIterator(self._ptr)
 
     @property
+    def _gateway4(self) -> str:
+        return _string_realloc_call_no_error(lambda b: lib._netplan_netdef_get_gateway4(self._ptr, b, len(b)))
+
+    @property
+    def _gateway6(self) -> str:
+        return _string_realloc_call_no_error(lambda b: lib._netplan_netdef_get_gateway6(self._ptr, b, len(b)))
+
+    @property
     def macaddress(self) -> str:
         return _string_realloc_call_no_error(lambda b: lib.netplan_netdef_get_macaddress(self._ptr, b, len(b)))
 

--- a/python-cffi/netplan/netdef.py
+++ b/python-cffi/netplan/netdef.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
+from typing import Optional
 
 from ._netplan_cffi import ffi, lib
 from ._utils import _string_realloc_call_no_error, NetplanException
@@ -58,6 +59,19 @@ class NetDefinition():
         if bool(lib.netplan_netdef_get_link_local_ipv6(self._ptr)):
             linklocal.append('ipv6')
         return linklocal
+
+    @property
+    def accept_ra(self) -> Optional[bool]:
+        # Even though 'accept-ra' is defined as a boolean in Netplan, it's mapped
+        # to three different values inside libnetplan: kernel, enabled and disabled.
+        # 'kernel' is the default value when it's not set.
+        value = lib.netplan_netdef_get_accept_ra(self._ptr)
+        if value == 1:
+            return True
+        elif value == 2:
+            return False
+        else:
+            return None
 
     @property
     def nameserver_addresses(self) -> '_NetdefNameserverIterator':

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -185,3 +185,29 @@ _netplan_netdef_pertype_iter_next(struct netdef_pertype_iter* it);
 
 NETPLAN_INTERNAL void
 _netplan_netdef_pertype_iter_free(struct netdef_pertype_iter* it);
+
+/**
+ * @brief   Get the `gateway4` setting of a given @ref NetplanNetDefinition.
+ * @details Copies a `NUL`-terminated string into a sized @p out_buffer. If the
+ *          buffer is too small, its content is not `NUL`-terminated.
+ * @param[in]  netdef          The @ref NetplanNetDefinition to query
+ * @param[out] out_buffer      A pre-allocated buffer to write the output string into, owned by the caller
+ * @param[in]  out_buffer_size The maximum size (in bytes) available for @p out_buffer
+ * @return                     The size of the copied string, including the final `NUL` character.
+ *                             If the buffer is too small, returns @ref NETPLAN_BUFFER_TOO_SMALL instead.
+ */
+NETPLAN_INTERNAL ssize_t
+_netplan_netdef_get_gateway4(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);
+
+/**
+ * @brief   Get the `gateway6` setting of a given @ref NetplanNetDefinition.
+ * @details Copies a `NUL`-terminated string into a sized @p out_buffer. If the
+ *          buffer is too small, its content is not `NUL`-terminated.
+ * @param[in]  netdef          The @ref NetplanNetDefinition to query
+ * @param[out] out_buffer      A pre-allocated buffer to write the output string into, owned by the caller
+ * @param[in]  out_buffer_size The maximum size (in bytes) available for @p out_buffer
+ * @return                     The size of the copied string, including the final `NUL` character.
+ *                             If the buffer is too small, returns @ref NETPLAN_BUFFER_TOO_SMALL instead.
+ */
+NETPLAN_INTERNAL ssize_t
+_netplan_netdef_get_gateway6(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buffer_size);

--- a/src/util.c
+++ b/src/util.c
@@ -1028,6 +1028,12 @@ netplan_netdef_get_link_local_ipv6(const NetplanNetDefinition* netdef)
     return netdef->linklocal.ipv6;
 }
 
+int
+netplan_netdef_get_accept_ra(const NetplanNetDefinition* netdef)
+{
+    return netdef->accept_ra;
+}
+
 ssize_t
 _netplan_netdef_get_gateway4(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size)
 {

--- a/src/util.c
+++ b/src/util.c
@@ -1028,6 +1028,18 @@ netplan_netdef_get_link_local_ipv6(const NetplanNetDefinition* netdef)
     return netdef->linklocal.ipv6;
 }
 
+ssize_t
+_netplan_netdef_get_gateway4(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size)
+{
+    return netplan_copy_string(netdef->gateway4, out_buffer, out_buf_size);
+}
+
+ssize_t
+_netplan_netdef_get_gateway6(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size)
+{
+    return netplan_copy_string(netdef->gateway6, out_buffer, out_buf_size);
+}
+
 gboolean
 is_multicast_address(const char* address)
 {

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -48,8 +48,8 @@ STATUS_OUTPUT = '''\
 
 ●  2: enp0s31f6 ethernet UP (networkd: enp0s31f6)
       MAC Address: 54:e1:ad:5f:24:b4 (Intel Corporation)
-        Addresses: 192.168.178.62/24 (dhcp)
-                   2001:9e8:a19f:1c00:56e1:adff:fe5f:24b4/64
+        Addresses: 192.168.178.62/24 (dynamic, dhcp)
+                   2001:9e8:a19f:1c00:56e1:adff:fe5f:24b4/64 (dynamic)
                    fe80::56e1:adff:fe5f:24b4/64 (link)
     DNS Addresses: 192.168.178.1
                    fd00::cece:1eff:fe3d:c737
@@ -63,9 +63,9 @@ STATUS_OUTPUT = '''\
 
 ●  5: wlan0 wifi/"MYCON" UP (NetworkManager: NM-b6b7a21d-186e-45e1-b3a6-636da1735563)
       MAC Address: 1c:4d:70:e4:e4:0e (Intel Corporation)
-        Addresses: 192.168.178.142/24
-                   2001:9e8:a19f:1c00:7011:2d1:951:ad03/64
-                   2001:9e8:a19f:1c00:f24f:f724:5dd1:d0ad/64
+        Addresses: 192.168.178.142/24 (dynamic)
+                   2001:9e8:a19f:1c00:7011:2d1:951:ad03/64 (dynamic)
+                   2001:9e8:a19f:1c00:f24f:f724:5dd1:d0ad/64 (dynamic)
                    fe80::fec1:6ced:5268:b46c/64 (link)
     DNS Addresses: 192.168.178.1
                    fd00::cece:1eff:fe3d:c737
@@ -337,8 +337,8 @@ class TestStatus(unittest.TestCase):
 
 ●  2: enp0s31f6 ethernet UP (networkd: enp0s31f6)
       MAC Address: 54:e1:ad:5f:24:b4 (Intel Corporation)
-        Addresses: 192.168.178.62/24 (dhcp)
-                   2001:9e8:a19f:1c00:56e1:adff:fe5f:24b4/64
+        Addresses: 192.168.178.62/24 (dynamic, dhcp)
+                   2001:9e8:a19f:1c00:56e1:adff:fe5f:24b4/64 (dynamic)
                    fe80::56e1:adff:fe5f:24b4/64 (link)
     DNS Addresses: 192.168.178.1
                    fd00::cece:1eff:fe3d:c737

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -49,7 +49,7 @@ STATUS_OUTPUT = '''\
 ●  2: enp0s31f6 ethernet UP (networkd: enp0s31f6)
       MAC Address: 54:e1:ad:5f:24:b4 (Intel Corporation)
         Addresses: 192.168.178.62/24 (dynamic, dhcp)
-                   2001:9e8:a19f:1c00:56e1:adff:fe5f:24b4/64 (dynamic)
+                   2001:9e8:a19f:1c00:56e1:adff:fe5f:24b4/64 (dynamic, ra)
                    fe80::56e1:adff:fe5f:24b4/64 (link)
     DNS Addresses: 192.168.178.1
                    fd00::cece:1eff:fe3d:c737
@@ -64,8 +64,8 @@ STATUS_OUTPUT = '''\
 ●  5: wlan0 wifi/"MYCON" UP (NetworkManager: NM-b6b7a21d-186e-45e1-b3a6-636da1735563)
       MAC Address: 1c:4d:70:e4:e4:0e (Intel Corporation)
         Addresses: 192.168.178.142/24 (dynamic)
-                   2001:9e8:a19f:1c00:7011:2d1:951:ad03/64 (dynamic)
-                   2001:9e8:a19f:1c00:f24f:f724:5dd1:d0ad/64 (dynamic)
+                   2001:9e8:a19f:1c00:7011:2d1:951:ad03/64 (dynamic, ra)
+                   2001:9e8:a19f:1c00:f24f:f724:5dd1:d0ad/64 (dynamic, ra)
                    fe80::fec1:6ced:5268:b46c/64 (link)
     DNS Addresses: 192.168.178.1
                    fd00::cece:1eff:fe3d:c737
@@ -338,7 +338,7 @@ class TestStatus(unittest.TestCase):
 ●  2: enp0s31f6 ethernet UP (networkd: enp0s31f6)
       MAC Address: 54:e1:ad:5f:24:b4 (Intel Corporation)
         Addresses: 192.168.178.62/24 (dynamic, dhcp)
-                   2001:9e8:a19f:1c00:56e1:adff:fe5f:24b4/64 (dynamic)
+                   2001:9e8:a19f:1c00:56e1:adff:fe5f:24b4/64 (dynamic, ra)
                    fe80::56e1:adff:fe5f:24b4/64 (link)
     DNS Addresses: 192.168.178.1
                    fd00::cece:1eff:fe3d:c737

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -927,6 +927,24 @@ class TestNetDefinition(TestBase):
 
         self.assertEqual(state['eth0'].macaddress, 'aa:bb:cc:dd:ee:ff')
 
+    def test_get_gateway4(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      gateway4: 192.168.0.254
+      ''')
+
+        self.assertEqual(state['eth0']._gateway4, '192.168.0.254')
+
+    def test_get_gateway6(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      gateway6: abcd::1234
+      ''')
+
+        self.assertEqual(state['eth0']._gateway6, 'abcd::1234')
+
         state = state_from_yaml(self.confdir, '''network:
   ethernets:
     eth0: {}''')

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -918,6 +918,20 @@ class TestNetDefinition(TestBase):
         self.assertNotIn('ipv4', state['eth0'].link_local)
         self.assertIn('ipv6', state['eth0'].link_local)
 
+    def test_get_accept_ra(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      accept-ra: false
+    eth1:
+      accept-ra: true
+    eth2: {}
+      ''')
+
+        self.assertFalse(state['eth0'].accept_ra)
+        self.assertTrue(state['eth1'].accept_ra)
+        self.assertIsNone(state['eth2'].accept_ra)
+
     def test_get_macaddress(self):
         state = state_from_yaml(self.confdir, '''network:
   ethernets:


### PR DESCRIPTION
This PR contains a bunch of small improvements to `netplan status --diff` and some additions to the libnetplan API:

- Add getters for the `gateway4` and `gateway6` properties. This is required during the analysis of routes.
- Routes from `gateway4` and `gateway6` are added to the list of routes being analyzed.
- Make use of the property `dynamic` from `addr_info` to help determining if the address was received dynamically.
- Make use of the `ra` flag from routes to help finding IPs that were received via RA.
- Add getter for the `accept-ra` property.
- Improve the analysis of RA and LL addresses.
- Fix a rendering issue in the `--diff` mode when `python3-rich` is not present.
- Use the ConfigSource property from networkd to reduce the guessing and be more precise when analyzing dynamic configuration.

I recommend testing it inside a LXD VM where IPV6 addresses are assigned dynamically. The currently netplan.io will show the IPv6 address and DNS as diffs. The heuristics added to the analysis help to reduce this noise.

## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

