### PR TITLE
Several code cleanup & fixes for TiCS

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -340,7 +340,7 @@ int main(int argc, char** argv)
             start_unit_jit("systemd-networkd.service");
         }
         g_autofree char* glob_run = g_build_path(G_DIR_SEPARATOR_S,
-                                                 rootdir ?: G_DIR_SEPARATOR_S,
+                                                 rootdir != NULL ? rootdir : G_DIR_SEPARATOR_S,
                                                  "run/systemd/system/netplan-*.service",
                                                  NULL);
         if (!glob(glob_run, 0, NULL, &gl)) {

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -209,7 +209,7 @@ STATIC gboolean
 write_vxlan(yaml_event_t* event, yaml_emitter_t* emitter, const NetplanNetDefinition* def)
 {
     if (def->type == NETPLAN_DEF_TYPE_TUNNEL && def->tunnel.mode == NETPLAN_TUNNEL_MODE_VXLAN) {
-        g_assert(def->vxlan);
+        g_assert(def->vxlan != NULL);
         YAML_UINT_0(def, event, emitter, "id", def->vxlan->vni);
         if (def->vxlan->link)
             YAML_STRING(def, event, emitter, "link", def->vxlan->link->id);
@@ -987,7 +987,8 @@ netplan_netdef_write_yaml(
         filename = g_strconcat("90-NM-", netdef->backend_settings.uuid, ".yaml", NULL);
     else
         filename = g_strconcat("10-netplan-", netdef->id, ".yaml", NULL);
-    path = g_build_path(G_DIR_SEPARATOR_S, rootdir ?: G_DIR_SEPARATOR_S, "etc", "netplan", filename, NULL);
+    path = g_build_path(G_DIR_SEPARATOR_S, rootdir != NULL ? rootdir : G_DIR_SEPARATOR_S,
+                        "etc", "netplan", filename, NULL);
 
     /* Start rendering YAML output */
     yaml_emitter_t emitter_data;
@@ -1149,7 +1150,7 @@ netplan_state_write_yaml_file(const NetplanState* np_state, const char* filename
     GList* to_write = NULL;
     int out_fd;
 
-    path = g_build_path(G_DIR_SEPARATOR_S, rootdir ?: G_DIR_SEPARATOR_S, "etc", "netplan", filename, NULL);
+    path = g_build_path(G_DIR_SEPARATOR_S, rootdir != NULL ? rootdir : G_DIR_SEPARATOR_S, "etc", "netplan", filename, NULL);
 
     while (iter) {
         NetplanNetDefinition* netdef = iter->data;
@@ -1160,7 +1161,7 @@ netplan_state_write_yaml_file(const NetplanState* np_state, const char* filename
     }
 
     /* Remove any existing file if there is no data to write */
-    gboolean write_globals = !!np_state->global_renderer;
+    gboolean write_globals = np_state->global_renderer != NULL;
     if (to_write == NULL && !write_globals) {
         if (unlink(path) && errno != ENOENT) {
             g_set_error(error, NETPLAN_FILE_ERROR, errno, "%m");
@@ -1218,7 +1219,7 @@ netplan_state_update_yaml_hierarchy(const NetplanState* np_state, const char* de
     g_assert(default_filename != NULL && *default_filename != '\0');
 
     perfile_netdefs = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, (GDestroyNotify)g_list_free);
-    default_path = g_build_path(G_DIR_SEPARATOR_S, rootdir ?: G_DIR_SEPARATOR_S, "etc", "netplan", default_filename, NULL);
+    default_path = g_build_path(G_DIR_SEPARATOR_S, rootdir != NULL ? rootdir : G_DIR_SEPARATOR_S, "etc", "netplan", default_filename, NULL);
     int out_fd = -1;
 
     /* Dump global conf to the default path */

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -108,7 +108,7 @@ kf_matches(GKeyFile* kf, const gchar* group, const gchar* key, const gchar* matc
 STATIC void
 set_true_on_match(GKeyFile* kf, const gchar* group, const gchar* key, const gchar* match, const void* dataptr)
 {
-    g_assert(dataptr);
+    g_assert(dataptr != NULL);
     if (kf_matches(kf, group, key, match)) {
         *((gboolean*) dataptr) = TRUE;
         _kf_clear_key(kf, group, key);
@@ -118,7 +118,7 @@ set_true_on_match(GKeyFile* kf, const gchar* group, const gchar* key, const gcha
 STATIC void
 keyfile_handle_generic_bool(GKeyFile* kf, const gchar* group, const gchar* key, gboolean* dataptr)
 {
-    g_assert(dataptr);
+    g_assert(dataptr != NULL);
     *dataptr = g_key_file_get_boolean(kf, group, key, NULL);
     _kf_clear_key(kf, group, key);
 }
@@ -126,8 +126,8 @@ keyfile_handle_generic_bool(GKeyFile* kf, const gchar* group, const gchar* key, 
 STATIC void
 keyfile_handle_generic_str(GKeyFile* kf, const gchar* group, const gchar* key, char** dataptr)
 {
-    g_assert(dataptr);
-    g_assert(!*dataptr);
+    g_assert(dataptr != NULL);
+    g_assert(*dataptr == NULL);
     *dataptr = g_key_file_get_string(kf, group, key, NULL);
     if (*dataptr)
         _kf_clear_key(kf, group, key);
@@ -136,7 +136,7 @@ keyfile_handle_generic_str(GKeyFile* kf, const gchar* group, const gchar* key, c
 STATIC void
 keyfile_handle_generic_uint(GKeyFile* kf, const gchar* group, const gchar* key, guint* dataptr, guint default_value)
 {
-    g_assert(dataptr);
+    g_assert(dataptr != NULL);
     if (g_key_file_has_key(kf, group, key, NULL)) {
         guint data = g_key_file_get_uint64(kf, group, key, NULL);
         if (data != default_value)
@@ -176,7 +176,7 @@ keyfile_handle_cloned_mac_address(GKeyFile *kf, NetplanNetDefinition* nd, const 
 STATIC void
 parse_addresses(GKeyFile* kf, const gchar* group, GArray** ip_arr)
 {
-    g_assert(ip_arr);
+    g_assert(ip_arr != NULL);
     if (kf_matches(kf, group, "method", "manual")) {
         gboolean unhandled_data = FALSE;
         gchar *key = NULL;
@@ -216,7 +216,7 @@ parse_addresses(GKeyFile* kf, const gchar* group, GArray** ip_arr)
 STATIC void
 parse_routes(GKeyFile* kf, const gchar* group, GArray** routes_arr)
 {
-    g_assert(routes_arr);
+    g_assert(routes_arr != NULL);
     NetplanIPRoute *route = NULL;
     gchar **split = NULL;
     for (unsigned i = 1;; ++i) {
@@ -306,7 +306,7 @@ parse_routes(GKeyFile* kf, const gchar* group, GArray** routes_arr)
 STATIC void
 parse_dhcp_overrides(GKeyFile* kf, const gchar* group, NetplanDHCPOverrides* dataptr)
 {
-    g_assert(dataptr);
+    g_assert(dataptr != NULL);
     if (   g_key_file_get_boolean(kf, group, "ignore-auto-routes", NULL)
         && g_key_file_get_boolean(kf, group, "never-default", NULL)) {
         (*dataptr).use_routes = FALSE;
@@ -322,7 +322,7 @@ parse_search_domains(GKeyFile* kf, const gchar* group, GArray** domains_arr)
 {
     // Keep "dns-search" as fallback/passthrough, as netplan cannot
     // differentiate between ipv4.dns-search and ipv6.dns-search
-    g_assert(domains_arr);
+    g_assert(domains_arr != NULL);
     gsize len = 0;
     gchar **split = g_key_file_get_string_list(kf, group, "dns-search", &len, NULL);
     if (split) {
@@ -347,7 +347,7 @@ parse_search_domains(GKeyFile* kf, const gchar* group, GArray** domains_arr)
 STATIC void
 parse_nameservers(GKeyFile* kf, const gchar* group, GArray** nameserver_arr)
 {
-    g_assert(nameserver_arr);
+    g_assert(nameserver_arr != NULL);
     gchar **split = g_key_file_get_string_list(kf, group, "dns", NULL, NULL);
     if (split) {
 
@@ -381,7 +381,7 @@ parse_nameservers(GKeyFile* kf, const gchar* group, GArray** nameserver_arr)
 STATIC void
 parse_dot1x_auth(GKeyFile* kf, NetplanAuthenticationSettings* auth)
 {
-    g_assert(auth);
+    g_assert(auth != NULL);
     g_autofree gchar* method = g_key_file_get_string(kf, "802-1x", "eap", NULL);
 
     if (method && g_strcmp0(method, "") != 0) {
@@ -431,7 +431,7 @@ parse_dot1x_auth(GKeyFile* kf, NetplanAuthenticationSettings* auth)
 STATIC void
 parse_bond_arp_ip_targets(GKeyFile* kf, GArray **targets_arr)
 {
-    g_assert(targets_arr);
+    g_assert(targets_arr != NULL);
     g_autofree gchar *v = g_key_file_get_string(kf, "bond", "arp_ip_target", NULL);
     if (v) {
         gchar** split = g_strsplit(v, ",", -1);

--- a/src/parse.c
+++ b/src/parse.c
@@ -353,7 +353,7 @@ process_mapping(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, c
 STATIC gboolean
 handle_generic_guint(NetplanParser* npp, yaml_node_t* node, const void* entryptr, const void* data, GError** error)
 {
-    g_assert(entryptr);
+    g_assert(entryptr != NULL);
     guint offset = GPOINTER_TO_UINT(data);
     guint64 v;
     gchar* endptr;
@@ -376,7 +376,7 @@ handle_generic_guint(NetplanParser* npp, yaml_node_t* node, const void* entryptr
 STATIC gboolean
 handle_generic_str(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, __unused GError** error)
 {
-    g_assert(entryptr);
+    g_assert(entryptr != NULL);
     guint offset = GPOINTER_TO_UINT(data);
     char** dest = (char**) ((void*) entryptr + offset);
     g_free(*dest);
@@ -388,7 +388,7 @@ handle_generic_str(NetplanParser* npp, yaml_node_t* node, void* entryptr, const 
 STATIC gboolean
 handle_special_macaddress_option(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
-    g_assert(entryptr);
+    g_assert(entryptr != NULL);
     g_assert(node->type == YAML_SCALAR_NODE);
 
     if (!_is_macaddress_special_nm_option(scalar(node)) &&
@@ -407,7 +407,7 @@ handle_special_macaddress_option(NetplanParser* npp, yaml_node_t* node, void* en
 STATIC gboolean
 handle_generic_mac(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
-    g_assert(entryptr);
+    g_assert(entryptr != NULL);
     g_assert(node->type == YAML_SCALAR_NODE);
 
     if (!_is_valid_macaddress(scalar(node)))
@@ -424,7 +424,7 @@ handle_generic_mac(NetplanParser* npp, yaml_node_t* node, void* entryptr, const 
 STATIC gboolean
 handle_generic_bool(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
-    g_assert(entryptr);
+    g_assert(entryptr != NULL);
     guint offset = GPOINTER_TO_UINT(data);
     gboolean v;
     gboolean* dest = ((void*) entryptr + offset);
@@ -455,7 +455,7 @@ handle_generic_bool(NetplanParser* npp, yaml_node_t* node, void* entryptr, const
 STATIC gboolean
 handle_generic_tristate(NetplanParser* npp, yaml_node_t* node, void* entryptr, const void* data, GError** error)
 {
-    g_assert(entryptr);
+    g_assert(entryptr != NULL);
     NetplanTristate v;
     guint offset = GPOINTER_TO_UINT(data);
     NetplanTristate* dest = ((void*) entryptr + offset);
@@ -1009,7 +1009,7 @@ STATIC gboolean
 handle_auth_key_management(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanAuthenticationSettings* auth = npp->current.auth;
-    g_assert(auth);
+    g_assert(auth != NULL);
     if (strcmp(scalar(node), "none") == 0)
         auth->key_management = NETPLAN_AUTH_KEY_MANAGEMENT_NONE;
     else if (strcmp(scalar(node), "psk") == 0)
@@ -1048,7 +1048,7 @@ STATIC gboolean
 handle_auth_method(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanAuthenticationSettings* auth = npp->current.auth;
-    g_assert(auth);
+    g_assert(auth != NULL);
     if (strcmp(scalar(node), "tls") == 0)
         auth->eap_method = NETPLAN_AUTH_EAP_TLS;
     else if (strcmp(scalar(node), "peap") == 0)
@@ -1103,7 +1103,7 @@ handle_ap_backend_settings_str(NetplanParser* npp, yaml_node_t* node, const void
 STATIC gboolean
 handle_access_point_datalist(NetplanParser* npp, yaml_node_t* node, const char* key_prefix, const void* data, GError** error)
 {
-    g_assert(npp->current.access_point);
+    g_assert(npp->current.access_point != NULL);
     gboolean ret = handle_generic_datalist(npp, node, key_prefix, npp->current.access_point, data, error);
 
     GData** list = &npp->current.access_point->backend_settings.passthrough;
@@ -1152,7 +1152,7 @@ STATIC gboolean
 handle_access_point_password(NetplanParser* npp, yaml_node_t* node, __unused const void* _, __unused GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
-    g_assert(access_point);
+    g_assert(access_point != NULL);
     /* shortcut for WPA-PSK */
     access_point->has_auth = TRUE;
     if (access_point->auth.key_management == NETPLAN_AUTH_KEY_MANAGEMENT_NONE)
@@ -1170,7 +1170,7 @@ handle_access_point_auth(NetplanParser* npp, yaml_node_t* node, __unused const c
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
     gboolean ret;
 
-    g_assert(access_point);
+    g_assert(access_point != NULL);
     access_point->has_auth = TRUE;
 
     npp->current.auth = &access_point->auth;
@@ -1184,7 +1184,7 @@ STATIC gboolean
 handle_access_point_mode(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
-    g_assert(access_point);
+    g_assert(access_point != NULL);
     if (strcmp(scalar(node), "infrastructure") == 0)
         access_point->mode = NETPLAN_WIFI_MODE_INFRASTRUCTURE;
     else if (strcmp(scalar(node), "adhoc") == 0)
@@ -1200,7 +1200,7 @@ STATIC gboolean
 handle_access_point_band(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
 {
     NetplanWifiAccessPoint *access_point = npp->current.access_point;
-    g_assert(access_point);
+    g_assert(access_point != NULL);
     if (strcmp(scalar(node), "5GHz") == 0 || strcmp(scalar(node), "5G") == 0)
         access_point->band = NETPLAN_WIFI_BAND_5;
     else if (strcmp(scalar(node), "2.4GHz") == 0 || strcmp(scalar(node), "2.4G") == 0)
@@ -1406,8 +1406,8 @@ const mapping_entry_handler address_option_handlers[] = {
 STATIC gboolean
 handle_generic_addresses(NetplanParser* npp, yaml_node_t* node, gboolean check_zero_prefix, GArray** ip4, GArray** ip6, GError** error)
 {
-    g_assert(ip4);
-    g_assert(ip6);
+    g_assert(ip4 != NULL);
+    g_assert(ip6 != NULL);
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         g_autofree char* addr = NULL;
         char* prefix_len;
@@ -1838,7 +1838,7 @@ handle_optional_addresses(NetplanParser* npp, yaml_node_t* node, __unused const 
 STATIC gboolean
 handle_vxlan_flags(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
-    g_assert(npp->current.vxlan);
+    g_assert(npp->current.vxlan != NULL);
     assert_type(npp, node, YAML_SEQUENCE_NODE);
     yaml_node_t* key_node = node-1; // The YAML key of given sequence `node`
 
@@ -1864,8 +1864,8 @@ handle_vxlan_flags(NetplanParser* npp, yaml_node_t* node, const void* data, GErr
             break;
         default: g_assert_not_reached(); // LCOV_EXCL_LINE
     }
-    g_assert(flags);
-    g_assert(out_ptr);
+    g_assert(flags != NULL);
+    g_assert(out_ptr != NULL);
 
     for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
         yaml_node_t *entry = yaml_document_get_node(&npp->doc, *i);
@@ -1894,14 +1894,14 @@ handle_vxlan_flags(NetplanParser* npp, yaml_node_t* node, const void* data, GErr
 STATIC gboolean
 handle_vxlan_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
-    g_assert(npp->current.vxlan);
+    g_assert(npp->current.vxlan != NULL);
     return handle_generic_guint(npp, node, npp->current.vxlan, data, error);
 }
 
 STATIC gboolean
 handle_vxlan_tristate(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
-    g_assert(npp->current.vxlan);
+    g_assert(npp->current.vxlan != NULL);
     return handle_generic_tristate(npp, node, npp->current.vxlan, data, error);
 }
 
@@ -1941,7 +1941,7 @@ check_and_set_family(gint family, gint* dest)
 STATIC gboolean
 handle_routes_bool(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
-    g_assert(npp->current.route);
+    g_assert(npp->current.route != NULL);
     return handle_generic_bool(npp, node, npp->current.route, data, error);
 }
 
@@ -2043,14 +2043,14 @@ handle_ip_rule_ip(NetplanParser* npp, yaml_node_t* node, const void* data, GErro
 STATIC gboolean
 handle_ip_rule_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
-    g_assert(npp->current.ip_rule);
+    g_assert(npp->current.ip_rule != NULL);
     return handle_generic_guint(npp, node, npp->current.ip_rule, data, error);
 }
 
 STATIC gboolean
 handle_routes_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
-    g_assert(npp->current.route);
+    g_assert(npp->current.route != NULL);
     return handle_generic_guint(npp, node, npp->current.route, data, error);
 }
 
@@ -2595,7 +2595,7 @@ handle_tunnel_key_mapping(NetplanParser* npp, yaml_node_t* node, const char* key
 STATIC gboolean
 handle_wireguard_peer_str(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
-    g_assert(npp->current.wireguard_peer);
+    g_assert(npp->current.wireguard_peer != NULL);
     return handle_generic_str(npp, node, npp->current.wireguard_peer, data, error);
 }
 
@@ -2606,7 +2606,7 @@ handle_wireguard_peer_str(NetplanParser* npp, yaml_node_t* node, const void* dat
 STATIC gboolean
 handle_wireguard_peer_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
-    g_assert(npp->current.wireguard_peer);
+    g_assert(npp->current.wireguard_peer != NULL);
     return handle_generic_guint(npp, node, npp->current.wireguard_peer, data, error);
 }
 

--- a/src/sriov.c
+++ b/src/sriov.c
@@ -30,7 +30,8 @@ STATIC gboolean
 write_sriov_rebind_systemd_unit(GHashTable* pfs, const char* rootdir, GError** error)
 {
     g_autofree gchar* id_escaped = NULL;
-    g_autofree char* link = g_strjoin(NULL, rootdir ?: "", "/run/systemd/system/multi-user.target.wants/netplan-sriov-rebind.service", NULL);
+    g_autofree char* link = g_strjoin(NULL, rootdir != NULL ? rootdir : "",
+                                      "/run/systemd/system/multi-user.target.wants/netplan-sriov-rebind.service", NULL);
     g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-sriov-rebind.service", NULL);
 
     GHashTableIter iter;
@@ -75,7 +76,8 @@ STATIC gboolean
 write_sriov_apply_systemd_unit(GHashTable* pfs, const char* rootdir, GError** error)
 {
     g_autofree gchar* id_escaped = NULL;
-    g_autofree char* link = g_strjoin(NULL, rootdir ?: "", "/run/systemd/system/multi-user.target.wants/netplan-sriov-apply.service", NULL);
+    g_autofree char* link = g_strjoin(NULL, rootdir != NULL ? rootdir : "",
+                                      "/run/systemd/system/multi-user.target.wants/netplan-sriov-apply.service", NULL);
     g_autofree char* path = g_strjoin(NULL, "/run/systemd/system/netplan-sriov-apply.service", NULL);
     GHashTableIter iter;
     gpointer key;

--- a/src/types.c
+++ b/src/types.c
@@ -403,7 +403,7 @@ netplan_state_new()
 void
 netplan_state_clear(NetplanState** np_state_p)
 {
-    g_assert(np_state_p);
+    g_assert(np_state_p != NULL);
     NetplanState* np_state = *np_state_p;
     *np_state_p = NULL;
     netplan_state_reset(np_state);
@@ -448,14 +448,14 @@ netplan_state_reset(NetplanState* np_state)
 NetplanBackend
 netplan_state_get_backend(const NetplanState* np_state)
 {
-    g_assert(np_state);
+    g_assert(np_state != NULL);
     return np_state->backend;
 }
 
 guint
 netplan_state_get_netdefs_size(const NetplanState* np_state)
 {
-    g_assert(np_state);
+    g_assert(np_state != NULL);
     return np_state->netdefs ? g_hash_table_size(np_state->netdefs) : 0;
 }
 
@@ -486,7 +486,7 @@ CLEAR_FROM_FREE(free_address_options, address_options_clear, NetplanAddressOptio
 NetplanNetDefinition*
 netplan_state_get_netdef(const NetplanState* np_state, const char* id)
 {
-    g_assert(np_state);
+    g_assert(np_state != NULL);
     if (!np_state->netdefs)
         return NULL;
     return g_hash_table_lookup(np_state->netdefs, id);
@@ -495,70 +495,70 @@ netplan_state_get_netdef(const NetplanState* np_state, const char* id)
 ssize_t
 netplan_netdef_get_filepath(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netplan_copy_string(netdef->filepath, out_buffer, out_buf_size);
 }
 
 NetplanBackend
 netplan_netdef_get_backend(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->backend;
 }
 
 NetplanDefType
 netplan_netdef_get_type(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->type;
 }
 
 ssize_t
 netplan_netdef_get_id(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netplan_copy_string(netdef->id, out_buffer, out_buf_size);
 }
 
 NetplanNetDefinition*
 netplan_netdef_get_vlan_link(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->vlan_link;
 }
 
 NetplanNetDefinition*
 netplan_netdef_get_sriov_link(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->sriov_link;
 }
 
 NetplanNetDefinition*
 netplan_netdef_get_bridge_link(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->bridge_link;
 }
 
 NetplanNetDefinition*
 netplan_netdef_get_vrf_link(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->vrf_link;
 }
 
 NetplanNetDefinition*
 netplan_netdef_get_bond_link(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->bond_link;
 }
 
 NetplanNetDefinition*
 netplan_netdef_get_peer_link(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->peer_link;
 }
 
@@ -572,56 +572,56 @@ netplan_state_has_nondefault_globals(const NetplanState* np_state)
 ssize_t
 _netplan_netdef_get_embedded_switch_mode(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netplan_copy_string(netdef->embedded_switch_mode, out_buffer, out_buf_size);
 }
 
 gboolean
 _netplan_netdef_get_delay_virtual_functions_rebind(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->sriov_delay_virtual_functions_rebind;
 }
 
 gboolean
 netplan_netdef_has_match(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->has_match;
 }
 
 gboolean
 _netplan_netdef_get_sriov_vlan_filter(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->sriov_vlan_filter;
 }
 
 guint
 _netplan_netdef_get_vlan_id(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->vlan_id;
 }
 
 gboolean
 _netplan_netdef_get_critical(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->critical;
 }
 
 gboolean
 _netplan_netdef_get_optional(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     return netdef->optional;
 }
 
 gboolean
 _netplan_netdef_is_trivial_compound_itf(const NetplanNetDefinition* netdef)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
     if (netdef->type == NETPLAN_DEF_TYPE_BOND)
         return !complex_object_is_dirty(netdef, &netdef->bond_params, sizeof(netdef->bond_params));
     else if (netdef->type == NETPLAN_DEF_TYPE_BRIDGE)
@@ -632,7 +632,7 @@ _netplan_netdef_is_trivial_compound_itf(const NetplanNetDefinition* netdef)
 ssize_t
 _netplan_netdef_get_bond_mode(const NetplanNetDefinition* netdef, char* out_buffer, size_t out_buf_size)
 {
-    g_assert(netdef);
+    g_assert(netdef != NULL);
 
     if (netdef->type == NETPLAN_DEF_TYPE_BOND && netdef->bond_params.mode)
         return netplan_copy_string(netdef->bond_params.mode, out_buffer, out_buf_size);


### PR DESCRIPTION
## Description
Fix some warnings reported by TiCS

* (6.8.4.b) Expression 'rootdir' is not a proper 'Boolean' condition.
* (6.10.8.b) Reserved identifier `__FUNCTION__` may not be used.
* (6.3.2.3.d) Encountered conversion between boolean type '(0, 1)' and non-boolean type 'char *'.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

