### PR TITLE
CI: cleanup after v1.1 release

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -48,8 +48,6 @@ jobs:
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
           sed -i 's|iproute2,|iproute2, ethtool,|' debian/control  # add ethtool as a dependency of netplan.io temporarily
-          sed -i 's|  python3-gi,|  python3-gi, python3-packaging,|' debian/tests/control  # needed for the 'routing' test (nm_version)
-          sed -i 's|bytecompile=-1|bytecompile=-1 -Dtesting=false|' debian/rules  # drop after v1.1
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"

--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -42,7 +42,6 @@ jobs:
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
           echo "3.0 (native)" > debian/source/format  # force native build
-          sed -i 's|bytecompile=-1|bytecompile=-1 -Dtesting=false|' debian/rules  # drop after v1.1
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"
@@ -63,10 +62,9 @@ jobs:
           MIRROR=http://archive.ubuntu.com/ubuntu autopkgtest-build-lxd ubuntu-daily:noble # LP: #2052639
       - name: Run autopkgtest
         run: |
-          # using --setup-commands temporarily to install:
-          # cmocka/pytest/rich/ethtool until they become proper test-deps
           pull-lp-source network-manager noble
           sudo autopkgtest -U \
             --copy=debian/artifacts:/root/ --setup-commands='dpkg -i /root/*.deb' \
+            --env=DEB_BUILD_OPTIONS=nocheck \
             --apt-pocket=proposed=src:network-manager \
             network-manager_*.dsc -- lxd autopkgtest/ubuntu/noble/amd64 || test $? -eq 2  # allow for skipped tests (exit code = 2)

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -287,9 +287,10 @@ class _CommonTests():
 
     def test_vrf_basic(self):
         try:
-            subprocess.check_call(['modprobe', 'vrf'])
+            subprocess.check_call(['ip', 'link', 'add', 'dev', 'modprobe-check', 'type', 'vrf', 'table', '666'])
+            subprocess.check_call(['ip', 'link', 'del', 'modprobe-check'])
         except Exception:
-            raise unittest.SkipTest("vrf module is unavailable, can't test")
+            raise unittest.SkipTest('vrf module is unavailable, can\'t test')
 
         self.setup_eth('slaac')
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'vrf0'], stderr=subprocess.DEVNULL)

--- a/tests/integration/tunnels.py
+++ b/tests/integration/tunnels.py
@@ -92,9 +92,10 @@ class _CommonTests():
 
     def test_tunnel_wireguard(self):
         try:
-            subprocess.check_call(['modprobe', 'wireguard'])
+            subprocess.check_call(['ip', 'link', 'add', 'dev', 'modprobe-check', 'type', 'wireguard'])
+            subprocess.check_call(['ip', 'link', 'del', 'modprobe-check'])
         except Exception:
-            raise unittest.SkipTest("wireguard module is unavailable, can't test")
+            raise unittest.SkipTest('wireguard module is unavailable, can\'t test')
 
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'wg0'], stderr=subprocess.DEVNULL)
         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', 'wg1'], stderr=subprocess.DEVNULL)


### PR DESCRIPTION
## Description
* Dropping some quirks that are not needed anymore as of the v1.1 packaging.
* Re-enable testing for network devices that need additional kernel modules (like `vrf` or `wireguard`) in containers.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

