### PR TITLE
netplan ignores NetworkManager ipv4.route-metric (LP: #2076172)

### DIFF
--- a/src/nm.c
+++ b/src/nm.c
@@ -878,7 +878,7 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
         g_key_file_set_boolean(kf, "ipv4", "never-default", TRUE);
     }
 
-    if (def->dhcp4 && def->dhcp4_overrides.metric != NETPLAN_METRIC_UNSPEC)
+    if ((def->dhcp4 || def->ip4_addresses || def->gateway4 || def->routes) && def->dhcp4_overrides.metric != NETPLAN_METRIC_UNSPEC)
         g_key_file_set_uint64(kf, "ipv4", "route-metric", def->dhcp4_overrides.metric);
 
     if (def->dhcp6 || def->ip6_addresses || def->gateway6 || def->ip6_nameservers || def->ip6_addr_gen_mode) {

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -2428,3 +2428,85 @@ method=auto
           ipv6.ip6-privacy: "-1"
           proxy._: ""
 '''.format(UUID, UUID)})
+
+    def test_ipv4_route_metric_is_overriden_when_dhcp4_is_disabled(self):
+        self.generate_from_keyfile('''[connection]
+id=dummy-123
+type=dummy
+uuid={}
+interface-name=dummy123
+
+[ipv4]
+method=manual
+address1=100.85.0.1/24,100.85.0.1
+route-metric=95
+
+[ipv6]
+method=ignore
+addr-gen-mode=default
+
+[dummy]
+
+[proxy]\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  dummy-devices:
+    NM-{}:
+      renderer: NetworkManager
+      addresses:
+      - "100.85.0.1/24"
+      dhcp4-overrides:
+        route-metric: 95
+      networkmanager:
+        uuid: "{}"
+        name: "dummy-123"
+        passthrough:
+          connection.interface-name: "dummy123"
+          ipv4.method: "manual"
+          ipv4.address1: "100.85.0.1/24,100.85.0.1"
+          ipv6.addr-gen-mode: "default"
+          dummy._: ""
+          proxy._: ""
+'''.format(UUID, UUID)})
+
+    def test_ipv6_route_metric_is_overriden_when_dhcp6_is_disabled(self):
+        self.generate_from_keyfile('''[connection]
+id=dummy-123
+type=dummy
+uuid={}
+interface-name=dummy123
+
+[ipv4]
+method=disabled
+
+[ipv6]
+method=manual
+address1=fdeb:446c:912d:8da::/64,fdeb:446c:912d:8da::1
+route-metric=95
+addr-gen-mode=default
+
+[dummy]
+
+[proxy]\n'''.format(UUID))
+        self.assert_netplan({UUID: '''network:
+  version: 2
+  dummy-devices:
+    NM-{}:
+      renderer: NetworkManager
+      addresses:
+      - "fdeb:446c:912d:8da::/64"
+      dhcp6-overrides:
+        route-metric: 95
+      networkmanager:
+        uuid: "{}"
+        name: "dummy-123"
+        passthrough:
+          connection.interface-name: "dummy123"
+          ipv4.method: "disabled"
+          ipv6.method: "manual"
+          ipv6.address1: "fdeb:446c:912d:8da::/64,fdeb:446c:912d:8da::1"
+          ipv6.addr-gen-mode: "default"
+          ipv6.ip6-privacy: "-1"
+          dummy._: ""
+          proxy._: ""
+'''.format(UUID, UUID)})


### PR DESCRIPTION
### Background
Dummy connections (from my testing) are not being passed the `ipv4.route-metric` value from NM, instead they have the default value of 550, though this behavior was not observed with the IPv6 protocol. The change is to allow to pass `ipv4.route-metric` to NM if either `dhcp4: True` or `ipv4.route-metric` values are passed using a `method: manual` setup.

This was tested by cloning the repo, making the code change and following [build install instructions](https://github.com/canonical/netplan?tab=readme-ov-file#build-using-meson).

You can also re-create this by running the following commands.

#### With `ipv4.method manual`:
- Run`nmcli c a type dummy ifname pvpnksintrf0 con-name pvpn-killswitch ipv4.method manual ipv4.addresses "100.85.0.1/24" ipv4.gateway "100.85.0.1" ipv6.method manual ipv6.addresses "fdeb:446c:912d:08da::/64" ipv6.gateway "fdeb:446c:912d:08da::1" ipv4.route-metric 98 ipv6.route-metric 95`
- `nmcli c s pvpn-killswitch` shows that `ipv6.route-metric` has been taken but not `ipv4.route-metric`, even though the data is present under `/etc/netplan/90*.yml`

The current behavior breaks the Proton VPN linux app on all Ubuntu 24.04 machines.

#### What is expected: `ipv4.method manual`
- The `ipv4.route-metric` value should be passed regardless of `ipv4.method` 

## Checklist
- [ ] Runs `make check` successfully. (for some reason fails locally due to linting and two failing tests which do not seem related to CI tests)
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] (Optional) Adds example YAML for new feature.
- [x] (Optional) Closes an open bug in Launchpad: https://bugs.launchpad.net/netplan/+bug/2076172