### PR TITLE
Implementing advmss ip route option

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -53,6 +53,7 @@ jobs:
           echo "	sh -c \"mkdir -p debian/tmp/usr/lib/systemd/system-generators; rm -rf debian/tmp/lib; ln -sf /usr/libexec/netplan/generate debian/tmp/usr/lib/systemd/system-generators/netplan\"" >> debian/rules
           # usrmerge-fix-end
           sed -i 's| systemd-dev|# DELETED: systemd-dev|' debian/control
+          sed -i 's|  python3-gi,|  python3-gi, python3-packaging,|' debian/tests/control  # needed for the 'routing' test (nm_version)
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -631,3 +631,18 @@ network:
 Don't forget to allow the UDP port `51821` in your instance's security group.
 
 After applying your configuration you should be able to reach your remote instance through the IP address `172.17.0.2`.
+
+
+# How to change Advertised MSS ('Maximal Segment Size') in custom route
+
+```yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    ens3:
+      addresses: [ "10.10.10.1/24" ]
+      routes:
+        - to: 192.168.0.0/24
+          via: 10.10.10.168
+          advertised-mss: 1400

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -756,6 +756,7 @@ network:
           via: 10.0.0.1
           metric: 100
           on-link: true
+          advertised-mss: 1400
         - to: default # could be ::/0 optionally
           via: cf02:de:ad:be:ef::2
     eth1:
@@ -840,6 +841,12 @@ network:
 
     > The receive window to be advertised for the route, represented by
     > number of segments. Must be a positive integer value.
+
+  - **`advertised-mss`** (scalar)
+
+    > The Maximum MSS ('Maximal Segment Size') to advertise to these destinations when establishing TCP connections. 
+    > If it is not given, Linux uses a default value calculated from the first hop device MTU. 
+    > Must be a positive integer.
 
 - **`routing-policy`** (mapping)
 

--- a/examples/static-routes.yaml
+++ b/examples/static-routes.yaml
@@ -1,0 +1,18 @@
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp3s0:
+      addresses:
+        - 10.10.10.2/24
+      nameservers:
+        search: [mydomain, otherdomain]
+        addresses: [10.10.10.1, 1.1.1.1]
+      routes: 
+        - to: default
+          via: 10.10.10.1
+        - to: 192.168.0.0/24
+          via: 10.10.10.254
+        - to: 172.29.29.0/24
+          via: 10.10.10.254
+          advertised-mss: 1400

--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -59,6 +59,7 @@ ffibuilder.cdef("""
         guint mtubytes;
         guint congestion_window;
         guint advertised_receive_window;
+        guint advmss;
     } NetplanIPRoute;
 
     // Error handling

--- a/python-cffi/netplan/netdef.py
+++ b/python-cffi/netplan/netdef.py
@@ -283,6 +283,7 @@ class _NetdefSearchDomainIterator:
 @dataclass
 class NetplanRoute:
     _METRIC_UNSPEC_ = lib.UINT_MAX
+    _ADVMSS_UNSPEC_ = 0
     _TABLE_UNSPEC_ = 0
 
     to: str = None
@@ -298,6 +299,7 @@ class NetplanRoute:
     congestion_window: int = 0
     advertised_receive_window: int = 0
     onlink: bool = False
+    advertised_mss: int = _ADVMSS_UNSPEC_
 
     def __str__(self):
         route = ""
@@ -388,7 +390,8 @@ class _NetdefRouteIterator:
             'mtubytes': next_value.mtubytes,
             'congestion_window': next_value.congestion_window,
             'advertised_receive_window': next_value.advertised_receive_window,
-            'onlink': next_value.onlink
+            'onlink': next_value.onlink,
+            'advertised_mss': next_value.advmss
         }
 
         return NetplanRoute(**route)

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -621,6 +621,7 @@ write_routes(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefin
             YAML_STRING(def, event, emitter, "from", r->from);
             YAML_STRING(def, event, emitter, "to", r->to);
             YAML_STRING(def, event, emitter, "via", r->via);
+            YAML_UINT_0(def, event, emitter, "advertised-mss", r->advmss);
             YAML_MAPPING_CLOSE(event, emitter);
         }
         YAML_SEQUENCE_CLOSE(event, emitter);

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -733,6 +733,8 @@ write_route(NetplanIPRoute* r, GString* s)
         g_string_append_printf(s, "InitialCongestionWindow=%u\n", r->congestion_window);
     if (r->advertised_receive_window != NETPLAN_ADVERTISED_RECEIVE_WINDOW_UNSPEC)
         g_string_append_printf(s, "InitialAdvertisedReceiveWindow=%u\n", r->advertised_receive_window);
+    if (r->advmss != NETPLAN_ADVMSS_UNSPEC)
+        g_string_append_printf(s, "TCPAdvertisedMaximumSegmentSize=%u\n", r->advmss);
 }
 
 STATIC void

--- a/src/nm.c
+++ b/src/nm.c
@@ -226,7 +226,8 @@ write_routes_nm(const NetplanNetDefinition* def, GKeyFile *kf, gint family, GErr
                 || cur_route->congestion_window
                 || cur_route->mtubytes
                 || cur_route->table != NETPLAN_ROUTE_TABLE_UNSPEC
-                || cur_route->from) {
+                || cur_route->from
+                || cur_route->advmss) {
                 tmp_key = g_strdup_printf("route%d_options", j);
                 tmp_val = g_string_new(NULL);
                 if (cur_route->onlink) {
@@ -243,6 +244,8 @@ write_routes_nm(const NetplanNetDefinition* def, GKeyFile *kf, gint family, GErr
                     g_string_append_printf(tmp_val, "table=%u,", cur_route->table);
                 if (cur_route->from)
                     g_string_append_printf(tmp_val, "src=%s,", cur_route->from);
+                if (cur_route->advmss != NETPLAN_ADVMSS_UNSPEC)
+                    g_string_append_printf(tmp_val, "advmss=%u,", cur_route->advmss);
                 tmp_val->str[tmp_val->len - 1] = '\0'; //remove trailing comma
                 g_key_file_set_string(kf, group, tmp_key, tmp_val->str);
                 g_free(tmp_key);

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -284,6 +284,8 @@ parse_routes(GKeyFile* kf, const gchar* group, GArray** routes_arr)
                     route->table = strtoul(kv[1], NULL, 10);
                 else if (g_strcmp0(kv[0], "src") == 0)
                     route->from = g_strdup(kv[1]); //no need to free, will stay in netdef
+                else if (g_strcmp0(kv[0], "advmss") == 0)
+                    route->advmss = strtoul(kv[1], NULL, 10);
                 else
                     unhandled_data = TRUE;
                 g_strfreev(kv);

--- a/src/parse.c
+++ b/src/parse.c
@@ -2194,6 +2194,7 @@ static const mapping_entry_handler routes_handlers[] = {
     {"mtu", YAML_SCALAR_NODE, {.generic=handle_routes_guint}, route_offset(mtubytes)},
     {"congestion-window", YAML_SCALAR_NODE, {.generic=handle_routes_guint}, route_offset(congestion_window)},
     {"advertised-receive-window", YAML_SCALAR_NODE, {.generic=handle_routes_guint}, route_offset(advertised_receive_window)},
+    {"advertised-mss", YAML_SCALAR_NODE, {.generic=handle_routes_guint}, route_offset(advmss)},
     {NULL}
 };
 

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -152,6 +152,7 @@ typedef struct {
     guint mtubytes;
     guint congestion_window;
     guint advertised_receive_window;
+    guint advmss;
 } NetplanIPRoute;
 
 typedef struct {
@@ -286,6 +287,7 @@ struct netplan_state_iterator {
 #define NETPLAN_IP_RULE_PRIO_UNSPEC G_MAXUINT
 #define NETPLAN_IP_RULE_FW_MARK_UNSPEC 0
 #define NETPLAN_IP_RULE_TOS_UNSPEC G_MAXUINT
+#define NETPLAN_ADVMSS_UNSPEC 0
 
 #if defined(UNITTESTS)
 #define STATIC

--- a/tests/config_fuzzer/schemas/common.js
+++ b/tests/config_fuzzer/schemas/common.js
@@ -52,8 +52,11 @@ export const routes = {
                 "advertised-receive-window": {
                     type: "integer",
                     minimum: 0
+                },
+                "advertised-mss": {
+                    type: "integer",
+                    minimum: 0
                 }
-
             },
             required: ["to", "via"]
         }

--- a/tests/generator/test_routing.py
+++ b/tests/generator/test_routing.py
@@ -835,6 +835,54 @@ Gateway=192.168.14.20
 Metric=4294967294
 '''})
 
+    def test_route_v4_advmss_systemd(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.14.20
+          advertised-mss: 1400
+          ''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=192.168.14.2/24
+
+[Route]
+Destination=10.10.10.0/24
+Gateway=192.168.14.20
+TCPAdvertisedMaximumSegmentSize=1400
+'''})
+
+    def test_route_v4_advmss_empty_systemd(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.14.20
+          ''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+Address=192.168.14.2/24
+
+[Route]
+Destination=10.10.10.0/24
+Gateway=192.168.14.20
+'''})
+
 
 class TestNetworkManager(TestBase):
 
@@ -1609,6 +1657,37 @@ wake-on-lan=0
 method=manual
 address1=192.168.14.2/24
 route1=10.10.10.0/24,192.168.14.20,4294967294
+
+[ipv6]
+method=ignore
+'''})
+
+    def test_route_v4_advmss_nm(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    engreen:
+      addresses: ["192.168.14.2/24"]
+      routes:
+        - to: 10.10.10.0/24
+          via: 192.168.14.20
+          advertised-mss: 1400
+          ''')
+
+        self.assert_nm({'engreen': '''[connection]
+id=netplan-engreen
+type=ethernet
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=manual
+address1=192.168.14.2/24
+route1=10.10.10.0/24,192.168.14.20
+route1_options=advmss=1400
 
 [ipv6]
 method=ignore

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -2356,6 +2356,40 @@ method=link-local\n'''.format(UUID), expect_fail=True)
 
         self.assertIn('missing \'table\' property', out)
 
+    def test_nm_parse_advmss_method_manual(self):
+        self.generate_from_keyfile('''[connection]
+id=netplan-engreen
+type=ethernet
+uuid={}
+interface-name=engreen
+
+[ethernet]
+wake-on-lan=0
+
+
+[ipv4]
+method=manual
+address1=192.168.14.2/24
+route1=10.10.10.0/24,192.168.1.20
+route1_options=advmss=1400
+'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  ethernets:
+    NM-{}:
+      renderer: NetworkManager
+      match:
+        name: "engreen"
+      addresses:
+      - "192.168.14.2/24"
+      routes:
+      - to: "10.10.10.0/24"
+        via: "192.168.1.20"
+        advertised-mss: 1400
+      networkmanager:
+        uuid: "{}"
+        name: "netplan-engreen"\n'''.format(UUID, UUID)})
+
     def test_nameserver_with_DoT_lp2055148(self):
         self.generate_from_keyfile('''[connection]
 id=ethernet-eth123

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -289,7 +289,11 @@ class TestNetdefRouteIterator(TestBase):
           mtu: 1500
           congestion-window: 123
           advertised-receive-window: 321
-          from: 192.168.0.0/24''')
+          from: 192.168.0.0/24
+        - to: 4.5.6.7/32
+          via: 1.2.3.4
+          on-link: true
+          advertised-mss: 1400''')
 
         netdef = next(netplan.netdef.NetDefinitionIterator(state, "ethernets"))
         routes = [route for route in netdef.routes]
@@ -300,6 +304,8 @@ class TestNetdefRouteIterator(TestBase):
                              routes[2].onlink, routes[2].type, routes[2].scope, routes[2].mtubytes, routes[2].congestion_window,
                              routes[2].advertised_receive_window},
                             {'3.2.1.0/24', '10.20.30.40', 1000, 1000, True, 'local', 'host', 1500, 123, 321, '192.168.0.0/24'})
+        self.assertSetEqual({routes[3].to, routes[3].via, routes[3].onlink, routes[3].advertised_mss},
+                            {'4.5.6.7/32', '1.2.3.4', True, 1400})
 
 
 class TestRoute(TestBase):


### PR DESCRIPTION
Hello everybody. I was missing the [advmss](https://www.linux.org/docs/man8/ip-route.html) functionality for static routes, and I decided to implement it. This option has been tested successfully in systemd-networkd, but has not tested in network manager.

Param name for ip route: advmss
Param name for systemd networkd: TCPAdvertisedMaximumSegmentSize
Param name for network manager: advmss

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [x] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

