### PR TITLE
tests: ethernets: Add ipv6-address-generation integration tests

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -21,19 +21,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-import re
-import time
-import subprocess
-import tempfile
-import unittest
-import shutil
-import gi
 import glob
-import json
-import pwd
 import grp
+import ipaddress
+import json
+import os
+import pwd
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+import gi
 
 # make sure we point to libnetplan properly.
 os.environ.update({'LD_LIBRARY_PATH': '.:{}'.format(os.environ.get('LD_LIBRARY_PATH'))})


### PR DESCRIPTION
## Description

These tests validate the Stable Privacy and Modified EUI-64 IPv6 address generation methods under both NetworkManager and systemd-networkd.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

