### PR TITLE
Revert PR 449 (LP: #2078009)

### DIFF
--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -25,8 +25,6 @@ import sys
 import glob
 import subprocess
 import shutil
-import tempfile
-import filecmp
 import time
 
 from .. import utils
@@ -110,6 +108,7 @@ class NetplanApply(utils.NetplanCommand):
                 return
 
         ovs_cleanup_service = '/run/systemd/system/netplan-ovs-cleanup.service'
+        old_files_networkd = bool(glob.glob('/run/systemd/network/*netplan-*'))
         old_ovs_glob = glob.glob('/run/systemd/system/netplan-ovs-*')
         # Ignore netplan-ovs-cleanup.service, as it can always be there
         if ovs_cleanup_service in old_ovs_glob:
@@ -119,32 +118,30 @@ class NetplanApply(utils.NetplanCommand):
         nm_ifaces = utils.nm_interfaces(old_nm_glob, utils.get_interfaces())
         old_files_nm = bool(old_nm_glob)
 
-        restart_networkd = False
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            # needs to be a subfolder as copytree wants to create it
-            old_files_dir = os.path.join(tmp_dir, 'cfg')
-            shutil.copytree('/run/systemd/network', old_files_dir)
+        generator_call = []
+        generate_out = None
+        if 'NETPLAN_PROFILE' in os.environ:
+            generator_call.extend(['valgrind', '--leak-check=full'])
+            generate_out = subprocess.STDOUT
 
-            generator_call = []
-            generate_out = None
-            if 'NETPLAN_PROFILE' in os.environ:
-                generator_call.extend(['valgrind', '--leak-check=full'])
-                generate_out = subprocess.STDOUT
-
-            generator_call.append(utils.get_generator_path())
-            if run_generate and subprocess.call(generator_call, stderr=generate_out) != 0:
-                if exit_on_error:
-                    sys.exit(os.EX_CONFIG)
-                else:
-                    raise ConfigurationError("the configuration could not be generated")
-
-            # Restart networkd if something in the configuration changed
-            comp = filecmp.dircmp('/run/systemd/network', old_files_dir)
-            if comp.left_only or comp.right_only or comp.diff_files:
-                restart_networkd = True
+        generator_call.append(utils.get_generator_path())
+        if run_generate and subprocess.call(generator_call, stderr=generate_out) != 0:
+            if exit_on_error:
+                sys.exit(os.EX_CONFIG)
+            else:
+                raise ConfigurationError("the configuration could not be generated")
 
         devices = utils.get_interfaces()
 
+        # Re-start service when
+        # 1. We have configuration files for it
+        # 2. Previously we had config files for it but not anymore
+        # Ideally we should compare the content of the *netplan-* files before and
+        # after generation to minimize the number of re-starts, but the conditions
+        # above works too.
+        restart_networkd = bool(glob.glob('/run/systemd/network/*netplan-*'))
+        if not restart_networkd and old_files_networkd:
+            restart_networkd = True
         restart_ovs_glob = glob.glob('/run/systemd/system/netplan-ovs-*')
         # Ignore netplan-ovs-cleanup.service, as it can always be there
         if ovs_cleanup_service in restart_ovs_glob:

--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -122,11 +122,8 @@ class NetplanApply(utils.NetplanCommand):
         restart_networkd = False
         with tempfile.TemporaryDirectory() as tmp_dir:
             # needs to be a subfolder as copytree wants to create it
-            run_systemd_network = '/run/systemd/network'
             old_files_dir = os.path.join(tmp_dir, 'cfg')
-            has_old_networkd_config = os.path.isdir(run_systemd_network)
-            if has_old_networkd_config:
-                shutil.copytree(run_systemd_network, old_files_dir)
+            shutil.copytree('/run/systemd/network', old_files_dir)
 
             generator_call = []
             generate_out = None
@@ -142,13 +139,9 @@ class NetplanApply(utils.NetplanCommand):
                     raise ConfigurationError("the configuration could not be generated")
 
             # Restart networkd if something in the configuration changed
-            has_new_networkd_config = os.path.isdir(run_systemd_network)
-            if has_old_networkd_config != has_new_networkd_config:
+            comp = filecmp.dircmp('/run/systemd/network', old_files_dir)
+            if comp.left_only or comp.right_only or comp.diff_files:
                 restart_networkd = True
-            elif has_old_networkd_config and has_new_networkd_config:
-                comp = filecmp.dircmp(run_systemd_network, old_files_dir)
-                if comp.left_only or comp.right_only or comp.diff_files:
-                    restart_networkd = True
 
         devices = utils.get_interfaces()
 


### PR DESCRIPTION
## Description

This PR essentially reverts https://github.com/canonical/netplan/pull/449/

The only conflict was due to an import that was removed (netifaces).

On https://github.com/canonical/netplan/pull/449/ `netplan apply` was changed to only apply if there were changes in the backend config files.

While this is a nice approach to avoid unnecessary network disruptions, backend configuration can be generated without `apply` be aware of it (via the generator (such as when daemon-reload is called) or `netplan generate`).

In this cases (if the generator or `netplan generate` runs first), when `apply` compares the previous configuration with the new one, there will be no changes.

See [LP: #2078009](https://bugs.launchpad.net/netplan/+bug/2078009). Here, when a new interface is added to the container, a `daemon-reload` happens (twice apparently). Because of that, the netplan generator is called, new backend configuration is generated and `netplan apply` wouldn't do any action after that.

Journal from the container at the moment the interface is plugged in:

```
Sep 16 12:59:22 doh systemd-networkd[441]: veth28d5cf88: Interface name change detected, renamed to eth2.
Sep 16 12:59:22 doh systemd[1]: Starting cloud-init-hotplugd.service - Cloud-init: Hotplug Hook...
Sep 16 12:59:22 doh cloud-init-hotplugd[712]: args=--subsystem=net handle --devpath=/devices/virtual/net/veth28d5cf88 --udevaction=add
Sep 16 12:59:23 doh systemd[1]: Reload requested from client PID 719 ('systemctl') (unit cloud-init-hotplugd.service)...
Sep 16 12:59:23 doh systemd[1]: Reloading...
Sep 16 12:59:23 doh systemd[1]: Configuration file /run/systemd/system/systemd-networkd-wait-online.service.d/10-netplan.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
Sep 16 12:59:23 doh systemd[1]: Configuration file /run/systemd/system/netplan-ovs-cleanup.service is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
Sep 16 12:59:23 doh systemd[1]: Reloading finished in 114 ms.
Sep 16 12:59:23 doh systemd[1]: Reload requested from client PID 769 ('systemctl') (unit cloud-init-hotplugd.service)...
Sep 16 12:59:23 doh systemd[1]: Reloading...
Sep 16 12:59:23 doh systemd[1]: Configuration file /run/systemd/system/systemd-networkd-wait-online.service.d/10-netplan.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
Sep 16 12:59:23 doh systemd[1]: Configuration file /run/systemd/system/netplan-ovs-cleanup.service is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
Sep 16 12:59:23 doh systemd[1]: Reloading finished in 106 ms.
Sep 16 12:59:23 doh systemd[1]: cloud-init-hotplugd.service: Deactivated successfully.
Sep 16 12:59:23 doh systemd[1]: Finished cloud-init-hotplugd.service - Cloud-init: Hotplug Hook.
Sep 16 12:59:33 doh systemd-journald[57]: Forwarding to syslog missed 2162 messages.
Sep 16 12:59:33 doh systemd[1]: systemd-timedated.service: Deactivated successfully.
Sep 16 12:59:33 doh systemd[1]: systemd-hostnamed.service: Deactivated successfully.
```

I created a PPA with these patches for testing: https://launchpad.net/~danilogondolfo/+archive/ubuntu/bugfixes

Autopkgtests on this PPA.

https://autopkgtest.ubuntu.com/results/autopkgtest-oracular-danilogondolfo-bugfixes/oracular/arm64/n/netplan.io/20240916_144524_6b1ba@/log.gz
https://autopkgtest.ubuntu.com/results/autopkgtest-oracular-danilogondolfo-bugfixes/oracular/ppc64el/n/netplan.io/20240916_144805_5f233@/log.gz
https://autopkgtest.ubuntu.com/results/autopkgtest-oracular-danilogondolfo-bugfixes/oracular/s390x/n/netplan.io/20240916_142627_dc92a@/log.gz
https://autopkgtest.ubuntu.com/results/autopkgtest-oracular-danilogondolfo-bugfixes/oracular/armhf/n/netplan.io/20240916_145550_526ff@/log.gz
https://autopkgtest.ubuntu.com/results/autopkgtest-oracular-danilogondolfo-bugfixes/oracular/amd64/n/netplan.io/20240916_145623_713d6@/log.gz

## Checklist

- [ ] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

