### PR TITLE
migrate: support aliases

### DIFF
--- a/netplan_cli/cli/commands/migrate.py
+++ b/netplan_cli/cli/commands/migrate.py
@@ -150,6 +150,10 @@ To install it on Debian or Ubuntu-based system, run `apt install python3-yaml`""
                         c['dhcp6'] = True
 
                 elif config['method'] == 'static':
+                    # Handle interface aliases
+                    if (":" in iface):
+                        iface = iface.split(':')[0]
+
                     c = netplan_config.setdefault('network', {}).setdefault('ethernets', {}).setdefault(iface, {})
 
                     if 'addresses' not in c:

--- a/tests/cli_legacy.py
+++ b/tests/cli_legacy.py
@@ -334,6 +334,13 @@ source-directory /etc/network/interfaces.d''')[0]
             'version': 2,
             'ethernets': {'en1': {'addresses': ["1.2.3.4/8"]}}}}, out.decode())
 
+    def test_static_ipv4_alias(self):
+        out = self.do_test('auto en1\niface en1 inet static\naddress 1.2.3.4/8\n'
+                           'auto en1:1\niface en1:1 inet static\naddress 1.2.3.5/8', dry_run=True)[0]
+        self.assertEqual(_load_yaml(out), {'network': {
+            'version': 2,
+            'ethernets': {'en1': {'addresses': ["1.2.3.4/8", "1.2.3.5/8"]}}}}, out.decode())
+
     def test_static_ipv4_no_address(self):
         out, err = self.do_test('auto en1\niface en1 inet static\nnetmask 1.2.3.4', expect_success=False)
         self.assertEqual(out, b'')


### PR DESCRIPTION
## Description
Netplan migrate haven't supported old syntax network interface aliases yet (eg. eth1:1 alias for eth1). An if statement is added to migrate.py that checks if interface name contains ':', this case the iface will be renamed and handled as not the alias one. The expected output is a simple interface that has multiple addresses. A test case is also provided in cli_legacy.py with the following name: test_static_ipv4_alias.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`). (for migrate.py)
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

