### PR TITLE
parse-nm: account for veth and dummy when checking for virtual types

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -65,6 +65,7 @@ typedef enum {
      * requires links to another netdef (such as vlan_link)
      * but it's not strictly mandatory
      * It's intended to be used only when renderer is NetworkManager
+     * Keep the PLACEHOLDER_ and MAX_ elements at the end of the enum
      */
     NETPLAN_DEF_TYPE_NM_PLACEHOLDER_,
     NETPLAN_DEF_TYPE_MAX_

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -668,7 +668,9 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
         nd_id = g_strdup(netdef_id);
         if (g_strcmp0(netdef_id, tmp_str) == 0)
             _kf_clear_key(kf, "connection", "interface-name");
-    } else if (tmp_str && nd_type >= NETPLAN_DEF_TYPE_VIRTUAL && nd_type < NETPLAN_DEF_TYPE_NM) {
+    } else if (tmp_str && nd_type != NETPLAN_DEF_TYPE_NM
+                && nd_type >= NETPLAN_DEF_TYPE_VIRTUAL
+                && nd_type < NETPLAN_DEF_TYPE_NM_PLACEHOLDER_) {
         /* netdef ID equals "interface-name" for virtual devices (bridge/bond/...) */
         nd_id = g_strdup(tmp_str);
         _kf_clear_key(kf, "connection", "interface-name");


### PR DESCRIPTION
The new types DUMMY and VETH were added to the types enum after the generic type NM. We it checked if the interfaces was virtual, in order to build the netdef id, it wouldn't consider DUMMY and VETH.

Because of that, when a dummy or veth interface is created via network manager, it's netdef ID would be the connection UUID. For virtual devices we want it to be the interface name.

It works fine with existing interfaces. Network Manager will get the netdef ID from the file name. It was tested by creating a bunch of dummies and veths via nmcli, updating libnetplan and creating new and modifying existing connections.

I created a PPA for oracular with this patch here https://launchpad.net/~danilogondolfo/+archive/ubuntu/netplan.io

Loading this keyfile:

```
[connection]
id=dummy-dummy0
type=dummy
uuid=dbcdd742-e2f2-4896-a709-e3e4a64c17b0
#Netplan: passthrough setting
interface-name=dummy0

[ipv4]
#Netplan: passthrough override
method=disabled

[ipv6]
#Netplan: passthrough override
method=disabled
#Netplan: passthrough setting
addr-gen-mode=default

[dummy]

[proxy]
```

Would emit this YAML:

```
network:
  version: 2
  dummy-devices:
    NM-dbcdd742-e2f2-4896-a709-e3e4a64c17b0:
      renderer: NetworkManager
      networkmanager:
        uuid: "dbcdd742-e2f2-4896-a709-e3e4a64c17b0"
        name: "dummy-dummy0"
        passthrough:
          connection.interface-name: "dummy0"
          ipv4.method: "disabled"
          ipv6.method: "disabled"
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          dummy._: ""
          proxy._: ""
```

With this fix it will emit:

```
network:
  version: 2
  dummy-devices:
    dummy0:
      renderer: NetworkManager
      networkmanager:
        uuid: "dbcdd742-e2f2-4896-a709-e3e4a64c17b0"
        name: "dummy-dummy0"
        passthrough:
          ipv4.method: "disabled"
          ipv6.method: "disabled"
          ipv6.addr-gen-mode: "default"
          ipv6.ip6-privacy: "-1"
          dummy._: ""
          proxy._: ""
```

## Description


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

