### PR TITLE
[RFC] CI: Ignore errors off by default

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -56,5 +56,7 @@ jobs:
           dch -v "$VER" "Autopkgtest CI testing (Noble)"
       - name: Run autopkgtest (incl. build)
         run: |
-          autopkgtest . \
-            -U --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 -- lxd autopkgtest/ubuntu/noble/amd64
+          autopkgtest . -U \
+            --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 \
+            --env=NETPLAN_PARSER_IGNORE_ERRORS=1 \
+            -- lxd autopkgtest/ubuntu/noble/amd64

--- a/tests/integration/run.py
+++ b/tests/integration/run.py
@@ -78,7 +78,7 @@ else:
 
 os.environ["NETPLAN_TEST_BACKENDS"] = ",".join(backends)
 
-run_with_ignore_errors = os.environ.get("NETPLAN_PARSER_IGNORE_ERRORS", "1")
+run_with_ignore_errors = os.environ.get("NETPLAN_PARSER_IGNORE_ERRORS", "0")
 
 returncode = 0
 for test in requested_tests:


### PR DESCRIPTION
## Description
CI:tests: Disable NETPLAN_PARSER_IGNORE_ERRORS by default
    
It's taking lots of compute time in upstream and downstream CI systems.
We still keep it on inside our `autopkgtest.yml` CI test, but turn it off
by default otherwise.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

