### PR TITLE
wpa_supplicant: add ExecReload to the service unit

### DIFF
--- a/src/networkd.c
+++ b/src/networkd.c
@@ -1341,6 +1341,8 @@ write_wpa_unit(const NetplanNetDefinition* def, const char* rootdir)
         g_string_append(s, " -Dnl80211,wext\n");
     }
 
+    g_string_append_printf(s, "ExecReload=/sbin/wpa_cli -i %s reconfigure\n", stdouth);
+
     g_autofree char* new_s = _netplan_scrub_systemd_unit_contents(s->str);
     g_string_free(s, TRUE);
     s = g_string_new(new_s);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -99,6 +99,7 @@ Wants=network.target
 [Service]
 Type=simple
 ExecStart=/sbin/wpa_supplicant -c /run/netplan/wpa-%(iface)s.conf -i%(iface)s -D%(drivers)s
+ExecReload=/sbin/wpa_cli -i %(iface)s reconfigure
 '''
 NM_MANAGED = 'SUBSYSTEM=="net", ACTION=="add|change|move", ENV{ID_NET_NAME}=="%s", ENV{NM_UNMANAGED}="0"\n'
 NM_UNMANAGED = 'SUBSYSTEM=="net", ACTION=="add|change|move", ENV{ID_NET_NAME}=="%s", ENV{NM_UNMANAGED}="1"\n'


### PR DESCRIPTION
Add an ExecReload command to call "wpa_cli reconfigure" on the interface. With that we can use "systemctl reload" to reconfigure a wireless device without having to call stop/start.


## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

