### PR TITLE
Improve interface re-naming via udev rules, avoiding custom logic

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1147,7 +1147,7 @@ write_rules_file(const NetplanNetDefinition* def, const char* rootdir)
     /* build file contents */
     s = g_string_sized_new(200);
 
-    g_string_append(s, "SUBSYSTEM==\"net\", ACTION==\"add\", ");
+    g_string_append(s, "SUBSYSTEM==\"net\", ACTION==\"add|change|move\", ");
 
     if (def->match.driver) {
         g_autofree char* driver = _netplan_scrub_string(def->match.driver);

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1147,7 +1147,8 @@ write_rules_file(const NetplanNetDefinition* def, const char* rootdir)
     /* build file contents */
     s = g_string_sized_new(200);
 
-    g_string_append(s, "SUBSYSTEM==\"net\", ACTION==\"add|change|move\", ");
+    //g_string_append(s, "SUBSYSTEM==\"net\", ACTION==\"add|change|move\", ");
+    g_string_append(s, "SUBSYSTEM==\"net\", ACTION==\"add\", ");
 
     if (def->match.driver) {
         g_autofree char* driver = _netplan_scrub_string(def->match.driver);

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -105,8 +105,8 @@ class IntegrationTestsBase(unittest.TestCase):
             os.remove(f)
         subprocess.call(['systemctl', 'daemon-reload'])
         subprocess.call(['udevadm', 'control', '--reload'])
-        subprocess.call(['udevadm', 'trigger', '--attr-match=subsystem=net'])
-        subprocess.call(['udevadm', 'settle'])
+        subprocess.call(['udevadm', 'trigger', '--action=change', '--subsystem-match=net', '--settle'])
+        subprocess.call(['udevadm', 'trigger', '--action=move', '--subsystem-match=net', '--settle'])
         try:
             os.remove('/run/systemd/generator/netplan.stamp')
         except FileNotFoundError:


### PR DESCRIPTION
## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

