### PR TITLE
CI: Fix doc-checks and skip tests if kernel modules are not available

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   docchecks:
     name: Run documentation checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       result_spelling: ${{ steps.spellcheck-step.outcome }}
       result_woke: ${{ steps.woke-step.outcome }}

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,5 +1,4 @@
 # Minimal makefile for Sphinx documentation
-#
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -278,6 +278,11 @@ class _CommonTests():
                       subprocess.check_output(['ip', 'route', 'show', '10.10.10.0/24']))
 
     def test_vrf_basic(self):
+        try:
+            subprocess.check_call(['modprobe', 'vrf'])
+        except Exception:
+            raise unittest.SkipTest("vrf module is unavailable, can't test")
+
         self.setup_eth('slaac')
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'vrf0'], stderr=subprocess.DEVNULL)
         self.addCleanup(subprocess.call, ['ip', 'route', 'flush', 'table', '1000'], stderr=subprocess.DEVNULL)

--- a/tests/integration/tunnels.py
+++ b/tests/integration/tunnels.py
@@ -91,6 +91,11 @@ class _CommonTests():
         self.assert_iface('tun0', ['tun0@NONE', 'link.* 0.0.0.0 peer 99.99.99.99'])
 
     def test_tunnel_wireguard(self):
+        try:
+            subprocess.check_call(['modprobe', 'wireguard'])
+        except Exception:
+            raise unittest.SkipTest("wireguard module is unavailable, can't test")
+
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'wg0'], stderr=subprocess.DEVNULL)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'wg1'], stderr=subprocess.DEVNULL)
         with open(self.config, 'w') as f:


### PR DESCRIPTION
## Description
* Skip VRF and WireGuard tests if kernel module is not available
* Run doc-checks on Ubuntu 22.04

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

