### PR TITLE
CI: Fix DebCI check, using newer 'meson' from unstable

### DIFF
--- a/.github/workflows/debci.yml
+++ b/.github/workflows/debci.yml
@@ -59,4 +59,5 @@ jobs:
           # using --setup-commands='apt -y install ...' temporarily to install
           # (test-/build-) deps until they become part of the packaging
           sudo autopkgtest . \
+            --add-apt-release='unstable' --pin-packages=unstable=meson \
             -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 --env=DEB_BUILD_OPTIONS=nocheck -- lxc autopkgtest-testing-amd64 || test $? -eq 2  # allow OVS test to be skipped (exit code = 2)


### PR DESCRIPTION
## Description
Meson migration is stuck, blocking Netplan migration in Debian.
See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1059223

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

