### PR TITLE
Add a scheduled workflow to run TICS

### DIFF
--- a/.github/workflows/tiobe.yml
+++ b/.github/workflows/tiobe.yml
@@ -1,0 +1,35 @@
+name: "TIOBE/TiCS"
+
+on:
+  schedule:
+    - cron: '0 0 * * TUE'
+
+jobs:
+  coverity:
+    if: github.repository == 'canonical/netplan'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
+          sudo sed -i 's/Types: deb/Types: deb deb-src/g' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt update
+          sudo apt build-dep -y netplan.io
+          sudo apt install -y gcovr python-is-python3 pylint flake8 python3-flake8
+      - name: Build Netplan
+        run: |
+          # The build directory must be called _build. TIOBE will look for coverage data in it.
+          meson setup _build --prefix=/usr -Db_coverage=true
+          meson compile -C _build -v
+          meson test -C _build -v
+      - name: Download and Install TICS
+        run: |
+          curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
+          bash install_tics.sh
+      - name: Run TICS
+        run: |
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
+          source ~/.profile
+          TICSQServer -project netplan -branchname master -calc ALL -tmpdir /tmp/tics -branchdir .   # wokeignore:rule=master

--- a/meson.build
+++ b/meson.build
@@ -138,6 +138,12 @@ if get_option('testing')
                     'meson-logs', 'coveragereport-py'), '--omit=/usr/*'],
              priority: -95, # run before 'coverage-py'
              is_parallel: false)
+        test('coverage-py-output-xml',
+             pycoverage,
+             args: ['xml', '-o', join_paths(meson.current_build_dir(),
+                    'meson-logs', 'coverage-py.xml'), '--omit=/usr/*'],
+             priority: -96, # run before 'coverage-py'
+             is_parallel: false)
         test('coverage-py',
              pycoverage,
              args: ['report', '--omit=/usr/*', '--show-missing', '--fail-under=100'],


### PR DESCRIPTION
## Description

I found out that this https://github.com/canonical/netplan/pull/496 is not really required. TICS will not use `-Wconversion` by default.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

