### PR TITLE
cli: drop python-netifaces (LP: #2065870, LP: #2017585)

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -47,6 +47,7 @@ jobs:
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
+          sed -i 's|iproute2,|iproute2, ethtool,|' debian/control  # add ethtool as a dependency of netplan.io temporarily
           sed -i 's|  python3-gi,|  python3-gi, python3-packaging,|' debian/tests/control  # needed for the 'routing' test (nm_version)
           sed -i 's|bytecompile=-1|bytecompile=-1 -Dtesting=false|' debian/rules  # drop after v1.1
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag

--- a/.github/workflows/debci.yml
+++ b/.github/workflows/debci.yml
@@ -50,6 +50,7 @@ jobs:
           dget -u "https://deb.debian.org/debian/pool/main/n/netplan.io/netplan.io_$V.dsc"
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
+          sed -i 's|iproute2,|iproute2, ethtool,|' debian/control  # add ethtool as a dependency of netplan.io temporarily
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"

--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -331,23 +331,6 @@ class NetplanApply(utils.NetplanCommand):
                 utils.nm_bring_interface_up(loopback_connection)
 
     @staticmethod
-    def is_composite_member(composites, phy):
-        """
-        Is this physical interface a member of a 'composite' virtual
-        interface? (bond, bridge)
-        """
-        for composite in composites:
-            for _, settings in composite.items():
-                if not type(settings) is dict:
-                    continue
-                members = settings.get('interfaces', [])
-                for iface in members:
-                    if iface == phy:
-                        return True
-
-        return False
-
-    @staticmethod
     def clear_virtual_links(prev_links, curr_links, devices=[]):
         """
         Calculate the delta of virtual links. And remove the links that were
@@ -381,7 +364,6 @@ class NetplanApply(utils.NetplanCommand):
         """
 
         changes = {}
-        composite_interfaces = [config_manager.bridges, config_manager.bonds]
 
         # Find physical interfaces which need a rename
         # But do not rename virtual interfaces
@@ -391,11 +373,6 @@ class NetplanApply(utils.NetplanCommand):
                 continue  # Skip if no new name needs to be set
             if not netdef._has_match:
                 continue  # Skip if no match for current name is given
-            if NetplanApply.is_composite_member(composite_interfaces, netdef.id):
-                logging.debug('Skipping composite member {}'.format(netdef.id))
-                # do not rename members of virtual devices. MAC addresses
-                # may be the same for all interface members.
-                continue
             # Find current name of the interface, according to match conditions and globs (name, mac, driver)
             current_iface_name = utils.find_matching_iface(interfaces, netdef)
             if not current_iface_name:

--- a/netplan_cli/cli/sriov.py
+++ b/netplan_cli/cli/sriov.py
@@ -27,8 +27,6 @@ from . import utils
 from ..configmanager import ConfigurationError
 import netplan
 
-import netifaces
-
 
 # PCIDevice class originates from mlnx_switchdev_mode/sriovify.py
 # Copyright 2019 Canonical Ltd, Apache License, Version 2.0
@@ -223,7 +221,7 @@ def _get_interface_name_for_netdef(netdef: netplan.NetDefinition) -> Optional[st
     Try to match a netdef with the real system network interface.
     Throws ConfigurationError if there is more than one match.
     """
-    interfaces: List[str] = netifaces.interfaces()
+    interfaces: List[str] = utils.get_interfaces()
     if netdef._has_match:
         # now here it's a bit tricky
         set_name: str = netdef.set_name
@@ -455,7 +453,7 @@ def apply_sriov_config(config_manager, rootdir='/'):
     them and perform all other necessary setup.
     """
     config_manager.parse()
-    interfaces = netifaces.interfaces()
+    interfaces = utils.get_interfaces()
     np_state = config_manager.np_state
 
     # for sr-iov devices, we identify VFs by them having a link: field
@@ -487,7 +485,7 @@ def apply_sriov_config(config_manager, rootdir='/'):
 
         # also, since the VF number changed, the interfaces list also
         # changed, so we need to refresh it
-        interfaces = netifaces.interfaces()
+        interfaces = utils.get_interfaces()
 
     # now in theory we should have all the new VFs set up and existing;
     # this is needed because we will have to now match the defined VF

--- a/tests/cli/test_units.py
+++ b/tests/cli/test_units.py
@@ -42,21 +42,6 @@ class TestCLI(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmproot)
 
-    def test_is_composite_member(self):
-        res = NetplanApply.is_composite_member([{'br0': {'interfaces': ['eth0']}}], 'eth0')
-        self.assertTrue(res)
-
-    def test_is_composite_member_false(self):
-        res = NetplanApply.is_composite_member([
-                  {'br0': {'interfaces': ['eth42']}},
-                  {'bond0': {'interfaces': ['eth1']}}
-              ], 'eth0')
-        self.assertFalse(res)
-
-    def test_is_composite_member_with_renderer(self):
-        res = NetplanApply.is_composite_member([{'renderer': 'networkd', 'br0': {'interfaces': ['eth0']}}], 'eth0')
-        self.assertTrue(res)
-
     @patch('subprocess.check_call')
     def test_clear_virtual_links(self, mock):
         # simulate as if 'tun3' would have already been delete another way,

--- a/tests/test_sriov.py
+++ b/tests/test_sriov.py
@@ -135,7 +135,7 @@ class TestSRIOV(unittest.TestCase):
         for i in range(len(vfs)):
             os.symlink(os.path.join('../../..', vfs[i][1]), os.path.join(pf_dev_path, 'virtfn'+str(i)))
 
-    @patch('netifaces.interfaces')
+    @patch('netplan_cli.cli.utils.get_interfaces')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
     def test_get_vf_count_vfs_and_pfs(self, gim, gidn, ifaces):
@@ -207,7 +207,7 @@ class TestSRIOV(unittest.TestCase):
             {'enp1': 'enp1', 'enp2': 'enp2', 'enp3': 'enp3',
              'enpx': 'enp5', 'enp8': 'enp8', 'enp10': 'enp10'})
 
-    @patch('netifaces.interfaces')
+    @patch('netplan_cli.cli.utils.get_interfaces')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
     def test_get_physical_functions(self, gim, gidn, ifaces):
@@ -268,7 +268,7 @@ class TestSRIOV(unittest.TestCase):
             {'enp1': 'enp1', 'enp2': 'enp2', 'enp3': 'enp3',
              'enpx': 'enp5', 'enp8': 'enp8', 'enp10': 'enp10'})
 
-    @patch('netifaces.interfaces')
+    @patch('netplan_cli.cli.utils.get_interfaces')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
     def test_get_vf_number_per_pf(self, gim, gidn, ifaces):
@@ -327,7 +327,7 @@ class TestSRIOV(unittest.TestCase):
             vf_counts,
             {'enp1': 2, 'enp2': 2, 'enp3': 1, 'enp5': 1, 'enp8': 7})
 
-    @patch('netifaces.interfaces')
+    @patch('netplan_cli.cli.utils.get_interfaces')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
     def test_get_virtual_functions(self, gim, gidn, ifaces):
@@ -386,7 +386,7 @@ class TestSRIOV(unittest.TestCase):
             {'enp1s16f1', 'enp1s16f2', 'enp2s16f1',
              'enp2s16f2', 'enp3s16f1', 'enpxs16f1'})
 
-    @patch('netifaces.interfaces')
+    @patch('netplan_cli.cli.utils.get_interfaces')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
     def test_get_vf_count_vfs_and_pfs_set_name(self, gim, gidn, ifaces):
@@ -433,7 +433,7 @@ class TestSRIOV(unittest.TestCase):
             pfs,
             {'enp1': 'pf1', 'enp8': 'enp8'})
 
-    @patch('netifaces.interfaces')
+    @patch('netplan_cli.cli.utils.get_interfaces')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
     def test_get_vf_count_vfs_and_pfs_many_match(self, gim, gidn, ifaces):
@@ -464,7 +464,7 @@ class TestSRIOV(unittest.TestCase):
         self.assertIn('matched more than one interface for a PF device: enpx',
                       str(e.exception))
 
-    @patch('netifaces.interfaces')
+    @patch('netplan_cli.cli.utils.get_interfaces')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
     def test_get_vf_count_vfs_and_pfs_not_enough_explicit(self, gim, gidn, ifaces):
@@ -646,7 +646,6 @@ class TestSRIOV(unittest.TestCase):
         self.assertIn('failed setting SR-IOV VLAN filter for vlan vlan10',
                       str(e.exception))
 
-    @patch('netifaces.interfaces')
     @patch('netplan_cli.cli.sriov._get_vf_number_per_pf')
     @patch('netplan_cli.cli.sriov._get_virtual_functions')
     @patch('netplan_cli.cli.sriov._get_physical_functions')
@@ -655,8 +654,9 @@ class TestSRIOV(unittest.TestCase):
     @patch('netplan_cli.cli.sriov.apply_vlan_filter_for_vf')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
-    def test_apply_sriov_config(self, gim, gidn, apply_vlan, quirks,
-                                set_numvfs, get_phys, get_virt, get_num, netifs):
+    @patch('netplan_cli.cli.utils.get_interfaces')
+    def test_apply_sriov_config(self, netifs, gim, gidn, apply_vlan, quirks,
+                                set_numvfs, get_phys, get_virt, get_num):
         # set up the environment
         with open(os.path.join(self.workdir.name, "etc/netplan/test.yaml"), 'w') as fd:
             print('''network:
@@ -711,7 +711,6 @@ class TestSRIOV(unittest.TestCase):
         # only one had a hardware vlan
         apply_vlan.assert_called_once_with('enp2', 'enp2s16f1', 'vf1.15', 15)
 
-    @patch('netifaces.interfaces')
     @patch('netplan_cli.cli.sriov._get_vf_number_per_pf')
     @patch('netplan_cli.cli.sriov._get_virtual_functions')
     @patch('netplan_cli.cli.sriov._get_physical_functions')
@@ -720,8 +719,9 @@ class TestSRIOV(unittest.TestCase):
     @patch('netplan_cli.cli.sriov.apply_vlan_filter_for_vf')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
-    def test_apply_sriov_config_invalid_vlan(self, gim, gidn, apply_vlan, quirks,
-                                             set_numvfs, get_phys, get_virt, get_num, netifs):
+    @patch('netplan_cli.cli.utils.get_interfaces')
+    def test_apply_sriov_config_invalid_vlan(self, netifs, gim, gidn, apply_vlan, quirks,
+                                             set_numvfs, get_phys, get_virt, get_num):
         # set up the environment
         with open(os.path.join(self.workdir.name, "etc/netplan/test.yaml"), 'w') as fd:
             print('''network:
@@ -783,7 +783,6 @@ class TestSRIOV(unittest.TestCase):
                           'either not a VF or has no matches',
                           logs.output[0])
 
-    @patch('netifaces.interfaces')
     @patch('netplan_cli.cli.sriov._get_vf_number_per_pf')
     @patch('netplan_cli.cli.sriov._get_virtual_functions')
     @patch('netplan_cli.cli.sriov._get_physical_functions')
@@ -792,8 +791,9 @@ class TestSRIOV(unittest.TestCase):
     @patch('netplan_cli.cli.sriov.apply_vlan_filter_for_vf')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
-    def test_apply_sriov_config_too_many_vlans(self, gim, gidn, apply_vlan, quirks,
-                                               set_numvfs, get_phys, get_virt, get_num, netifs):
+    @patch('netplan_cli.cli.utils.get_interfaces')
+    def test_apply_sriov_config_too_many_vlans(self, netifs, gim, gidn, apply_vlan, quirks,
+                                               set_numvfs, get_phys, get_virt, get_num):
         # set up the environment
         with open(os.path.join(self.workdir.name, "etc/netplan/test.yaml"), 'w') as fd:
             print('''network:
@@ -842,7 +842,6 @@ class TestSRIOV(unittest.TestCase):
                       str(e.exception))
         self.assertEqual(apply_vlan.call_count, 1)
 
-    @patch('netifaces.interfaces')
     @patch('netplan_cli.cli.sriov._get_vf_number_per_pf')
     @patch('netplan_cli.cli.sriov._get_virtual_functions')
     @patch('netplan_cli.cli.sriov._get_physical_functions')
@@ -851,8 +850,9 @@ class TestSRIOV(unittest.TestCase):
     @patch('netplan_cli.cli.sriov.apply_vlan_filter_for_vf')
     @patch('netplan_cli.cli.utils.get_interface_driver_name')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
-    def test_apply_sriov_config_many_match(self, gim, gidn, apply_vlan, quirks,
-                                           set_numvfs, get_phys, get_virt, get_num, netifs):
+    @patch('netplan_cli.cli.utils.get_interfaces')
+    def test_apply_sriov_config_many_match(self, netifs, gim, gidn, apply_vlan, quirks,
+                                           set_numvfs, get_phys, get_virt, get_num):
         # set up the environment
         with open(os.path.join(self.workdir.name, "etc/netplan/test.yaml"), 'w') as fd:
             print('''network:
@@ -919,7 +919,7 @@ MODALIAS=pci:v00008086d0000156Fsv000017AAsd00002245bc02sc00i00
             self.assertTrue(pcidev.is_vf)
 
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
-    @patch('netifaces.interfaces')
+    @patch('netplan_cli.cli.utils.get_interfaces')
     @patch('netplan_cli.cli.sriov._get_vf_number_per_pf')
     @patch('netplan_cli.cli.sriov._get_virtual_functions')
     @patch('netplan_cli.cli.sriov._get_physical_functions')
@@ -1022,7 +1022,7 @@ MODALIAS=pci:v00008086d0000156Fsv000017AAsd00002245bc02sc00i00
 
     @patch('netplan_cli.cli.sriov.unbind_vfs')
     @patch('netplan_cli.cli.utils.get_interface_macaddress')
-    @patch('netifaces.interfaces')
+    @patch('netplan_cli.cli.utils.get_interfaces')
     @patch('netplan_cli.cli.sriov._get_vf_number_per_pf')
     @patch('netplan_cli.cli.sriov._get_virtual_functions')
     @patch('netplan_cli.cli.sriov._get_physical_functions')


### PR DESCRIPTION
netifaces doesn't return the permanent MAC address of physical interfaces.

This causes a problem with bonds for example where all the interfaces in the bond will share the same MAC address. When `netplan apply` tries to find a unique matching based on the MAC returned by netifaces and the MAC set in the YAML, it will not be found.

```
# netplan apply
[]
Cannot find unique matching interface for nic0
```

The `is_composite_member()` method wasn't working properly as well. It was always returning False. In the end I stopped using it.

Regarding skipping bond/bridge members during renames, that seems to be put in place as a workaround for [LP: #1802322](https://bugs.launchpad.net/netplan/+bug/1802322). The problem it fixed was happening because the code was matching interfaces by their non-permanent MAC address. When they are added to a bond, they will share the same MAC. The code was confusing one interface with another and trying to rename them.

By not renaming them the backend will "forget" about the interface. We will emit the new name to the backend config files but keep the interface with the old name in the system so it will not be found anymore. This is worse than causing a quick disconnection during the rename process as further changes to the interface will not be applied. The user would need to either rename it manually (which will cause a disconnection anyway) or reboot. I also found that networkd <= 255 was triggering a rename anyway when we called `udevadm test` from `netplan apply` so we've been unintentionally allowing renames anyway...

Fixes: [LP#2065870](https://bugs.launchpad.net/netplan/+bug/2065870)

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad. LP#2065870, LP#2017585

