### PR TITLE
CLI:apply: call udevadm trigger, using --action=move (Closes: #1071220) (LP: #2066344, LP: #2071363)

### DIFF
--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -254,8 +254,7 @@ class NetplanApply(utils.NetplanCommand):
 
         # Reloading of udev rules happens during 'netplan generate' already
         # subprocess.check_call(['udevadm', 'control', '--reload-rules'])
-        subprocess.check_call(['udevadm', 'trigger', '--attr-match=subsystem=net'])
-        subprocess.check_call(['udevadm', 'settle'])
+        subprocess.check_call(['udevadm', 'trigger', '--action=move', '--subsystem-match=net', '--settle'])
 
         # apply any SR-IOV related changes, if applicable
         NetplanApply.process_sriov_config(config_manager, exit_on_error)

--- a/tests/netplan_dbus/test_dbus.py
+++ b/tests/netplan_dbus/test_dbus.py
@@ -48,7 +48,7 @@ class TestNetplanDBus(unittest.TestCase):
   ethernets:
     eth0:
       dhcp4: true""")
-        self.addCleanup(shutil.rmtree, self.tmp)
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         self.mock_netplan_cmd = MockCmd("netplan")
         self._create_mock_system_bus()
         self._run_netplan_dbus_on_mock_bus()
@@ -284,7 +284,7 @@ class TestNetplanDBus(unittest.TestCase):
 
         cid = self._new_config_object()
         tmpdir = self.tmp + '/run/netplan/config-{}'.format(cid)
-        self.addClassCleanup(shutil.rmtree, tmpdir)
+        self.addClassCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
 
         # Verify the object path has been created, by calling .Config.Get() on that object
         # it would throw an error if it does not exist
@@ -319,7 +319,7 @@ class TestNetplanDBus(unittest.TestCase):
     def test_netplan_dbus_config_set(self):
         cid = self._new_config_object()
         tmpdir = self.tmp + '/run/netplan/config-{}'.format(cid)
-        self.addCleanup(shutil.rmtree, tmpdir)
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
 
         # Verify .Config.Set() on the config object
         # No actual YAML file will be created, as the netplan command is mocked
@@ -340,7 +340,7 @@ class TestNetplanDBus(unittest.TestCase):
     def test_netplan_dbus_config_get(self):
         cid = self._new_config_object()
         tmpdir = self.tmp + '/run/netplan/config-{}'.format(cid)
-        self.addCleanup(shutil.rmtree, tmpdir)
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
 
         # Verify .Config.Get() on the config object
         self.mock_netplan_cmd.set_output("network:\n  eth42:\n    dhcp6: true")


### PR DESCRIPTION
## Description
CLI:apply: call udevadm trigger, using --action=add (Closes: #1071220)
    
This will (re)-apply .link files, e.g. to set offloading options

As per discussion in [Debian#1071220](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1071220):

Yu says:

> https://github.com/canonical/netplan/blob/26d2591d771cb4343c06dbb1e0eb1f3587ec910d/netplan_cli/cli/commands/apply.py#L257
> 
> Here, "--action add" is necessary, otherwise the generated .link
> files will be never applied to existing interfaces.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#2066344

