### PR TITLE
RFC: New "networkmanager.passthrough" structure (LP: #2080301)

### DIFF
--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -31,6 +31,7 @@ jobs:
           dnf -y install epel-release || true
           dnf config-manager --set-enabled crb || true  # Meson/CMocka on EL9
           dnf -y install centos-release-nfv-openvswitch || true  # OVS on EL9
+          dnf -y install gdb
           dnf -y builddep rpm/netplan.spec
           adduser test
           chown -R test:test .

--- a/doc/netplan-everywhere.md
+++ b/doc/netplan-everywhere.md
@@ -101,12 +101,14 @@ network:
         uuid: "0f7a33ac-512e-4c03-b088-4db00fe3292e"
         name: "Ethernet connection 1"
         passthrough:
-          ethernet._: ""
-          ipv4.ignore-auto-dns: "true"
-          ipv6.addr-gen-mode: "default"
-          ipv6.method: "disabled"
-          ipv6.ip6-privacy: "-1"
-          proxy._: ""
+          ethernet: {}
+          ipv4:
+            ignore-auto-dns: "true"
+          ipv6:
+            addr-gen-mode: "default"
+            method: "disabled"
+            ip6-privacy: "-1"
+          proxy: {}
 ```
 
 All the configuration under the `passthrough` mapping is added to
@@ -126,17 +128,21 @@ network:
         uuid: "db5f0f67-1f4c-4d59-8ab8-3d278389cf87"
         name: "myvpnconnection"
         passthrough:
-          connection.type: "vpn"
-          vpn.ca: "path to ca.crt"
-          vpn.cert: "path to client.crt"
-          vpn.cipher: "AES-256-GCM"
-          vpn.connection-type: "tls"
-          vpn.dev: "tun"
-          vpn.key: "path to client.key"
-          vpn.remote: "1.2.3.4:1194"
-          vpn.service-type: "org.freedesktop.NetworkManager.openvpn"
-          ipv4.method: "auto"
-          ipv6.addr-gen-mode: "default"
-          ipv6.method: "auto"
-          proxy._: ""
+          connection:
+            type: "vpn"
+          vpn:
+            ca: "path to ca.crt"
+            cert: "path to client.crt"
+            cipher: "AES-256-GCM"
+            connection-type: "tls"
+            dev: "tun"
+            key: "path to client.key"
+            remote: "1.2.3.4:1194"
+            service-type: "org.freedesktop.NetworkManager.openvpn"
+          ipv4:
+            method: "auto"
+          ipv6:
+            addr-gen-mode: "default"
+            method: "auto"
+          proxy: {}
 ```

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -2146,15 +2146,17 @@ network:
         uuid: "db5f0f67-1f4c-4d59-8ab8-3d278389cf87"
         name: "myvpnconnection"
         passthrough:
-          connection.type: "vpn"
-          vpn.ca: "path to ca.crt"
-          vpn.cert: "path to client.crt"
-          vpn.cipher: "AES-256-GCM"
-          vpn.connection-type: "tls"
-          vpn.dev: "tun"
-          vpn.key: "path to client.key"
-          vpn.remote: "1.2.3.4:1194"
-          vpn.service-type: "org.freedesktop.NetworkManager.openvpn"
+          connection:
+            type: "vpn"
+          vpn:
+            ca: "path to ca.crt"
+            cert: "path to client.crt"
+            cipher: "AES-256-GCM"
+            connection-type: "tls"
+            dev: "tun"
+            key: "path to client.key"
+            remote: "1.2.3.4:1194"
+            service-type: "org.freedesktop.NetworkManager.openvpn"
 ```
 
 ## Back end-specific configuration parameters

--- a/src/abi.h
+++ b/src/abi.h
@@ -211,7 +211,7 @@ typedef struct netplan_backend_settings {
     char *uuid;
     char *stable_id;
     char *device;
-    GData* passthrough; /* See g_datalist* functions */
+    GHashTable* passthrough;
 } NetplanBackendSettings;
 
 typedef struct netplan_vxlan NetplanVxlan;

--- a/src/parse.c
+++ b/src/parse.c
@@ -1927,7 +1927,7 @@ handle_vxlan_tristate(NetplanParser* npp, yaml_node_t* node, const void* data, G
 STATIC int
 get_ip_family(const char* address)
 {
-    g_autofree char *ip_str;
+    g_autofree char *ip_str = NULL;
     char *prefix_len;
 
     ip_str = g_strdup(address);

--- a/src/types.c
+++ b/src/types.c
@@ -169,6 +169,21 @@ reset_ip_rule(NetplanIPRule* ip_rule)
     ip_rule->fwmark = NETPLAN_IP_RULE_FW_MARK_UNSPEC;
 }
 
+STATIC void
+reset_passthrough(GHashTable* passthrough)
+{
+    GHashTableIter iter;
+    GHashTable* group;
+    gchar* group_name;
+
+    g_hash_table_iter_init(&iter, passthrough);
+
+    while (g_hash_table_iter_next(&iter, (gpointer) &group_name, (gpointer) &group)) {
+        g_hash_table_destroy(group);
+    }
+    g_hash_table_destroy(passthrough);
+}
+
 /* Reset a backend settings object. */
 STATIC void
 reset_backend_settings(NetplanBackendSettings* settings)
@@ -177,7 +192,9 @@ reset_backend_settings(NetplanBackendSettings* settings)
     FREE_AND_NULLIFY(settings->uuid);
     FREE_AND_NULLIFY(settings->stable_id);
     FREE_AND_NULLIFY(settings->device);
-    g_datalist_clear(&settings->passthrough);
+    if (settings->passthrough != NULL) {
+        reset_passthrough(settings->passthrough);
+    }
 }
 
 STATIC void

--- a/src/validation.c
+++ b/src/validation.c
@@ -407,7 +407,14 @@ validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, GErr
         // LCOV_EXCL_STOP
     }
 
-    if (nd->type == NETPLAN_DEF_TYPE_NM && (!nd->backend_settings.passthrough || !g_datalist_get_data(&nd->backend_settings.passthrough, "connection.type")))
+    GHashTable* key = NULL;
+    if (nd->backend_settings.passthrough != NULL) {
+        GHashTable* group = g_hash_table_lookup(nd->backend_settings.passthrough, "connection");
+        if (group != NULL) {
+            key = g_hash_table_lookup(group, "type");
+        }
+    }
+    if (nd->type == NETPLAN_DEF_TYPE_NM && key == NULL)
         return yaml_error(npp, NULL, error, "%s: network type 'nm-devices:' needs to provide a 'connection.type' via passthrough", nd->id);
 
     if (npp->current.netdef)

--- a/tests/config_fuzzer/schemas/bridges.js
+++ b/tests/config_fuzzer/schemas/bridges.js
@@ -124,12 +124,18 @@ const bridges_schema = {
                                             properties: {
                                                 eth0: {
                                                     type: "integer",
+                                                    minimum: 0,
+                                                    maximum: 4000000000
                                                 },
                                                 eth1: {
                                                     type: "integer",
+                                                    minimum: 0,
+                                                    maximum: 4000000000
                                                 },
                                                 eth2: {
                                                     type: "integer",
+                                                    minimum: 0,
+                                                    maximum: 4000000000
                                                 },
                                             }
                                         },

--- a/tests/config_fuzzer/schemas/common.js
+++ b/tests/config_fuzzer/schemas/common.js
@@ -210,6 +210,11 @@ export const networkmanager_settings = {
                         type: "string"
                     }
                 },
+                patternProperties: {
+                    "[azAZ09-]{1,10}": {
+                        type: "object",
+                    }
+                }
             }
         },
         required: ["passthrough"]

--- a/tests/config_fuzzer/schemas/nm-devices.js
+++ b/tests/config_fuzzer/schemas/nm-devices.js
@@ -1,4 +1,4 @@
-import common_properties, { minMaxProperties } from "./common.js";
+import { minMaxProperties, networkmanager_settings } from "./common.js";
 
 const nmdevices_schema = {
     type: "object",
@@ -34,29 +34,7 @@ const nmdevices_schema = {
                                     type: "string",
                                     enum: ["NetworkManager"]
                                 },
-                                networkmanager: {
-                                    type: "object",
-                                    additionalProperties: false,
-                                    properties: {
-                                        uuid: {
-                                            type: "string"
-                                        },
-                                        name: {
-                                            type: "string"
-                                        },
-                                        passthrough: {
-                                            type: "object",
-                                            additionalProperties: true,
-                                            properties: {
-                                                "connection.type": {
-                                                    type: "string"
-                                                }
-                                            },
-                                            required: ["connection.type"]
-                                        }
-                                    },
-                                    required: ["passthrough"]
-                                },
+                                ...networkmanager_settings
                             },
                             required: ["networkmanager"]
                         }

--- a/tests/generator/test_modems.py
+++ b/tests/generator/test_modems.py
@@ -380,17 +380,21 @@ method=ignore
         uuid: a08c5805-7cf5-43f7-afb9-12cb30f6eca3
         name: "T-Mobile Funkadelic 2"
         passthrough:
-          connection.type: "bluetooth"
-          gsm.apn: "internet2.voicestream.com"
-          gsm.device-id: "da812de91eec16620b06cd0ca5cbc7ea25245222"
-          gsm.username: "george.clinton.again"
-          gsm.sim-operator-id: "310260"
-          gsm.pin: "123456"
-          gsm.sim-id: "89148000000060671234"
-          gsm.password: "parliament2"
-          gsm.network-id: "254098"
-          ipv4.method: "auto"
-          ipv6.method: "auto"''')
+          connection:
+            type: bluetooth
+          gsm:
+            apn: internet2.voicestream.com
+            device-id: da812de91eec16620b06cd0ca5cbc7ea25245222
+            username: george.clinton.again
+            sim-operator-id: 310260
+            pin: 123456
+            sim-id: 89148000000060671234
+            password: parliament2
+            network-id: 254098
+          ipv4:
+            method: auto
+          ipv6:
+            method: auto''')
         self.assert_nm({'NM-a08c5805-7cf5-43f7-afb9-12cb30f6eca3': '''[connection]
 id=T-Mobile Funkadelic 2
 #Netplan: passthrough override
@@ -400,19 +404,19 @@ uuid=a08c5805-7cf5-43f7-afb9-12cb30f6eca3
 [gsm]
 apn=internet2.voicestream.com
 #Netplan: passthrough setting
-device-id=da812de91eec16620b06cd0ca5cbc7ea25245222
+password=parliament2
+#Netplan: passthrough setting
+network-id=254098
+#Netplan: passthrough setting
+sim-id=89148000000060671234
+#Netplan: passthrough setting
+pin=123456
 #Netplan: passthrough setting
 username=george.clinton.again
 #Netplan: passthrough setting
 sim-operator-id=310260
 #Netplan: passthrough setting
-pin=123456
-#Netplan: passthrough setting
-sim-id=89148000000060671234
-#Netplan: passthrough setting
-password=parliament2
-#Netplan: passthrough setting
-network-id=254098
+device-id=da812de91eec16620b06cd0ca5cbc7ea25245222
 
 [ipv4]
 #Netplan: passthrough override

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -137,6 +137,39 @@ key=a
 match-device=type:ethernet
 managed=1\n\n''')
 
+    def test_passthrough_basic_mapping_no_type_ignore_error(self):
+        out = self.generate('''network:
+  version: 2
+  nm-devices:
+    NM-87749f1d-334f-40b2-98d4-55db58965f5f:
+      renderer: NetworkManager
+      match: {}
+      networkmanager:
+        uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
+        name: some NM id
+        passthrough:
+          connection:
+            uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
+            permissions: ""''', skip_generated_yaml_validation=True, ignore_errors=True)
+
+        self.assertIn('network type \'nm-devices:\' needs to provide a \'connection.type\'', out)
+
+    def test_passthrough_basic_mapping_no_connection_ignore_error(self):
+        out = self.generate('''network:
+  version: 2
+  nm-devices:
+    NM-87749f1d-334f-40b2-98d4-55db58965f5f:
+      renderer: NetworkManager
+      match: {}
+      networkmanager:
+        uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
+        name: some NM id
+        passthrough:
+          a:
+            b: c''', skip_generated_yaml_validation=True, ignore_errors=True)
+
+        self.assertIn('network type \'nm-devices:\' needs to provide a \'connection.type\'', out)
+
     def test_passthrough_wifi(self):
         self.generate('''network:
   version: 2

--- a/tests/generator/test_passthrough.py
+++ b/tests/generator/test_passthrough.py
@@ -39,7 +39,7 @@ class TestNetworkManager(TestBase):
         passthrough:
           connection.uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
           connection.type: ethernet
-          connection.permissions: ""''')
+          connection.permissions: ""''', skip_generated_yaml_validation=True)
 
         self.assert_nm({'NM-87749f1d-334f-40b2-98d4-55db58965f5f': '''[connection]
 id=some NM id
@@ -60,6 +60,83 @@ method=ignore
 match-device=type:ethernet
 managed=1\n\n''')
 
+    def test_passthrough_basic_mapping(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    NM-87749f1d-334f-40b2-98d4-55db58965f5f:
+      renderer: NetworkManager
+      match: {}
+      networkmanager:
+        uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
+        name: some NM id
+        passthrough:
+          connection:
+            uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
+            type: ethernet
+            permissions: ""''')
+
+        self.assert_nm({'NM-87749f1d-334f-40b2-98d4-55db58965f5f': '''[connection]
+id=some NM id
+type=ethernet
+uuid=87749f1d-334f-40b2-98d4-55db58965f5f
+#Netplan: passthrough setting
+permissions=
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+'''}, '''[device-netplan.ethernets.NM-87749f1d-334f-40b2-98d4-55db58965f5f]
+match-device=type:ethernet
+managed=1\n\n''')
+
+    def test_passthrough_basic_mapping_with_duplication(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    NM-87749f1d-334f-40b2-98d4-55db58965f5f:
+      renderer: NetworkManager
+      match: {}
+      networkmanager:
+        uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
+        name: some NM id
+        passthrough:
+          connection:
+            uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
+            type: ethernet
+            permissions: ""
+          group2:
+            key: a
+            key: b''', skip_generated_yaml_validation=True)
+
+        self.assert_nm({'NM-87749f1d-334f-40b2-98d4-55db58965f5f': '''[connection]
+id=some NM id
+type=ethernet
+uuid=87749f1d-334f-40b2-98d4-55db58965f5f
+#Netplan: passthrough setting
+permissions=
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+
+[group2]
+#Netplan: passthrough setting
+key=a
+'''}, '''[device-netplan.ethernets.NM-87749f1d-334f-40b2-98d4-55db58965f5f]
+match-device=type:ethernet
+managed=1\n\n''')
+
     def test_passthrough_wifi(self):
         self.generate('''network:
   version: 2
@@ -75,6 +152,61 @@ managed=1\n\n''')
             passthrough:
               connection.permissions: ""
               wifi.ssid: SOME-SSID
+        "OTHER-SSID":
+          hidden: true''', skip_generated_yaml_validation=True)
+
+        self.assert_nm({'NM-87749f1d-334f-40b2-98d4-55db58965f5f-SOME-SSID': '''[connection]
+id=myid with spaces
+type=wifi
+uuid=87749f1d-334f-40b2-98d4-55db58965f5f
+#Netplan: passthrough setting
+permissions=
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=SOME-SSID
+mode=infrastructure
+''',
+                        'NM-87749f1d-334f-40b2-98d4-55db58965f5f-OTHER-SSID': '''[connection]
+id=netplan-NM-87749f1d-334f-40b2-98d4-55db58965f5f-OTHER-SSID
+type=wifi
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+
+[wifi]
+ssid=OTHER-SSID
+mode=infrastructure
+hidden=true
+'''}, '''[device-netplan.wifis.NM-87749f1d-334f-40b2-98d4-55db58965f5f]
+match-device=type:wifi
+managed=1\n\n''')
+
+    def test_passthrough_wifi_mapping(self):
+        self.generate('''network:
+  version: 2
+  wifis:
+    NM-87749f1d-334f-40b2-98d4-55db58965f5f:
+      renderer: NetworkManager
+      match: {}
+      access-points:
+        "SOME-SSID":
+          networkmanager:
+            uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
+            name: myid with spaces
+            passthrough:
+              connection:
+                permissions: ""
+              wifi:
+                ssid: SOME-SSID
         "OTHER-SSID":
           hidden: true''')
 
@@ -121,8 +253,9 @@ managed=1\n\n''')
       match: {}
       networkmanager:
         passthrough:
-          connection.uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
-          connection.type: dummy''')  # wokeignore:rule=dummy
+          connection:
+            uuid: 87749f1d-334f-40b2-98d4-55db58965f5f
+            type: dummy''')  # wokeignore:rule=dummy
 
         self.assert_nm({'NM-87749f1d-334f-40b2-98d4-55db58965f5f': '''[connection]
 id=netplan-NM-87749f1d-334f-40b2-98d4-55db58965f5f
@@ -149,7 +282,38 @@ managed=1\n\n''')
       networkmanager:
         passthrough:
           connection.type: "wireguard"
-          wireguard-peer.some-key.endpoint: 1.2.3.4''')
+          wireguard-peer.some-key.endpoint: 1.2.3.4''', skip_generated_yaml_validation=True)
+
+        self.assert_nm({'dotted-group-test': '''[connection]
+id=netplan-dotted-group-test
+#Netplan: passthrough setting
+type=wireguard
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+
+[wireguard-peer.some-key]
+#Netplan: passthrough setting
+endpoint=1.2.3.4
+'''}, '''[device-netplan.nm-devices.dotted-group-test]
+match-device=type:wireguard
+managed=1\n\n''')
+
+    def test_passthrough_dotted_group_mapping(self):
+        self.generate('''network:
+  nm-devices:
+    dotted-group-test:
+      renderer: NetworkManager
+      match: {}
+      networkmanager:
+        passthrough:
+          connection:
+            type: "wireguard"
+          wireguard-peer.some-key:
+            endpoint: 1.2.3.4''')
 
         self.assert_nm({'dotted-group-test': '''[connection]
 id=netplan-dotted-group-test
@@ -179,7 +343,7 @@ managed=1\n\n''')
         passthrough:
           tc.qdisc.root: something
           tc.qdisc.fff1: ":abc"
-          tc.filters.test: "test"''')
+          tc.filters.test: "test"''', skip_generated_yaml_validation=True)
 
         self.assert_nm({'dotted-key-test': '''[connection]
 id=netplan-dotted-key-test
@@ -198,9 +362,46 @@ method=ignore
 #Netplan: passthrough setting
 qdisc.root=something
 #Netplan: passthrough setting
+filters.test=test
+#Netplan: passthrough setting
 qdisc.fff1=:abc
+'''}, '''[device-netplan.ethernets.dotted-key-test]
+match-device=type:ethernet
+managed=1\n\n''')
+
+    def test_passthrough_dotted_key_mapping(self):
+        self.generate('''network:
+  ethernets:
+    dotted-key-test:
+      renderer: NetworkManager
+      match: {}
+      networkmanager:
+        passthrough:
+          tc:
+            qdisc.root: something
+            qdisc.fff1: ":abc"
+            filters.test: "test"''')
+
+        self.assert_nm({'dotted-key-test': '''[connection]
+id=netplan-dotted-key-test
+type=ethernet
+
+[ethernet]
+wake-on-lan=0
+
+[ipv4]
+method=link-local
+
+[ipv6]
+method=ignore
+
+[tc]
+#Netplan: passthrough setting
+qdisc.root=something
 #Netplan: passthrough setting
 filters.test=test
+#Netplan: passthrough setting
+qdisc.fff1=:abc
 '''}, '''[device-netplan.ethernets.dotted-key-test]
 match-device=type:ethernet
 managed=1\n\n''')
@@ -215,7 +416,8 @@ managed=1\n\n''')
         "SOME-SSID": # implicit "mode: infrasturcutre"
           networkmanager:
             passthrough:
-              wifi.mode: "mesh"''')
+              wifi:
+                mode: "mesh"''')
 
         self.assert_nm({'test-SOME-SSID': '''[connection]
 id=netplan-test-SOME-SSID
@@ -243,7 +445,7 @@ managed=1\n\n''')
       match: {}
       networkmanager:
         passthrough:
-          proxy._: ""''')
+          proxy: {}''')
 
         self.assert_nm({'test': '''[connection]
 id=netplan-test
@@ -311,7 +513,8 @@ method=ignore
         uuid: 626dd384-8b3d-3690-9511-192b2c79b3fd
         name: "netplan-eth0"
         passthrough:
-          "ipv6.ip6-privacy": "-1"
+          ipv6:
+            ip6-privacy: -1
 ''')
 
         self.assert_nm({'eth0': '''[connection]

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -91,9 +91,12 @@ ip6-privacy=0
         uuid: "{}"
         name: "T-Mobile Funkadelic 2"
         passthrough:
-          gsm.home-only: "true"
-          ipv4.dns-search: ""
-          ipv6.dns-search: ""
+          gsm:
+            home-only: "true"
+          ipv4:
+            dns-search: ""
+          ipv6:
+            dns-search: ""
 '''.format(UUID, UUID)})
 
     def test_keyfile_cdma(self):
@@ -165,21 +168,25 @@ method=auto
         uuid: "{}"
         name: "T-Mobile Funkadelic 2"
         passthrough:
-          connection.type: "bluetooth"
-          gsm.apn: "internet2.voicestream.com"
-          gsm.device-id: "da812de91eec16620b06cd0ca5cbc7ea25245222"
-          gsm.home-only: "true"
-          gsm.network-id: "254098"
-          gsm.password: "parliament2"
-          gsm.pin: "123456"
-          gsm.sim-id: "89148000000060671234"
-          gsm.sim-operator-id: "310260"
-          gsm.username: "george.clinton.again"
-          ipv4.dns-search: ""
-          ipv4.method: "auto"
-          ipv6.dns-search: ""
-          ipv6.method: "auto"
-          proxy._: ""
+          connection:
+            type: "bluetooth"
+          proxy: {{}}
+          gsm:
+            password: "parliament2"
+            apn: "internet2.voicestream.com"
+            home-only: "true"
+            network-id: "254098"
+            sim-id: "89148000000060671234"
+            pin: "123456"
+            device-id: "da812de91eec16620b06cd0ca5cbc7ea25245222"
+            sim-operator-id: "310260"
+            username: "george.clinton.again"
+          ipv4:
+            method: "auto"
+            dns-search: ""
+          ipv6:
+            method: "auto"
+            dns-search: ""
 '''.format(UUID, UUID)})
 
     def test_keyfile_method_auto(self):
@@ -232,9 +239,11 @@ route-metric=4242
         uuid: "{}"
         name: "Test"
         passthrough:
-          ipv4.dns-search: ""
-          ipv6.dns-search: ""
-          proxy._: ""
+          proxy: {{}}
+          ipv4:
+            dns-search: ""
+          ipv6:
+            dns-search: ""
 '''.format(UUID, UUID)})
 
     def test_keyfile_fail_validation(self):
@@ -332,13 +341,15 @@ route2=4:5:6:7:8:9:0:1/63,,5
         uuid: "{}"
         name: "Test"
         passthrough:
-          ipv4.dns-search: "foo.local;bar.remote;"
-          ipv4.method: "manual"
-          ipv4.address1: "1.2.3.4/24,8.8.8.8"
-          ipv6.dns-search: "bar.local"
-          ipv6.route1: "dead:beef::1/128,2001:1234::2"
-          ipv6.route1_options: "unknown=invalid,"
-          proxy._: ""
+          proxy: {{}}
+          ipv4:
+            method: "manual"
+            dns-search: "foo.local;bar.remote;"
+            address1: "1.2.3.4/24,8.8.8.8"
+          ipv6:
+            route1_options: "unknown=invalid,"
+            dns-search: "bar.local"
+            route1: "dead:beef::1/128,2001:1234::2"
 '''.format(UUID, UUID)})
 
     def test_keyfile_dummy(self):       # wokeignore:rule=dummy
@@ -456,8 +467,10 @@ dns-search='''.format(UUID))
             uuid: "{}"
             name: "myid with spaces"
             passthrough:
-              connection.permissions: ""
-              ipv4.dns-search: ""
+              connection:
+                permissions: ""
+              ipv4:
+                dns-search: ""
       networkmanager:
         uuid: "{}"
         name: "myid with spaces"
@@ -517,8 +530,10 @@ dns-search='''.format(UUID, method))
             uuid: "{}"
             name: "testnet"
             passthrough:
-              connection.permissions: ""
-              ipv4.dns-search: ""
+              connection:
+                permissions: ""
+              ipv4:
+                dns-search: ""
       networkmanager:
         uuid: "{}"
         name: "testnet"
@@ -580,7 +595,8 @@ method=auto'''.format(UUID))
             uuid: "{}"
             name: "myid with spaces"
             passthrough:
-              connection.permissions: ""
+              connection:
+                permissions: ""
       networkmanager:
         uuid: "{}"
         name: "myid with spaces"
@@ -627,7 +643,8 @@ method=auto'''.format(UUID))
             uuid: "{}"
             name: "myid with spaces"
             passthrough:
-              connection.permissions: ""
+              connection:
+                permissions: ""
       networkmanager:
         uuid: "{}"
         name: "myid with spaces"
@@ -673,8 +690,10 @@ method=auto'''.format(UUID))
             uuid: "{}"
             name: "myid with spaces"
             passthrough:
-              connection.permissions: ""
-              802-1x.eap: "md5"
+              connection:
+                permissions: ""
+              802-1x:
+                eap: "md5"
       networkmanager:
         uuid: "{}"
         name: "myid with spaces"
@@ -729,7 +748,8 @@ method=auto'''.format(UUID), regenerate=False)
             uuid: "{}"
             name: "myid with spaces"
             passthrough:
-              connection.permissions: ""
+              connection:
+                permissions: ""
       networkmanager:
         uuid: "{}"
         name: "myid with spaces"
@@ -754,7 +774,8 @@ mode={}'''.format(UUID, nm_mode))
         if nm_mode != nd_mode:
             wifi_mode = '''
             passthrough:
-              wifi.mode: "{}"'''.format(nm_mode)
+              wifi:
+                mode: "{}"'''.format(nm_mode)
         if nd_mode != 'infrastructure':
             ap_mode = '\n          mode: "%s"' % nd_mode
         self.assert_netplan({UUID: '''network:
@@ -848,7 +869,8 @@ method=auto'''.format(UUID))
         uuid: "{}"
         name: "myid with spaces"
         passthrough:
-          ethernet.wake-on-lan: "2"
+          ethernet:
+            wake-on-lan: "2"
 '''.format(UUID, UUID)})
 
     def test_keyfile_wake_on_lan_nm_default(self):
@@ -967,16 +989,21 @@ psk=test1234
             uuid: "{}"
             name: "Hotspot-1"
             passthrough:
-              connection.autoconnect: "false"
-              connection.permissions: ""
-              ipv4.dns-search: ""
-              ipv6.addr-gen-mode: "1"
-              ipv6.dns-search: ""
-              wifi.mac-address-blacklist: "" # wokeignore:rule=blacklist
-              wifi-security.group: "ccmp;"
-              wifi-security.pairwise: "ccmp;"
-              wifi-security.proto: "rsn;"
-              proxy._: ""
+              connection:
+                permissions: ""
+                autoconnect: "false"
+              wifi:
+                mac-address-blacklist: "" # wokeignore:rule=blacklist
+              wifi-security:
+                proto: "rsn;"
+                group: "ccmp;"
+                pairwise: "ccmp;"
+              ipv4:
+                dns-search: ""
+              ipv6:
+                addr-gen-mode: "1"
+                dns-search: ""
+              proxy: {{}}
       networkmanager:
         uuid: "{}"
         name: "Hotspot-1"
@@ -1041,7 +1068,8 @@ method=ignore
         uuid: "{}"
         name: "netplan-enblue"
         passthrough:
-          connection.interface-name: "enblue"
+          connection:
+            interface-name: "enblue"
 '''.format(UUID, UUID)})
 
     def test_keyfile_bridge(self):
@@ -1262,10 +1290,12 @@ ip6-privacy=0
         uuid: "{}"
         name: "gsm"
         passthrough:
-          ipv4.address1: "10.10.28.159/24"
-          ipv4.address2: "10.10.164.254/24"
-          ipv4.address3: "10.10.246.132/24"
-          ipv6.addr-gen-mode: "1"
+          ipv4:
+            address2: "10.10.164.254/24"
+            address1: "10.10.28.159/24"
+            address3: "10.10.246.132/24"
+          ipv6:
+            addr-gen-mode: "1"
 '''.format(UUID, UUID)})
 
     def test_keyfile_netplan0103_compat(self):
@@ -1359,18 +1389,22 @@ route4=5:6:7:8:9:0:1:2/62
         uuid: "{}"
         name: "Work Wired"
         passthrough:
-          connection.autoconnect: "false"
-          connection.permissions: ""
-          connection.timestamp: "305419896"
-          ethernet.mac-address-blacklist: "" # wokeignore:rule=blacklist
-          ipv4.address1: "192.168.0.5/24,192.168.0.1"
-          ipv4.dns-search: ""
-          ipv4.method: "manual"
-          ipv4.route4: "3.3.3.3/6,0.0.0.0,4"
-          ipv4.route4_options: "cwnd=10,mtu=1492,src=1.2.3.4"
-          ipv6.dns-search: "wallaceandgromit.com;"
-          ipv6.ip6-privacy: "1"
-          proxy._: ""
+          connection:
+            permissions: ""
+            autoconnect: "false"
+            timestamp: "305419896"
+          proxy: {{}}
+          ipv4:
+            route4_options: "cwnd=10,mtu=1492,src=1.2.3.4"
+            method: "manual"
+            dns-search: ""
+            address1: "192.168.0.5/24,192.168.0.1"
+            route4: "3.3.3.3/6,0.0.0.0,4"
+          ethernet:
+            mac-address-blacklist: "" # wokeignore:rule=blacklist
+          ipv6:
+            dns-search: "wallaceandgromit.com;"
+            ip6-privacy: "1"
 '''.format(UUID, UUID)})
 
     def test_keyfile_tunnel_regression_lp1952967(self):
@@ -1413,13 +1447,16 @@ method=auto
         uuid: "{}"
         name: "IP tunnel connection 1"
         passthrough:
-          connection.autoconnect: "false"
-          connection.interface-name: "gre10"
-          connection.permissions: ""
-          ipv4.dns-search: ""
-          ipv6.dns-search: ""
-          ipv6.ip6-privacy: "-1"
-          proxy._: ""
+          connection:
+            permissions: ""
+            autoconnect: "false"
+            interface-name: "gre10"
+          proxy: {{}}
+          ipv4:
+            dns-search: ""
+          ipv6:
+            dns-search: ""
+            ip6-privacy: "-1"
 '''.format(UUID, UUID)})
 
     def test_keyfile_ip6_privacy_default_netplan_0104_compat(self):
@@ -1451,7 +1488,8 @@ method=auto
         uuid: "{}"
         name: "Test"
         passthrough:
-          ipv6.ip6-privacy: "-1"
+          ipv6:
+            ip6-privacy: "-1"
 '''.format(UUID, UUID)})
 
     def test_keyfile_wpa3_sae(self):
@@ -1498,8 +1536,9 @@ method=auto
             uuid: "ff9d6ebc-226d-4f82-a485-b7ff83b9607f"
             name: "test2"
             passthrough:
-              ipv6.ip6-privacy: "-1"
-              proxy._: ""
+              proxy: {{}}
+              ipv6:
+                ip6-privacy: "-1"
       networkmanager:
         uuid: "{}"
         name: "test2"
@@ -1563,8 +1602,9 @@ method=auto
             uuid: "ff9d6ebc-226d-4f82-a485-b7ff83b9607f"
             name: "test2"
             passthrough:
-              ipv6.ip6-privacy: "-1"
-              proxy._: ""
+              proxy: {{}}
+              ipv6:
+                ip6-privacy: "-1"
       networkmanager:
         uuid: "{}"
         name: "test2"
@@ -1628,8 +1668,9 @@ method=auto
             uuid: "ff9d6ebc-226d-4f82-a485-b7ff83b9607f"
             name: "test2"
             passthrough:
-              ipv6.ip6-privacy: "-1"
-              proxy._: ""
+              proxy: {{}}
+              ipv6:
+                ip6-privacy: "-1"
       networkmanager:
         uuid: "{}"
         name: "test2"
@@ -1687,15 +1728,19 @@ dns-search=wallaceandgromit.com;
         uuid: "{}"
         name: "Work Wired"
         passthrough:
-          connection.autoconnect: "false"
-          connection.timestamp: "305419896"
-          ethernet.wake-on-lan: "1"
-          ipv4.method: "manual"
-          ipv4.address1: "192.168.0.5/24,192.168.0.1"
-          ipv6.addr-gen-mode: "1"
-          ipv6.dns-search: "wallaceandgromit.com;"
-          ipv6.ip6-privacy: "-1"
-          proxy._: ""
+          connection:
+            autoconnect: "false"
+            timestamp: "305419896"
+          proxy: {{}}
+          ipv4:
+            method: "manual"
+            address1: "192.168.0.5/24,192.168.0.1"
+          ethernet:
+            wake-on-lan: "1"
+          ipv6:
+            addr-gen-mode: "1"
+            dns-search: "wallaceandgromit.com;"
+            ip6-privacy: "-1"
 '''.format(UUID, UUID)})
 
     def test_keyfile_nm_140_default_ethernet_group(self):
@@ -1730,13 +1775,15 @@ method=auto
         uuid: "{}"
         name: "Test Write Bridge Main"
         passthrough:
-          ethernet._: ""
-          bridge._: ""
-          ipv4.address1: "1.2.3.4/24,1.1.1.1"
-          ipv4.method: "manual"
-          ipv6.addr-gen-mode: "default"
-          ipv6.ip6-privacy: "-1"
-          proxy._: ""
+          proxy: {{}}
+          ipv4:
+            method: "manual"
+            address1: "1.2.3.4/24,1.1.1.1"
+          ethernet: {{}}
+          bridge: {{}}
+          ipv6:
+            addr-gen-mode: "default"
+            ip6-privacy: "-1"
 '''.format(UUID)})
 
     def test_multiple_eap_methods(self):
@@ -1784,8 +1831,10 @@ method=auto\n'''.format(UUID))
             uuid: "{}"
             name: "MyWifi"
             passthrough:
-              wifi-security.auth-alg: "open"
-              802-1x.eap: "peap;tls"
+              wifi-security:
+                auth-alg: "open"
+              802-1x:
+                eap: "peap;tls"
       networkmanager:
         uuid: "{}"
         name: "MyWifi"
@@ -1836,7 +1885,8 @@ method=auto\n'''.format(UUID))
             uuid: "{}"
             name: "MyWifi"
             passthrough:
-              wifi-security.auth-alg: "open"
+              wifi-security:
+                auth-alg: "open"
       networkmanager:
         uuid: "{}"
         name: "MyWifi"
@@ -1862,7 +1912,8 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "wg0"
         passthrough:
-          connection.interface-name: "wg0"
+          connection:
+            interface-name: "wg0"
 '''.format(UUID, UUID)})
 
     def test_wireguard_with_key(self):
@@ -1890,7 +1941,8 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "wg0"
         passthrough:
-          connection.interface-name: "wg0"
+          connection:
+            interface-name: "wg0"
 '''.format(UUID, UUID)})
 
     def test_wireguard_with_key_and_peer(self):
@@ -1928,7 +1980,8 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "wg0"
         passthrough:
-          connection.interface-name: "wg0"
+          connection:
+            interface-name: "wg0"
 '''.format(UUID, UUID)})
 
     def test_wireguard_with_empty_endpoint(self):
@@ -1965,7 +2018,8 @@ method=auto\n'''.format(UUID), regenerate=False)
         uuid: "{}"
         name: "wg0"
         passthrough:
-          connection.interface-name: "wg0"
+          connection:
+            interface-name: "wg0"
 '''.format(UUID, UUID)})
 
     def test_wireguard_allowed_ips_without_prefix(self):
@@ -2008,7 +2062,8 @@ method=auto\n'''.format(UUID), regenerate=False)
         uuid: "{}"
         name: "wg0"
         passthrough:
-          connection.interface-name: "wg0"
+          connection:
+            interface-name: "wg0"
 '''.format(UUID, UUID)})
 
     def test_wireguard_with_key_flags(self):
@@ -2049,7 +2104,8 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "wg0"
         passthrough:
-          connection.interface-name: "wg0"
+          connection:
+            interface-name: "wg0"
 '''.format(UUID, UUID)})
 
     def test_wireguard_with_key_all_flags_enabled(self):
@@ -2092,7 +2148,8 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "wg0"
         passthrough:
-          connection.interface-name: "wg0"
+          connection:
+            interface-name: "wg0"
 '''.format(UUID, UUID)})
 
     def test_wireguard_with_key_and_peer_without_allowed_ips(self):
@@ -2127,7 +2184,8 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "wg0"
         passthrough:
-          connection.interface-name: "wg0"
+          connection:
+            interface-name: "wg0"
 '''.format(UUID, UUID)})
 
     def test_vxlan_with_local_and_remote(self):
@@ -2158,7 +2216,8 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "vxlan10"
         passthrough:
-          connection.interface-name: "vxlan10"
+          connection:
+            interface-name: "vxlan10"
 '''.format(UUID, UUID)})
 
     def test_simple_vxlan(self):
@@ -2185,7 +2244,8 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "vxlan10"
         passthrough:
-          connection.interface-name: "vxlan10"
+          connection:
+            interface-name: "vxlan10"
 '''.format(UUID, UUID)})
 
     def test_invalid_tunnel_mode(self):
@@ -2238,7 +2298,8 @@ dns-search='''.format(UUID))
             uuid: "{}"
             name: "myid with spaces"
             passthrough:
-              ipv4.dns-search: ""
+              ipv4:
+                dns-search: ""
       networkmanager:
         uuid: "{}"
         name: "myid with spaces"
@@ -2271,7 +2332,8 @@ dns-search='''.format(UUID))
         uuid: "{}"
         name: "myid with spaces"
         passthrough:
-          ipv4.dns-search: ""
+          ipv4:
+            dns-search: ""
 '''.format(UUID, UUID)})
 
     def test_veth_pair(self):
@@ -2297,7 +2359,8 @@ method=auto\n'''.format(UUID))
         uuid: "{}"
         name: "veth-peer1"
         passthrough:
-          connection.interface-name: "veth-peer1"
+          connection:
+            interface-name: "veth-peer1"
 '''.format(UUID, UUID)})
 
     def test_veth_without_peer(self):
@@ -2337,7 +2400,8 @@ method=link-local\n'''.format(UUID))
         uuid: "{}"
         name: "vrf0"
         passthrough:
-          connection.interface-name: "vrf0"
+          connection:
+            interface-name: "vrf0"
 '''.format(UUID, UUID)})
 
     def test_vrf_without_table_should_fail(self):
@@ -2422,11 +2486,13 @@ method=auto
         uuid: "{}"
         name: "ethernet-eth123"
         passthrough:
-          ethernet._: ""
-          ipv4.dns: "8.8.8.8;1.1.1.1#lxd;192.168.0.1#domain.local;"
-          ipv6.addr-gen-mode: "default"
-          ipv6.ip6-privacy: "-1"
-          proxy._: ""
+          proxy: {{}}
+          ipv4:
+            dns: "8.8.8.8;1.1.1.1#lxd;192.168.0.1#domain.local;"
+          ethernet: {{}}
+          ipv6:
+            addr-gen-mode: "default"
+            ip6-privacy: "-1"
 '''.format(UUID, UUID)})
 
     def test_ipv4_route_metric_is_overriden_when_dhcp4_is_disabled(self):
@@ -2461,12 +2527,15 @@ addr-gen-mode=default
         uuid: "{}"
         name: "dummy-123"
         passthrough:
-          connection.interface-name: "dummy123"
-          ipv4.method: "manual"
-          ipv4.address1: "100.85.0.1/24,100.85.0.1"
-          ipv6.addr-gen-mode: "default"
-          dummy._: ""
-          proxy._: ""
+          connection:
+            interface-name: "dummy123"
+          proxy: {{}}
+          ipv4:
+            method: "manual"
+            address1: "100.85.0.1/24,100.85.0.1"
+          ipv6:
+            addr-gen-mode: "default"
+          dummy: {{}}
 '''.format(UUID, UUID)})
 
     def test_ipv6_route_metric_is_overriden_when_dhcp6_is_disabled(self):
@@ -2501,12 +2570,15 @@ addr-gen-mode=default
         uuid: "{}"
         name: "dummy-123"
         passthrough:
-          connection.interface-name: "dummy123"
-          ipv4.method: "disabled"
-          ipv6.method: "manual"
-          ipv6.address1: "fdeb:446c:912d:8da::/64,fdeb:446c:912d:8da::1"
-          ipv6.addr-gen-mode: "default"
-          ipv6.ip6-privacy: "-1"
-          dummy._: ""
-          proxy._: ""
+          connection:
+            interface-name: "dummy123"
+          proxy: {{}}
+          ipv4:
+            method: "disabled"
+          ipv6:
+            addr-gen-mode: "default"
+            method: "manual"
+            address1: "fdeb:446c:912d:8da::/64,fdeb:446c:912d:8da::1"
+            ip6-privacy: "-1"
+          dummy: {{}}
 '''.format(UUID, UUID)})


### PR DESCRIPTION
## Description

This PR proposes a new format for the `networkmanager.passthrough` section. The new format was a suggestion from the [LP#2080301](https://bugs.launchpad.net/netplan/+bug/2080301) bug reporter. It addresses the problem reported in the bug and is future proof against similar problems.

The main problem with the currently used format is that it's ambiguous. The keyfile `[group].key=value` format is encoded as a string separated by dots. As dots can be used in the key name, it becomes tricky to separate what is the group and what is the key name. A different character could be used but we could eventually hit the same problem.

Arguably we could do something like `[group-name-between-brackets]key-name: value`. Brackets are forbidden in group names (I think?!). But it still would be a change in the format so I opted for turning each entry into mappings.

Here is how it looks like:

```yaml
  nm-devices:
    NM-4bf69677-e326-49b4-8e37-2acf3074f6c7:
      renderer: NetworkManager
      networkmanager:
        uuid: "4bf69677-e326-49b4-8e37-2acf3074f6c7"
        name: "tuntap7"
        passthrough:
          connection:
            type: "tun"
            autoconnect: "false"
            interface-name: "tuntap7"
          proxy: {}
          tun: {}
          ipv4:
            method: "manual"
            address1: "4.3.2.1/24,1.2.3.254"
            dns: "1.2.3.254;4.3.2.254;"
          ipv6:
            addr-gen-mode: "default"
            method: "manual"
            address1: "1:2:3::4/64,1:2:3::abcd"
            dns: "1:2:3::abcd;abcd:3:2::1;"
```

With the integration of netplan and Network Manager on Ubuntu, tweaking the passthrough configuration might be necessary every now and then due to things missing in netplan. This format makes it easier to do that.

The old format is still accepted for backwards compatibility. The parser still accepts it but will emit the new format. So YAMLs generated by Network Manager will be updated if the user modifies the connection and it will still work with existing YAMLs if they are never updated.

**IMPORTANT**: the `datalist` data structure was replaced with hash tables. This will make the order in which elements are added to keyfiles unpredictable. I'm not 100% sure that ordering would cause problems with configuration from the `passthrough` section. My main motivation to drop datalists is that [GQuarks might leak memory](https://github.com/GNOME/glib/blob/main/glib/gquark.c#L295). We hit this issue in our config_fuzzer test due to the number of GQuarks needed when a big number of entries are added to the datalist.

A couple of Network Manager autopkgtests are failing due to the change in the structure and will need to be fixed as well.

I understand it's a big change and we might decide to not merge it so I made it an RFC.

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

