### PR TITLE
generate: avoid calling 'udevadm control --reload' (LP: #1999178)

### DIFF
--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -262,8 +262,7 @@ class NetplanApply(utils.NetplanCommand):
                                       stdout=subprocess.DEVNULL,
                                       stderr=subprocess.DEVNULL)
 
-        # Reloading of udev rules happens during 'netplan generate' already
-        # subprocess.check_call(['udevadm', 'control', '--reload-rules'])
+        subprocess.check_call(['udevadm', 'control', '--reload'])
         subprocess.check_call(['udevadm', 'trigger', '--action=move', '--subsystem-match=net', '--settle'])
 
         # apply any SR-IOV related changes, if applicable

--- a/netplan_cli/cli/commands/generate.py
+++ b/netplan_cli/cli/commands/generate.py
@@ -82,6 +82,10 @@ class NetplanGenerate(utils.NetplanCommand):
             argv += ['--mapping', self.mapping]
         logging.debug('command generate: running %s', argv)
         res = subprocess.call(argv)
+        try:
+            subprocess.check_call(['udevadm', 'control', '--reload'])
+        except subprocess.CalledProcessError as e:
+            logging.debug(f'Could not call "udevadm control --reload": {str(e)}')
         # reload systemd, as we might have changed service units, such as
         # /run/systemd/system/systemd-networkd-wait-online.service.d/10-netplan.conf
         # Skip it if --mapping is used as nothing will be generated

--- a/rpm/netplan.spec
+++ b/rpm/netplan.spec
@@ -50,6 +50,7 @@ BuildRequires:  python3dist(pytest-cov)
 BuildRequires:  python3dist(pyyaml)
 BuildRequires:  python3dist(rich)
 BuildRequires:  %{_bindir}/ovs-vsctl
+BuildRequires:  systemd-udev
 
 # /usr/sbin/netplan is a Python 3 script that requires Python modules
 Requires:       python3dist(netifaces)

--- a/src/generate.c
+++ b/src/generate.c
@@ -54,13 +54,6 @@ static GOptionEntry options[] = {
     {NULL}
 };
 
-static void
-reload_udevd(void)
-{
-    const gchar *argv[] = { "/bin/udevadm", "control", "--reload", NULL };
-    g_spawn_sync(NULL, (gchar**)argv, NULL, G_SPAWN_STDERR_TO_DEV_NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-};
-
 /**
  * Create enablement symlink for systemd-networkd.service.
  */
@@ -307,13 +300,6 @@ int main(int argc, char** argv)
 
         CHECK_CALL(netplan_state_finish_nm_write(np_state, rootdir, &error), ignore_errors);
         CHECK_CALL(netplan_state_finish_sriov_write(np_state, rootdir, &error), ignore_errors);
-        /* We may have written .rules & .link files, thus we must
-         * invalidate udevd cache of its config as by default it only
-         * invalidates cache at most every 3 seconds. Not sure if this
-         * should live in `generate' or `apply', but it is confusing
-         * when udevd ignores just-in-time created rules files.
-         */
-        reload_udevd();
     }
 
     /* Disable /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf


### PR DESCRIPTION
## Description
The udev rules directories are monitored and re-loaded automatically with modern systemd-udevd. No need to manually reload them in the generator, causing side-effects.

We can still force-reload them when issuing `netplan generate` or `netplan apply` through the CLI, just to be on the safe side.

Replaces: https://github.com/canonical/netplan/pull/304


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#1999178

