### PR TITLE
ctests: fix a memory leak in a unit test

### DIFF
--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -282,6 +282,7 @@ test_parser_flags_bad_flags(__unused void** state)
     assert_string_equal(error->message, "Invalid flag set");
     assert_int_equal(error->domain, NETPLAN_PARSER_ERROR);
     assert_int_equal(error->code, NETPLAN_ERROR_INVALID_FLAG);
+    netplan_error_clear(&error);
     netplan_parser_clear(&npp);
 }
 


### PR DESCRIPTION
The error object wasn't being released.


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

