### PR TITLE
nm/nd: fix a couple of crashes

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -1043,10 +1043,12 @@ _netplan_netdef_write_nm(
         GHashTableIter iter;
         gpointer key;
         const NetplanWifiAccessPoint* ap;
-        g_assert(netdef->access_points);
-        g_hash_table_iter_init(&iter, netdef->access_points);
-        while (g_hash_table_iter_next(&iter, &key, (gpointer) &ap) && no_error)
-            no_error = write_nm_conf_access_point(netdef, rootdir, ap, error);
+        if (netdef->access_points) {
+            g_hash_table_iter_init(&iter, netdef->access_points);
+            while (g_hash_table_iter_next(&iter, &key, (gpointer) &ap) && no_error) {
+                no_error = write_nm_conf_access_point(netdef, rootdir, ap, error);
+            }
+        }
     } else {
         g_assert(netdef->access_points == NULL);
         no_error = write_nm_conf_access_point(netdef, rootdir, NULL, error);

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -1280,6 +1280,75 @@ Name=eth0
 LinkLocalAddressing=ipv6
 '''})
 
+    def test_ignore_errors_bad_wifi_nd(self):
+        self.generate('''network:
+  version: 2
+  wifis:
+    wlan0:
+      badkey: badvalue
+      access-points:
+        ssid:
+          password: abcdefgh''', expect_fail=False, skip_generated_yaml_validation=True, ignore_errors=True)
+
+    def test_ignore_errors_bad_wifi_nm(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  wifis:
+    wlan0:
+      badkey: badvalue
+      access-points:
+        ssid:
+          password: abcdefgh''', expect_fail=False, skip_generated_yaml_validation=True, ignore_errors=True)
+
+    def test_ignore_errors_bad_ap_nd(self):
+        self.generate('''network:
+  version: 2
+  wifis:
+    wlan0:
+      access-points:
+        ssid:
+          badkey: badvalue
+          password: abcdefgh''', expect_fail=False, skip_generated_yaml_validation=True, ignore_errors=True)
+
+    def test_ignore_errors_bad_ap_nm(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  wifis:
+    wlan0:
+      access-points:
+        ssid:
+          badkey: badvalue
+          password: abcdefgh''', expect_fail=False, skip_generated_yaml_validation=True, ignore_errors=True)
+
+    def test_ignore_errors_bad_wireguard_nd(self):
+        self.generate('''network:
+  version: 2
+  tunnels:
+    wg0:
+      mode: wireguard
+      addresses: [10.10.10.20/24]
+      key: 4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=
+      mark: 42
+      port: 51820
+      peers:
+        badkey: badvalue''', expect_fail=False, skip_generated_yaml_validation=True, ignore_errors=True)
+
+    def test_ignore_errors_bad_wireguard_nm(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  tunnels:
+    wg0:
+      mode: wireguard
+      addresses: [10.10.10.20/24]
+      key: 4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=
+      mark: 42
+      port: 51820
+      peers:
+        badkey: badvalue''', expect_fail=False, skip_generated_yaml_validation=True, ignore_errors=True)
+
     def test_ignore_errors_missing_interface(self):
         self.generate('''network:
   version: 2


### PR DESCRIPTION
These problems happen when the ignore_errors flag is used.

Wifi: When parsing is interrupted before access points are added to the interface, the code that generates configuration for NM and networkd will crash. They assume the list is never empty. Add a check to see if the list is empty.

Wireguard: The same problem happens on networkd when the list of peers is empty. The NM code already checks it.

Add unit tests for these cases.


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

