### PR TITLE
ci: run meson tests with unbuffer

### DIFF
--- a/.github/workflows/tiobe.yml
+++ b/.github/workflows/tiobe.yml
@@ -1,11 +1,12 @@
 name: "TIOBE/TiCS"
 
-on:
-  schedule:
-    - cron: '0 0 * * TUE'
+on: workflow_dispatch
+#on:
+#  schedule:
+#    - cron: '0 0 * * TUE'
 
 jobs:
-  coverity:
+  tics:
     if: github.repository == 'canonical/netplan'
     runs-on: ubuntu-24.04
 
@@ -23,7 +24,7 @@ jobs:
           # The build directory must be called _build. TIOBE will look for coverage data in it.
           meson setup _build --prefix=/usr -Db_coverage=true
           meson compile -C _build -v
-          meson test -C _build -v
+          unbuffer meson test -C _build -v
       - name: Download and Install TICS
         run: |
           curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh


### PR DESCRIPTION
Fix the job name and disable the scheduler for now so the job can be triggered manually [1].

[1] - https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch

## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

