### PR TITLE
tests:ethernets: avoid flaky test_ip6_eui64 results

### DIFF
--- a/tests/integration/ethernets.py
+++ b/tests/integration/ethernets.py
@@ -223,7 +223,7 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e_client, ['inet6 2600::42/64'])
 
     def test_ip6_stable_privacy(self):
-        self.setup_eth('ra-only')
+        self.setup_eth('ra-stateless')
         with open(self.config, 'w') as f:
             f.write('''network:
   version: 2
@@ -240,7 +240,7 @@ class _CommonTests():
         self.assert_iface_up(self.dev_e_client, ['inet6 2600::'], [f'inet6 {eui_addr.compressed}/64'])
 
     def test_ip6_eui64(self):
-        self.setup_eth('ra-only')
+        self.setup_eth('ra-stateless')
         with open(self.config, 'w') as f:
             f.write('''network:
   version: 2
@@ -250,9 +250,9 @@ class _CommonTests():
       dhcp6: yes
       accept-ra: yes
       ipv6-address-generation: eui64''' % {'r': self.backend, 'ec': self.dev_e_client})
-        self.generate_and_settle([self.state_dhcp6(self.dev_e_client)])
         # Compare to EUI-64 address, to make sure it matches the one generated.
         eui_addr = mac_to_eui64(self.dev_e_client_mac)
+        self.generate_and_settle([self.state(self.dev_e_client, eui_addr.compressed)])
         self.assert_iface_up(self.dev_e_client, [f'inet6 {eui_addr.compressed}/64'])
 
     def test_link_local_all(self):


### PR DESCRIPTION
## Description
Avoid flaky `test_ip6_eui64` results, when statefull DHCPv6 is quicker than stateless EUI-64 address generation.
Also use a `ra-stateless` configuration option to dnsmasq, to avoid providing stateful DHCP addresses to the client;
`ra-only` doesn't seem to work properly, when combined with `--dhcp-range` (from `integration/base.py`).

This seems to fail from time to time on systemd v256 based systems, such as Debian testing or Ubuntu oracular.

Follow-up to https://github.com/canonical/netplan/pull/509

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

