### PR TITLE
bullet point removal

### DIFF
--- a/doc/netplan-generate.md
+++ b/doc/netplan-generate.md
@@ -64,7 +64,7 @@ There are 3 locations that **`netplan generate`** considers:
 
 If there are multiple files with exactly the same name, then only one
 will be read. A file in `/run/netplan` will shadow - completely replace
-- a file with the same name in `/etc/netplan`. A file in `/etc/netplan`
+a file with the same name in `/etc/netplan`. A file in `/etc/netplan`
 will itself shadow a file in `/lib/netplan`.
 
 Or, in other words, `/run/netplan` is top priority, then `/etc/netplan`,

--- a/doc/netplan-generate.md
+++ b/doc/netplan-generate.md
@@ -63,7 +63,7 @@ There are 3 locations that **`netplan generate`** considers:
  * `/run/netplan/*.yaml`
 
 If there are multiple files with exactly the same name, then only one
-will be read. A file in `/run/netplan` will shadow - completely replace
+will be read. A file in `/run/netplan` will shadow (completely replace)
 a file with the same name in `/etc/netplan`. A file in `/etc/netplan`
 will itself shadow a file in `/lib/netplan`.
 


### PR DESCRIPTION
There was a single bullet point that divided a sentence. I removed it because I thought it was a typo.


## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

