### PR TITLE
networkmanager: add support for stable-ssid MAC option (LP: #2084234)

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -499,7 +499,7 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
   > "XX:XX:XX:XX:XX:XX". The following special options are also accepted:
   > `permanent` and `random`.
   > In addition to these options, the NetworkManager renderer also accepts
-  > `stable` and `preserve`.
+  > `stable`, `stable-ssid` (Wi-Fi only) and `preserve`.
   >
   > **Note:** This will not work reliably for devices matched by name
   > only and rendered by networkd, due to interactions with device

--- a/src/parse.c
+++ b/src/parse.c
@@ -392,7 +392,7 @@ handle_special_macaddress_option(NetplanParser* npp, yaml_node_t* node, void* en
     g_assert(entryptr != NULL);
     g_assert(node->type == YAML_SCALAR_NODE);
 
-    if (!_is_macaddress_special_nm_option(scalar(node)) &&
+    if (!_is_macaddress_special_nm_option(npp->current.netdef, scalar(node)) &&
         !_is_macaddress_special_nd_option(scalar(node)))
         return FALSE;
 
@@ -695,7 +695,7 @@ handle_netdef_set_mac(NetplanParser* npp, yaml_node_t* node, const void* data, G
         if (!handle_special_macaddress_option(npp, node, npp->current.netdef, data, NULL)) {
             return yaml_error(npp, node, error,
                               "Invalid MAC address '%s', must be XX:XX:XX:XX:XX:XX, XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX"
-                              " or one of 'permanent', 'random', 'stable', 'preserve'.",
+                              " or one of 'permanent', 'random', 'stable', 'preserve', 'stable-ssid' (Wi-Fi only).",
                               scalar(node));
         }
     }

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -136,7 +136,7 @@ gboolean
 _is_auth_key_management_psk(const NetplanAuthenticationSettings* auth);
 
 gboolean
-_is_macaddress_special_nm_option(const char* value);
+_is_macaddress_special_nm_option(const NetplanNetDefinition* netdef, const char* value);
 
 gboolean
 _is_macaddress_special_nd_option(const char* value);

--- a/src/util.c
+++ b/src/util.c
@@ -1239,12 +1239,13 @@ _is_auth_key_management_psk(const NetplanAuthenticationSettings* auth)
 }
 
 gboolean
-_is_macaddress_special_nm_option(const char* value)
+_is_macaddress_special_nm_option(const NetplanNetDefinition* netdef, const char* value)
 {
     return (   !g_strcmp0(value, "preserve")
             || !g_strcmp0(value, "permanent")
             || !g_strcmp0(value, "random")
-            || !g_strcmp0(value, "stable"));
+            || !g_strcmp0(value, "stable")
+            || (!g_strcmp0(value, "stable-ssid") && netdef->type == NETPLAN_DEF_TYPE_WIFI));
 }
 
 gboolean

--- a/tests/generator/test_ethernets.py
+++ b/tests/generator/test_ethernets.py
@@ -504,7 +504,21 @@ method=ignore
 
         error = ("Invalid MAC address 'preservetypo', must be XX:XX:XX:XX:XX:XX, "
                  "XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX or "
-                 "one of 'permanent', 'random', 'stable', 'preserve'")
+                 "one of 'permanent', 'random', 'stable', 'preserve', 'stable-ssid' (Wi-Fi only)")
+        self.assertIn(error, res)
+
+    def test_eth_set_mac_special_values_ethernet_stable_ssid(self):
+        res = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  ethernets:
+    eth0:
+      macaddress: stable-ssid
+      dhcp4: true''', expect_fail=True)
+
+        error = ("Invalid MAC address 'stable-ssid', must be XX:XX:XX:XX:XX:XX, "
+                 "XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX or "
+                 "one of 'permanent', 'random', 'stable', 'preserve', 'stable-ssid' (Wi-Fi only)")
         self.assertIn(error, res)
 
     def test_eth_match_by_driver(self):

--- a/tests/generator/test_wifis.py
+++ b/tests/generator/test_wifis.py
@@ -1114,6 +1114,42 @@ mode=infrastructure
             new_config = f.read()
             self.assertIn('ExecStart=/usr/sbin/iw reg set DE\n', new_config)
 
+    def test_wlan_set_mac_special_values(self):
+        self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  wifis:
+    wlan0:
+      macaddress: stable-ssid
+      dhcp4: true
+      access-points:
+        "mynetwork":
+          password: mypassword''')
+
+        self.assert_networkd(None)
+
+        self.assert_nm({'wlan0-mynetwork': '''[connection]
+id=netplan-wlan0-mynetwork
+type=wifi
+interface-name=wlan0
+
+[wifi]
+cloned-mac-address=stable-ssid
+ssid=mynetwork
+mode=infrastructure
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+
+[wifi-security]
+key-mgmt=wpa-psk
+pmf=2
+psk=mypassword
+'''})
+
 
 class TestConfigErrors(TestBase):
 


### PR DESCRIPTION
802-11-wireless.cloned-mac-address = stable-ssid was added in Network Manager 1.46 and is available through the GUI applet.

Fixes https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2084234

## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

