### PR TITLE
Update the docs checks runner to ubuntu-latest

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'doc/**'
   push:
+    branches: [ main ]
     paths:
       - 'doc/**'
   workflow_dispatch:
@@ -40,7 +41,7 @@ concurrency:
 jobs:
   docchecks:
     name: Run documentation checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       result_spelling: ${{ steps.spellcheck-step.outcome }}
       result_woke: ${{ steps.woke-step.outcome }}


### PR DESCRIPTION
## Description

Updates the docs-check GH Action runner to `ubuntu-latest` to fix a [problem with Doxygen](https://github.com/canonical/netplan/actions/runs/10351751575/job/28650924351).

(Actual spelling mistakes fixed in #499.)

## Checklist

n/a

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

