### PR TITLE
ci/tics: set the token before trying to download TICS

### DIFF
--- a/.github/workflows/tiobe.yml
+++ b/.github/workflows/tiobe.yml
@@ -26,6 +26,7 @@ jobs:
           unbuffer meson test -C _build -v
       - name: Download and Install TICS
         run: |
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
           curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
           bash install_tics.sh
       - name: Run TICS


### PR DESCRIPTION
The download started to fail without authentication.

I tested it locally and the script `install_tics.sh` works when the variable is exported.

## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

