### PR TITLE
ovs: quote external-ids and other-config values (LP: #2070318)

### DIFF
--- a/src/openvswitch.c
+++ b/src/openvswitch.c
@@ -134,7 +134,7 @@ write_ovs_tag_setting(const gchar* id, const char* type, const char* col, const 
     g_string_append_printf(s, "%s", col);
     if (key)
         g_string_append_printf(s, "/%s", key);
-    g_string_append_printf(s, "=%s", clean_value);
+    g_string_append_printf(s, "=\"%s\"", clean_value);
     append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s %s", type, id, s->str);
     g_string_free(s, TRUE);
 }
@@ -150,7 +150,7 @@ write_ovs_additional_data(GHashTable *data, const char* type, const gchar* id, G
     while (g_hash_table_iter_next(&iter, (gpointer) &key, (gpointer) &value)) {
         /* XXX: we need to check what happens when an invalid key=value pair
             gets supplied here. We might want to handle this somehow. */
-        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s %s:%s=%s",
+        append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s %s:%s=\"%s\"",
                            type, id, setting, key, value);
         write_ovs_tag_setting(id, type, setting, key, value, cmds);
     }
@@ -210,7 +210,7 @@ STATIC void
 write_ovs_tag_netplan(const gchar* id, const char* type, GString* cmds)
 {
     /* Mark this bridge/port/interface as created by netplan */
-    append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s external-ids:netplan=true",
+    append_systemd_cmd(cmds, OPENVSWITCH_OVS_VSCTL " set %s %s external-ids:netplan=\"true\"",
                        type, id);
 }
 

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -65,11 +65,11 @@ Wants=ovsdb-server.service\nAfter=ovsdb-server.service\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
 .device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
 OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
-OVS_BR_DEFAULT = 'ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan=true\nExecStart=/usr/bin/ovs-vsctl \
+OVS_BR_DEFAULT = 'ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan=\"true\"\nExecStart=/usr/bin/ovs-vsctl \
 set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/global/set-fail-mode=\
-standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set \
-Bridge %(iface)s external-ids:netplan/mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
-rstp_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/rstp_enable=false\n'
+\"standalone\"\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set \
+Bridge %(iface)s external-ids:netplan/mcast_snooping_enable="false"\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
+rstp_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/rstp_enable=\"false\"\n'
 OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
 Type=oneshot\nTimeoutStartSec=10s\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
 OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -67,10 +67,10 @@ After=netplan-ovs-ovs0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/external-ids/iface-id=myhostname
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/other-config/disable-in-band=true
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id="myhostname"
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/external-ids/iface-id="myhostname"
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band="true"
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/other-config/disable-in-band="true"
 '''},
                          'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'extra': '''\
 Requires=netplan-ovs-ovs0.service
@@ -79,8 +79,8 @@ After=netplan-ovs-ovs0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
-ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-config/disable-in-band=false
+ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band="false"
+ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-config/disable-in-band="false"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -118,10 +118,10 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-confi
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/external-ids/iface-id=myhostname
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/other-config/disable-in-band=true
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id="myhostname"
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/external-ids/iface-id="myhostname"
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band="true"
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/other-config/disable-in-band="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -143,7 +143,7 @@ TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs0
 ''' + OVS_BR_DEFAULT % {'iface': 'ovs0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set Bridge ovs0 protocols=OpenFlow10,OpenFlow11,OpenFlow12
-ExecStart=/usr/bin/ovs-vsctl set Bridge ovs0 external-ids:netplan/protocols=OpenFlow10,OpenFlow11,OpenFlow12
+ExecStart=/usr/bin/ovs-vsctl set Bridge ovs0 external-ids:netplan/protocols="OpenFlow10,OpenFlow11,OpenFlow12"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -198,11 +198,11 @@ After=netplan-ovs-br0.service
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id=myhostname
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/iface-id=myhostname
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id="myhostname"
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/iface-id="myhostname"
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -267,9 +267,9 @@ After=netplan-ovs-br0.service
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=active
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="active"
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -333,11 +333,11 @@ After=netplan-ovs-br0.service
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode=balance-tcp
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode="balance-tcp"
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -373,11 +373,11 @@ After=netplan-ovs-br0.service
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode=active-backup
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode="active-backup"
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -451,10 +451,10 @@ Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/external-ids/iface-id=myhostname
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band=true
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/other-config/disable-in-band=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id="myhostname"
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/external-ids/iface-id="myhostname"
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band="true"
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/other-config/disable-in-band="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the bridge has been only configured for OVS
@@ -483,13 +483,13 @@ TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan="true"
 ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-fail-mode=secure
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-fail-mode="secure"
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/mcast_snooping_enable=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/mcast_snooping_enable="true"
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/rstp_enable=true
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/rstp_enable="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -543,7 +543,7 @@ TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/protocols=OpenFlow10,OpenFlow11,OpenFlow15
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/protocols="OpenFlow10,OpenFlow11,OpenFlow15"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -594,18 +594,18 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
 ExecStart=/usr/bin/ovs-vsctl set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 \
 tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 unix:/some/path punix:other/path
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-controller=ptcp:,ptcp:1337,\
+ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-controller="ptcp:,ptcp:1337,\
 ptcp:1337:[fe80::1234%eth0],pssl:1337:[fe80::1],ssl:10.10.10.1,tcp:127.0.0.1:1337,tcp:[fe80::1234%eth0],tcp:[fe80::1]:1337,\
-unix:/some/path,punix:other/path
+unix:/some/path,punix:other/path"
 ExecStart=/usr/bin/ovs-vsctl set Controller br0 connection-mode=out-of-band
-ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-mode=out-of-band
+ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-mode="out-of-band"
 '''},
                          'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl="/key/path,/some/path,/another/path"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -703,7 +703,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
+ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl="/key/path,/some/path,/another/path"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -808,9 +808,9 @@ After=netplan-ovs-br0.service
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
@@ -867,9 +867,9 @@ After=netplan-ovs-br0.service
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0 -- set Interface patchy type=patch options:peer=patchx
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
 ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp=off
+ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
 '''},
                          'patchx.service': OVS_VIRTUAL % {'iface': 'patchx', 'extra':
                                                           '''Requires=netplan-ovs-br1.service
@@ -878,7 +878,7 @@ After=netplan-ovs-br1.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan="true"
 '''},
                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
                                                           '''Requires=netplan-ovs-bond0.service
@@ -887,7 +887,7 @@ After=netplan-ovs-bond0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
@@ -932,7 +932,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan="true"
 '''},
                          'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
                                                             '''Requires=netplan-ovs-br1.service
@@ -941,7 +941,7 @@ After=netplan-ovs-br1.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
@@ -976,7 +976,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -1006,7 +1006,7 @@ After=netplan-ovs-br0.service
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -1101,9 +1101,9 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br123
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br123 nic1
 ''' + OVS_BR_DEFAULT % {'iface': 'br123'} + ('\
 ExecStart=/usr/bin/ovs-vsctl set Bridge br123 protocols=OpenFlow10,OpenFlow11,OpenFlow12\n\
-ExecStart=/usr/bin/ovs-vsctl set Bridge br123 external-ids:netplan/protocols=OpenFlow10,OpenFlow11,OpenFlow12\n\
+ExecStart=/usr/bin/ovs-vsctl set Bridge br123 external-ids:netplan/protocols="OpenFlow10,OpenFlow11,OpenFlow12"\n\
 ExecStart=/usr/bin/ovs-vsctl set-controller br123 tcp:127.0.0.1:6653\n\
-ExecStart=/usr/bin/ovs-vsctl set Bridge br123 external-ids:netplan/global/set-controller=tcp:127.0.0.1:6653\n\
+ExecStart=/usr/bin/ovs-vsctl set Bridge br123 external-ids:netplan/global/set-controller="tcp:127.0.0.1:6653"\n\
 ')},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
@@ -1136,7 +1136,7 @@ After=netplan-ovs-abc%2F..%2F..%2F123.service
 Type=oneshot
 TimeoutStartSec=10s
 ExecStart=/usr/bin/ovs-vsctl --may-exist add-br abc/../../123.100 abc/../../123 100
-ExecStart=/usr/bin/ovs-vsctl set Interface abc/../../123.100 external-ids:netplan=true
+ExecStart=/usr/bin/ovs-vsctl set Interface abc/../../123.100 external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
@@ -1175,10 +1175,10 @@ After=netplan-ovs-ovs0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:a\\n1\\ra= \\; a \\; 1 ;a; ;b\\t;\\t3 ;\\ta\\t; 1
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/external-ids/a\\n1\\ra=,;,a,;,1,;a;,;b\\t;\\t3,;\\ta\\t;,1
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:a\\n1\\ra= \\; a \\; 1 ;a; ;b\\t;\\t3 ;\\ta\\t; 1
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/other-config/a\\n1\\ra=,;,a,;,1,;a;,;b\\t;\\t3,;\\ta\\t;,1
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:a\\n1\\ra=" \\; a \\; 1 ;a; ;b\\t;\\t3 ;\\ta\\t; 1"
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/external-ids/a\\n1\\ra=",;,a,;,1,;a;,;b\\t;\\t3,;\\ta\\t;,1"
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:a\\n1\\ra=" \\; a \\; 1 ;a; ;b\\t;\\t3 ;\\ta\\t; 1"
+ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/other-config/a\\n1\\ra=",;,a,;,1,;a;,;b\\t;\\t3,;\\ta\\t;,1"
 '''},
                          'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'extra': '''\
 Requires=netplan-ovs-ovs0.service
@@ -1187,8 +1187,8 @@ After=netplan-ovs-ovs0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
-ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-config/disable-in-band=false
+ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band="false"
+ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-config/disable-in-band="false"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -526,6 +526,7 @@ class _CommonTests():
         mcast-snooping: true
         external-ids:
           iface-id: myhostname
+          ovn-cms-options: "card-serial-number=MT42424242N8,enable-chassis-as-gw"
         other-config:
           disable-in-band: true
           hwaddr: aa:bb:cc:dd:ee:ff
@@ -600,6 +601,8 @@ class _CommonTests():
         self.assertNotIn(b'somekey=55:44:33:22:11:00', after['external-ids-Open_vSwitch'])
         self.assertIn(b'iface-id=myhostname', before['external-ids-Bridge'])
         self.assertNotIn(b'iface-id=myhostname', after['external-ids-Bridge'])
+        self.assertIn(b'ovn-cms-options=card-serial-number=MT42424242N8,enable-chassis-as-gw', before['external-ids-Bridge'])
+        self.assertNotIn(b'ovn-cms-options=card-serial-number=MT42424242N8,enable-chassis-as-gw', after['external-ids-Bridge'])
         self.assertIn(b'iface-id=mylocaliface', before['external-ids-Interface'])
         self.assertNotIn(b'iface-id=mylocaliface', after['external-ids-Interface'])
         for tbl in ('Bridge', 'Port'):

--- a/tests/test_ovs.py
+++ b/tests/test_ovs.py
@@ -94,7 +94,7 @@ Bootstrap: false'''
     def test_clear_dict(self, mock):
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key', 'value')
         mock.assert_has_calls([
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key', 'value']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key=\"value\"']),
             call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
         ])
 
@@ -118,7 +118,7 @@ Bootstrap: false'''
     def test_clear_dict_colon(self, mock):
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key', 'fa:16:3e:4b:19:3a')
         mock.assert_has_calls([
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key', r'fa\:16\:3e\:4b\:19\:3a']),
+            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key=\"fa:16:3e:4b:19:3a\"']),
             call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
         ])
         mock.mock_calls


### PR DESCRIPTION
For complex values, ovs-vsctl requires that they are quoted or it will error out. [LP: #2070318](https://bugs.launchpad.net/netplan/+bug/2070318)

Interestingly, it seems to work from systemd units. But I added quotes there too.

I added a new test case to the integration test `test_settings_tag_cleanup` that will fail without quotes. It's based on the example provided in the bug report.

```
test_settings_tag_cleanup (__main__.TestOVS.test_settings_tag_cleanup) ... eth42 eth43 ovs0 ovs1
** (process:6306): WARNING **: 11:04:05.201: Permissions for /etc/netplan/01-main.yaml are too open. Netplan configuration should NOT be accessible by others.
ovs-vsctl: card-serial-number=MT42424242N8,enable-chassis-as-gw: unexpected "=" parsing set of 1 or more strings
Traceback (most recent call last):
  File "/usr/sbin/netplan", line 23, in <module>
    netplan.main()
...
  File "/usr/share/netplan/netplan_cli/cli/ovs.py", line 64, in _del_dict
    subprocess.check_call([OPENVSWITCH_OVS_VSCTL, 'remove', type, iface, column, key, _escape_colon(value)])
  File "/usr/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/usr/bin/ovs-vsctl', 'remove', 'Bridge', 'ovs0', 'external-ids', 'ovn-cms-options', 'card-serial-number=MT42424242N8,enable-chassis-as-gw']' returned non-zero exit status 1.
ERROR
test_vlan_maas (__main__.TestOVS.test_vlan_maas) ... eth42 ovs0 eth42.21 ok
test_zzz_ovs_debugging (__main__.TestOVS.test_zzz_ovs_debugging)
Display OVS logs of the previous tests ... skipped 'For debugging only'

======================================================================
ERROR: test_settings_tag_cleanup (__main__.TestOVS.test_settings_tag_cleanup)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/autopkgtest.CeX2HX/tree/tests/integration/ovs.py", line 541, in test_settings_tag_cleanup
    subprocess.check_call(['netplan', 'apply', '--only-ovs-cleanup'])
  File "/usr/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['netplan', 'apply', '--only-ovs-cleanup']' returned non-zero exit status 1.

----------------------------------------------------------------------
Ran 13 tests in 221.779s
```

While here, add some debugging information so we can see the ovs-vsctl command executed by "netplan apply" with --debug.

I created a PPA for Noble with this patch: https://launchpad.net/~danilogondolfo/+archive/ubuntu/netplan.io/

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

