### PR TITLE
cli/generate: skip daemon_reload with --mapping

### DIFF
--- a/netplan_cli/cli/commands/generate.py
+++ b/netplan_cli/cli/commands/generate.py
@@ -84,9 +84,11 @@ class NetplanGenerate(utils.NetplanCommand):
         res = subprocess.call(argv)
         # reload systemd, as we might have changed service units, such as
         # /run/systemd/system/systemd-networkd-wait-online.service.d/10-netplan.conf
-        try:
-            utils.systemctl_daemon_reload()
-        except subprocess.CalledProcessError as e:
-            logging.warning(e)
+        # Skip it if --mapping is used as nothing will be generated
+        if self.mapping is None:
+            try:
+                utils.systemctl_daemon_reload()
+            except subprocess.CalledProcessError as e:
+                logging.warning(e)
         # FIXME: os.execv(argv[0], argv) would be better but fails coverage
         sys.exit(res)


### PR DESCRIPTION
When --mapping is used, nothing is generated so there is no need for calling daemon-reload.


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

