### PR TITLE
networkd: make s-n-wait-online wait for at least one routable interface

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1566,6 +1566,12 @@ _netplan_networkd_write_wait_online(const NetplanState* np_state, const char* ro
                               && !(netplan_netdef_get_bond_link(def) || netplan_netdef_get_bridge_link(def)));
             _netplan_address_iter_free(addr_iter);
 
+            // Not all bond members need to be connected (have carrier) for the parent to be ready
+            NetplanNetDefinition* bond_parent = netplan_netdef_get_bond_link(def);
+            if (bond_parent && !d->routable && !d->degraded) {
+                g_info("Not all bond members need to be connected for %s to be ready. "
+                       "Consider marking them as \"optional: true\", to avoid blocking systemd-networkd-wait-online.", bond_parent->id);
+            }
 
             // no matching => single physical interface, ignoring non-existing interfaces
             // OR: virtual interfaces, those will be created later on and cannot have a matching condition

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1570,7 +1570,8 @@ _netplan_networkd_write_wait_online(const NetplanState* np_state, const char* ro
             NetplanNetDefinition* bond_parent = netplan_netdef_get_bond_link(def);
             if (bond_parent && !d->routable && !d->degraded) {
                 g_info("Not all bond members need to be connected for %s to be ready. "
-                       "Consider marking them as \"optional: true\", to avoid blocking systemd-networkd-wait-online.", bond_parent->id);
+                       "Consider marking %s as \"optional: true\", to avoid blocking "
+                       "systemd-networkd-wait-online.", bond_parent->id, def->id);
             }
 
             // no matching => single physical interface, ignoring non-existing interfaces

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -209,9 +209,9 @@ ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i eth99.4
 
         # should be a no-op the second time while the stamp exists
         out = subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir],
-                                      stderr=subprocess.STDOUT)
+                                      stderr=subprocess.STDOUT, text=True)
         self.assertFalse(os.path.exists(n))
-        self.assertIn(b'netplan generate already ran', out)
+        self.assertIn('netplan generate already ran', out)
 
         # after removing the stamp it generates again, and not trip over the
         # existing enablement symlink
@@ -345,11 +345,11 @@ ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i br0
 
         try:
             subprocess.check_output([generator, '--root-dir', self.workdir.name],
-                                    stderr=subprocess.STDOUT)
+                                    stderr=subprocess.STDOUT, text=True)
             self.fail("direct systemd generator call is expected to fail, but succeeded.")  # pragma: nocover
         except subprocess.CalledProcessError as e:
             self.assertEqual(e.returncode, 1)
-            self.assertIn(b'can not be called directly', e.output)
+            self.assertIn('can not be called directly', e.output)
 
     def test_systemd_generator_escaping(self):
         conf = os.path.join(self.confdir, 'a.yaml')
@@ -396,9 +396,9 @@ ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i a \\; b
 
         # should be a no-op the second time while the stamp exists
         out = subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir],
-                                      stderr=subprocess.STDOUT)
+                                      stderr=subprocess.STDOUT, text=True)
         self.assertFalse(os.path.exists(n))
-        self.assertIn(b'netplan generate already ran', out)
+        self.assertIn('netplan generate already ran', out)
 
         # after removing the stamp it generates again, and not trip over the
         # existing enablement symlink

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -155,10 +155,15 @@ class TestConfigArgs(TestBase):
       link-local: []
       ignore-carrier: true
       addresses: [10.0.0.3/24]
+    eth99.46: # routable, but optional. So no wait-online log message about this bond member
+      link: eth99
+      id: 46
+      dhcp4: true
+      optional: true
   bonds:
     bond0:
       dhcp4: true
-      interfaces: [eth99.42, eth99.43]''')
+      interfaces: [eth99.42, eth99.43, et99.46]''')
         os.chmod(conf, mode=0o600)
         outdir = os.path.join(self.workdir.name, 'out')
         os.mkdir(outdir)
@@ -185,8 +190,10 @@ class TestConfigArgs(TestBase):
         os.unlink(n)
 
         # check log message about bonds wait-online
-        self.assertIn('Not all bond members need to be connected for bond0 to be ready. '
-                      'Consider marking them as "optional: true", to avoid blocking systemd-networkd-wait-online.', out)
+        self.assertIn('Not all bond members need to be connected for bond0 to be ready.', out)
+        self.assertIn('Consider marking eth99.42 as "optional: true", to avoid blocking systemd-networkd-wait-online.', out)
+        self.assertNotIn('making eth99.43 as "optional: true"', out)  # routable
+        self.assertNotIn('making eth99.46 as "optional: true"', out)  # optional
 
         # should auto-enable networkd and -wait-online
         service_dir = os.path.join(self.workdir.name, 'run', 'systemd', 'system')

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -429,7 +429,8 @@ ConditionPathIsSymbolicLink=/run/systemd/generator/network-online.target.wants/s
 
 [Service]
 ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i %s:degraded -i br0:degraded -i findme:carrier
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i findme:carrier
+ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i %s -i br0
 ''' % self.dev_e2_client)
 
 

--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -429,9 +429,9 @@ ConditionPathIsSymbolicLink=/run/systemd/generator/network-online.target.wants/s
 
 [Service]
 ExecStart=
-ExecStart=/lib/systemd/systemd-networkd-wait-online -i findme:carrier
-ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i %s -i br0
-''' % self.dev_e2_client)
+ExecStart=/lib/systemd/systemd-networkd-wait-online -i %(e2c)s:carrier -i br0:degraded -i findme:carrier
+ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i %(e2c)s -i br0
+''' % {'e2c': self.dev_e2_client})
 
 
 @unittest.skipIf("NetworkManager" not in test_backends,


### PR DESCRIPTION
## Description
wait-online: wait for 'routable' state, if corresponding IPs are defined

Generally, we should be waiting on "routable" state (instead of "degraded") when we have static IP/dhcp4/dhcp6/RA.

[Our spec](https://discourse.ubuntu.com/t/spec-definition-of-an-online-system/27838) defines "at least one interface MUST be up on the link layer and have received layer 3 (IP) configuration" (ignoring link-local).

We now start two separate `systemd-networkd-wait-online` processes. One waiting for "carrier" & "degraded" interfaces (including the "routable" ones), not using "--any". Another one waiting just for "routable" interfaces, combined with "--any". Both blocking "network-online.target".

FR-7838

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

