### PR TITLE
emitter: allow unicode characters in the emitter (LP: #2071652)

### DIFF
--- a/src/yaml-helpers.h
+++ b/src/yaml-helpers.h
@@ -88,6 +88,7 @@
 #define YAML_OUT_START(event_ptr, emitter_ptr, file) \
 { \
     yaml_emitter_initialize(emitter_ptr); \
+    yaml_emitter_set_unicode(emitter_ptr, 1); \
     yaml_emitter_set_output_file(emitter_ptr, file); \
     yaml_stream_start_event_initialize(event_ptr, YAML_UTF8_ENCODING); \
     if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto err_path; \


### PR DESCRIPTION
The YAML emitter from libyaml will convert non-ascii characters to latin1 by default.

See LP: #2071652


## Description

See https://bugs.launchpad.net/netplan/+bug/2071652 for details.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

