### PR TITLE
Handle implicity conversions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ find = find_program('find')
 add_project_arguments(
     '-DSBINDIR="' + join_paths(get_option('prefix'), get_option('sbindir')) + '"',
     '-D_GNU_SOURCE',
+    '-Wconversion',
     language: 'c')
 
 inc = include_directories('include')

--- a/src/error.c
+++ b/src/error.c
@@ -32,18 +32,16 @@
  ****************************************************/
 
 STATIC void
-write_error_marker(GString *message, int column)
+write_error_marker(GString *message, size_t column)
 {
-    int i;
-
-    for (i = 0; (column > 0 && i < column); i++)
+    for (size_t i = 0; (column > 0 && i < column); i++)
         g_string_append_printf(message, " ");
 
     g_string_append_printf(message, "^");
 }
 
 STATIC char *
-get_syntax_error_context(const NetplanParser* npp, const int line_num, const int column, GError **error)
+get_syntax_error_context(const NetplanParser* npp, const size_t line_num, const size_t column, GError **error)
 {
     GString *message = NULL;
     GFile *cur_file = g_file_new_for_path(npp->current.filepath);
@@ -57,7 +55,7 @@ get_syntax_error_context(const NetplanParser* npp, const int line_num, const int
     stream = g_data_input_stream_new (G_INPUT_STREAM(file_stream));
     g_object_unref(file_stream);
 
-    for (int i = 0; i < line_num + 1; i++) {
+    for (size_t i = 0; i < line_num + 1; i++) {
         g_free(line);
         line = g_data_input_stream_read_line(stream, &len, NULL, error);
     }

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -553,7 +553,7 @@ write_tunnel_settings(yaml_event_t* event, yaml_emitter_t* emitter, const Netpla
                 YAML_SCALAR_PLAIN(event, emitter, "private-key-flags");
                 YAML_SEQUENCE_OPEN(event, emitter);
 
-                for(int i = 1; i < NETPLAN_KEY_FLAG_MAX_; i <<= 1) {
+                for(guint i = 1; i < NETPLAN_KEY_FLAG_MAX_; i <<= 1) {
                     if (def->tunnel_private_key_flags & i)
                         YAML_SCALAR_PLAIN(event, emitter, netplan_key_flags_name(i));
                 }

--- a/src/nm.c
+++ b/src/nm.c
@@ -268,7 +268,7 @@ write_nm_bond_parameters(const NetplanNetDefinition* def, GKeyFile *kf)
     if (def->bond_params.monitor_interval)
         g_key_file_set_string(kf, "bond", "miimon", def->bond_params.monitor_interval);
     if (def->bond_params.min_links)
-        g_key_file_set_integer(kf, "bond", "min_links", def->bond_params.min_links);
+        g_key_file_set_uint64(kf, "bond", "min_links", def->bond_params.min_links);
     if (def->bond_params.transmit_hash_policy)
         g_key_file_set_string(kf, "bond", "xmit_hash_policy", def->bond_params.transmit_hash_policy);
     if (def->bond_params.selection_logic)
@@ -298,17 +298,17 @@ write_nm_bond_parameters(const NetplanNetDefinition* def, GKeyFile *kf)
     if (def->bond_params.fail_over_mac_policy)
         g_key_file_set_string(kf, "bond", "fail_over_mac", def->bond_params.fail_over_mac_policy);
     if (def->bond_params.gratuitous_arp) {
-        g_key_file_set_integer(kf, "bond", "num_grat_arp", def->bond_params.gratuitous_arp);
+        g_key_file_set_uint64(kf, "bond", "num_grat_arp", def->bond_params.gratuitous_arp);
         /* Work around issue in NM where unset unsolicited_na will overwrite num_grat_arp:
          * https://github.com/NetworkManager/NetworkManager/commit/42b0bef33c77a0921590b2697f077e8ea7805166 */
-        g_key_file_set_integer(kf, "bond", "num_unsol_na", def->bond_params.gratuitous_arp);
+        g_key_file_set_uint64(kf, "bond", "num_unsol_na", def->bond_params.gratuitous_arp);
     }
     if (def->bond_params.packets_per_member)
-        g_key_file_set_integer(kf, "bond", "packets_per_slave", def->bond_params.packets_per_member); /* wokeignore:rule=slave */
+        g_key_file_set_uint64(kf, "bond", "packets_per_slave", def->bond_params.packets_per_member); /* wokeignore:rule=slave */
     if (def->bond_params.primary_reselect_policy)
         g_key_file_set_string(kf, "bond", "primary_reselect", def->bond_params.primary_reselect_policy);
     if (def->bond_params.resend_igmp)
-        g_key_file_set_integer(kf, "bond", "resend_igmp", def->bond_params.resend_igmp);
+        g_key_file_set_uint64(kf, "bond", "resend_igmp", def->bond_params.resend_igmp);
     if (def->bond_params.learn_interval)
         g_key_file_set_string(kf, "bond", "lp_interval", def->bond_params.learn_interval);
     if (def->bond_params.primary_member)
@@ -363,7 +363,7 @@ write_nm_wireguard_params(const NetplanNetDefinition* def, GKeyFile *kf, GError*
             g_autofree gchar* tmp_group = g_strdup_printf("wireguard-peer.%s", peer->public_key);
 
             if (peer->keepalive)
-                g_key_file_set_integer(kf, tmp_group, "persistent-keepalive", peer->keepalive);
+                g_key_file_set_uint64(kf, tmp_group, "persistent-keepalive", peer->keepalive);
             if (peer->endpoint)
                 g_key_file_set_string(kf, tmp_group, "endpoint", peer->endpoint);
 
@@ -791,7 +791,7 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
             if (def->mtubytes)
                 g_key_file_set_uint64(kf, nm_type, "mtu", def->mtubytes);
             if (def->wowlan && def->wowlan > NETPLAN_WIFI_WOWLAN_DEFAULT)
-                g_key_file_set_uint64(kf, nm_type, "wake-on-wlan", def->wowlan);
+                g_key_file_set_integer(kf, nm_type, "wake-on-wlan", def->wowlan);
             if (def->ib_mode != NETPLAN_IB_MODE_KERNEL)
                 g_key_file_set_string(kf, nm_type, "transport-mode", netplan_infiniband_mode_name(def->ib_mode));
         }

--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -307,7 +307,8 @@ write_ovs_bridge_controller_targets(const NetplanOVSSettings* settings, const Ne
             }
         g_string_append_printf(s, "%s ", target);
     }
-    g_string_erase(s, s->len-1, 1);
+    g_assert(s->len < G_MAXSSIZE);
+    g_string_erase(s, (gssize)s->len-1, 1);
 
     append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set-controller %s %s", bridge, s->str);
     write_ovs_tag_setting(bridge, "Bridge", "global", "set-controller", s->str, cmds);

--- a/src/sriov.c
+++ b/src/sriov.c
@@ -222,5 +222,12 @@ _netplan_state_get_vf_count_for_def(const NetplanState* np_state, const NetplanN
         g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_VALIDATION, "more VFs allocated than the explicit size declared: %d > %d", count, netdef->sriov_explicit_vf_count);
         return -1;
     }
-    return netdef->sriov_explicit_vf_count != G_MAXUINT ? netdef->sriov_explicit_vf_count : count;
+
+    if (netdef->sriov_explicit_vf_count != G_MAXUINT) {
+        g_assert(netdef->sriov_explicit_vf_count <= G_MAXINT);
+        count = netdef->sriov_explicit_vf_count;
+    }
+
+    g_assert(count <= G_MAXINT);
+    return (int)count;
 }

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -258,7 +258,7 @@ struct netplan_parser {
      * Appears to be unused?
      * */
     GHashTable* ids_in_file;
-    int missing_ids_found;
+    guint missing_ids_found;
 
     /* Which fields have been nullified by a subsequent patch? */
     GHashTable* null_fields;

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -56,10 +56,10 @@ const char*
 get_unspecified_address(int ip_family);
 
 int
-wifi_get_freq24(int channel);
+wifi_get_freq24(guint channel);
 
 int
-wifi_get_freq5(int channel);
+wifi_get_freq5(guint channel);
 
 gchar*
 systemd_escape(char* string);

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -41,7 +41,7 @@ NETPLAN_INTERNAL void
 _netplan_g_string_free_to_file(GString* s, const char* rootdir, const char* path, const char* suffix);
 
 void
-_netplan_g_string_free_to_file_with_permissions(GString* s, const char* rootdir, const char* path, const char* suffix, const char* owner, const char* group, mode_t mode);
+_netplan_g_string_free_to_file_with_permissions(GString* s, const char* rootdir, const char* path, const char* suffix, const char* owner, const char* group, int mode);
 
 NETPLAN_INTERNAL void
 _netplan_unlink_glob(const char* rootdir, const char* _glob);

--- a/src/util.c
+++ b/src/util.c
@@ -440,7 +440,7 @@ cleanup:
  * Get the frequency of a given 2.4GHz WiFi channel
  */
 int
-wifi_get_freq24(int channel)
+wifi_get_freq24(guint channel)
 {
     if (channel < 1 || channel > 14) {
         g_fprintf(stderr, "ERROR: invalid 2.4GHz WiFi channel: %d\n", channel);
@@ -466,9 +466,9 @@ wifi_get_freq24(int channel)
  * Get the frequency of a given 5GHz WiFi channel
  */
 int
-wifi_get_freq5(int channel)
+wifi_get_freq5(guint channel)
 {
-    int channels[] = { 7, 8, 9, 11, 12, 16, 32, 34, 36, 38, 40, 42, 44, 46, 48,
+    guint channels[] = { 7, 8, 9, 11, 12, 16, 32, 34, 36, 38, 40, 42, 44, 46, 48,
                        50, 52, 54, 56, 58, 60, 62, 64, 68, 96, 100, 102, 104,
                        106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126,
                        128, 132, 134, 136, 138, 140, 142, 144, 149, 151, 153,

--- a/src/validation.c
+++ b/src/validation.c
@@ -337,7 +337,7 @@ validate_tunnel_backend_rules(const NetplanParser* npp, NetplanNetDefinition* nd
 gboolean
 validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, GError** error)
 {
-    int missing_id_count = g_hash_table_size(npp->missing_id);
+    guint missing_id_count = g_hash_table_size(npp->missing_id);
     gboolean valid = FALSE;
     NetplanBackend backend = nd->backend;
 

--- a/src/yaml-helpers.h
+++ b/src/yaml-helpers.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <glib.h>
 #include <yaml.h>
 
 #define YAML_MAPPING_OPEN(event_ptr, emitter_ptr) \
@@ -41,7 +42,9 @@
 }
 #define YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, scalar) \
 { \
-    yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t *)YAML_STR_TAG, (yaml_char_t *)scalar, strlen(scalar), 1, 0, YAML_PLAIN_SCALAR_STYLE); \
+    size_t _length = strlen(scalar); \
+    g_assert(_length < G_MAXINT); \
+    yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t *)YAML_STR_TAG, (yaml_char_t *)scalar, (int)_length, 1, 0, YAML_PLAIN_SCALAR_STYLE); \
     if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto err_path; \
 }
 
@@ -50,13 +53,15 @@
         YAML_SCALAR_PLAIN(event_ptr, emitter_ptr, flags_func(flag));
 
 #define YAML_NULL_PLAIN(event_ptr, emitter_ptr) \
-    yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t*)YAML_NULL_TAG, (yaml_char_t*)"null", strlen("null"), 1, 0, YAML_PLAIN_SCALAR_STYLE); \
+    yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t*)YAML_NULL_TAG, (yaml_char_t*)"null", (int)strlen("null"), 1, 0, YAML_PLAIN_SCALAR_STYLE); \
     if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto err_path; \
 
 /* Implicit plain and quoted tags, double quoted style */
 #define YAML_SCALAR_QUOTED(event_ptr, emitter_ptr, scalar) \
 { \
-    yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t *)YAML_STR_TAG, (yaml_char_t *)scalar, strlen(scalar), 1, 1, YAML_DOUBLE_QUOTED_SCALAR_STYLE); \
+    size_t _length = strlen(scalar); \
+    g_assert(_length < G_MAXINT); \
+    yaml_scalar_event_initialize(event_ptr, NULL, (yaml_char_t *)YAML_STR_TAG, (yaml_char_t *)scalar, (int)_length, 1, 1, YAML_DOUBLE_QUOTED_SCALAR_STYLE); \
     if (!yaml_emitter_emit(emitter_ptr, event_ptr)) goto err_path; \
 }
 #define YAML_NONNULL_STRING(event_ptr, emitter_ptr, key, value_ptr) \

--- a/tests/ctests/test_netplan_error.c
+++ b/tests/ctests/test_netplan_error.c
@@ -26,7 +26,7 @@ test_netplan_error_code(__unused void** state)
 {
     GError *gerror = g_error_new(1234, 5678, "%s: error message", "it failed");
     uint64_t error_code = netplan_error_code(gerror);
-    GQuark domain = error_code >> 32;
+    GQuark domain = (GQuark)(error_code >> 32);
     gint error = (gint) error_code;
 
     assert_int_equal(domain, 1234);

--- a/tests/ctests/test_netplan_keyfile.c
+++ b/tests/ctests/test_netplan_keyfile.c
@@ -260,8 +260,8 @@ test_load_keyfile_utf8_password(__unused void** state)
 {
     NetplanState *np_state = NULL;
     int fd;
-    int size;
-    int res;
+    size_t size;
+    ssize_t res;
     char* yaml;
 
     const char* keyfile =
@@ -306,7 +306,7 @@ test_load_keyfile_utf8_password(__unused void** state)
 
     netplan_state_dump_yaml(np_state, fd, NULL);
 
-    size = lseek(fd, 0, SEEK_CUR) + 1;
+    size = (size_t)lseek(fd, 0, SEEK_CUR) + 1;
     yaml = malloc(size);
     memset(yaml, 0, size);
     lseek(fd, 0, SEEK_SET);

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -389,8 +389,8 @@ test_parse_utf8_characters(__unused void** state)
 {
     NetplanState *np_state = NULL;
     int fd;
-    int size;
-    int res;
+    size_t size;
+    ssize_t res;
 
     char* yaml =
         "network:\n"
@@ -418,7 +418,7 @@ test_parse_utf8_characters(__unused void** state)
 
     netplan_state_dump_yaml(np_state, fd, NULL);
 
-    size = lseek(fd, 0, SEEK_CUR) + 1;
+    size = (size_t)lseek(fd, 0, SEEK_CUR) + 1;
     yaml = malloc(size);
     memset(yaml, 0, size);
     lseek(fd, 0, SEEK_SET);


### PR DESCRIPTION
## Description
Fix some type conversions and make some implicit conversions explicit.
It's a requirement to add the TIOBE analysis to our CI as it will build the project with `-Wconversion`.

I'd recommend to use interactive rebase to step through each commit individually starting from the first one and call `meson compile` with `-j1` so you can see what compiler errors each commit fixes. I didn't want to paste the error to the commit messages...

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

