### PR TITLE
[RFC] Set keep-configuration=no by default for Network Manager

### DIFF
--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -290,11 +290,7 @@ class NetplanApply(utils.NetplanCommand):
             # 2nd: start all other services
             utils.systemctl('start', netplan_wpa + netplan_ovs, sync=True)
         if restart_nm:
-            # Flush all IP addresses of NM managed interfaces, to avoid NM creating
-            # new, non netplan-* connection profiles, using the existing IPs.
             nm_interfaces = utils.nm_interfaces(restart_nm_glob, devices)
-            for iface in nm_interfaces:
-                utils.ip_addr_flush(iface)
             # clear NM state, especially the [device].managed=true config, as that might have been
             # re-set via an udev rule setting "NM_UNMANAGED=1"
             shutil.rmtree('/run/NetworkManager/devices', ignore_errors=True)

--- a/src/generate.c
+++ b/src/generate.c
@@ -304,8 +304,19 @@ int main(int argc, char** argv)
 
     /* Disable /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf
      * (which restricts NM to wifi and wwan) if "renderer: NetworkManager" is used anywhere */
-    if (netplan_state_get_backend(np_state) == NETPLAN_BACKEND_NM || any_nm)
+    if (netplan_state_get_backend(np_state) == NETPLAN_BACKEND_NM || any_nm) {
         _netplan_g_string_free_to_file(g_string_new(NULL), rootdir, "/run/NetworkManager/conf.d/10-globally-managed-devices.conf", NULL);
+
+        /*
+         * Always try to match existing interfaces with connections.
+         * Because "netplan apply" is too aggressive with Network Manager connections it might
+         * create in-memory profiles for existing virtual interfaces.
+         * keep-configuration forces NM to use existing connection profiles for these interfaces avoiding
+         * this problem.
+         */
+        _netplan_g_string_free_to_file(g_string_new("[device]\nkeep-configuration=no\n"), rootdir,
+                                       "/run/NetworkManager/conf.d/10-keep-configuration.conf", NULL);
+    }
 
     gboolean enable_wait_online = FALSE;
     if (any_networkd)

--- a/src/nm.c
+++ b/src/nm.c
@@ -1185,8 +1185,11 @@ _netplan_nm_cleanup(const char* rootdir)
                                           "/run/NetworkManager/conf.d/netplan.conf", NULL);
     g_autofree char* global_manage_path = g_strjoin(NULL, rootdir != NULL ? rootdir : "",
                                                     "/run/NetworkManager/conf.d/10-globally-managed-devices.conf", NULL);
+    g_autofree char* keep_configuration_path = g_strjoin(NULL, rootdir != NULL ? rootdir : "",
+                                                    "/run/NetworkManager/conf.d/10-keep-configuration.conf", NULL);
     unlink(confpath);
     unlink(global_manage_path);
+    unlink(keep_configuration_path);
     _netplan_unlink_glob(rootdir, "/run/NetworkManager/system-connections/netplan-*");
     return TRUE;
 }


### PR DESCRIPTION
## Description

Network Manager will not touch external interfaces by default but might create a temporary in-memory connection for them. In some situations, in particular when there are virtual interfaces present in the YAML, `netplan apply` will lead to persistent connections to be inactive and the creation of temporary ones. It happens because `netplan apply` will restart the daemon and delete all of its state from disk. It's not clear to me why it fails to match the existing interfaces to connection profiles though.

One workaround consists in settings the global configuration `keep-configuration=no`. With this setting, NM will look for the best profile that can manage a given interface. With this in place, `netplan apply` seems to always produce the correct results when Network Manager is the renderer.

NOTE - SIDE EFFECT: the `lo` temporary connection will not be created anymore with `keep-configuration=no`. 

NOTE 2: I'm not sure where `keep-configuration=no` can break things for us.

Arguably, not creating external connections for interfaces that are not managed by Netplan is, I think, the behavior we want.

**Alternative solution**: forcing `netplan apply` to delete virtual interfaces and let Network Manager recreate them also works. It's arguably safer than setting `keep-configuration=no` as it's not clear what it could break.

I created a PPA for Oracular with this patch here https://launchpad.net/~danilogondolfo/+archive/ubuntu/netplan.io
The PPA also contains https://github.com/canonical/netplan/pull/518

Reproducer: use the configuration below and run `netplan apply` a few times and observe that some of the connections created by Netplan will not be activated and there will be external temporary connections for some interfaces. `networkd` is mixed in to show that `keep-configuration=no` will not interfere with it.

```yaml
network:
  version: 2
  renderer: NetworkManager
  ethernets:
    enp5s0:
      dhcp4: true
  bridges:
    br0:
      addresses:
      - "192.168.5.1/24"
      dhcp4: false
      dhcp6: false
      interfaces:
      - veth6
      - veth4
      - veth2
      - veth0
    br1:
      addresses:
      - "192.168.6.1/24"
      dhcp4: false
      dhcp6: false
      interfaces:
      - veth3
      - veth1
      - veth7
      - veth5
    br123:
      renderer: networkd
      interfaces:
      - veth123
    br321:
      renderer: networkd
      interfaces:
      - veth321
  bonds:
    bond0:
      addresses:
      - "192.168.0.1/24"
      dhcp4: false
      dhcp6: false
    bond1:
      addresses:
      - "192.168.1.1/24"
      dhcp4: false
      dhcp6: false
    bond2:
      addresses:
      - "192.168.2.1/24"
      dhcp4: false
      dhcp6: false
    bond3:
      addresses:
      - "192.168.3.1/24"
      dhcp4: false
      dhcp6: false
    bond4:
      addresses:
      - "192.168.4.1/24"
      dhcp4: false
      dhcp6: false
    bond123:
      renderer: networkd
      interfaces:
      - dummy123
    bond321:
      renderer: networkd
      interfaces:
      - dummy321
  dummy-devices:
    dummy0:
      dhcp4: false
      dhcp6: false
    dummy1:
      dhcp4: false
      dhcp6: false
    dummy2:
      dhcp4: false
      dhcp6: false
    dummy3:
      dhcp4: false
      dhcp6: false
    dummy123:
      renderer: networkd
    dummy321:
      renderer: networkd
  virtual-ethernets:
    veth0:
      peer: "veth1"
    veth1:
      peer: "veth0"
    veth2:
      peer: "veth3"
    veth3:
      peer: "veth2"
    veth4:
      peer: "veth5"
    veth5:
      peer: "veth4"
    veth6:
      peer: "veth7"
    veth7:
      peer: "veth6"
    veth123:
      renderer: networkd
      peer: "veth321"
    veth321:
      renderer: networkd
      peer: "veth123"
```

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

