### PR TITLE
networkmanager: add support for "routing-policy" (LP: #2086544)

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -879,6 +879,9 @@ network:
     > Specify a priority for the routing policy rule, to influence the order
     > in which routing rules are processed. A higher number means lower
     > priority: rules are processed in order by increasing priority number.
+    > Specifying an explicit, unique, priority for each routing policy rule
+    > is strongly recommended and is mandatory on the `NetworkManager`
+    > back-end.
 
   - **`mark`** (scalar)
 

--- a/src/nm.c
+++ b/src/nm.c
@@ -254,6 +254,64 @@ write_routes_nm(const NetplanNetDefinition* def, GKeyFile *kf, gint family, GErr
             j++;
         }
     }
+
+    return TRUE;
+}
+
+STATIC gboolean
+write_ip_rules_nm(const NetplanNetDefinition* def, GKeyFile *kf, gint family, GError** error)
+{
+    const gchar* group = NULL;
+    gchar* tmp_key = NULL;
+    GString* tmp_val = NULL;
+
+    if (family == AF_INET)
+        group = "ipv4";
+    else if (family == AF_INET6)
+        group = "ipv6";
+    g_assert(group != NULL);
+
+    if (def->ip_rules != NULL) {
+        for (unsigned i = 0, j = 1; i < def->ip_rules->len; ++i) {
+            const NetplanIPRule *cur_rule = g_array_index(def->ip_rules, NetplanIPRule*, i);
+
+            if (cur_rule->family != family)
+                continue;
+
+            /* NetworkManager requires that priority be specified.  This is
+             * also in-line with the iproute2 guidance that "Each rule should
+             * have an explicitly set unique priority value"[1].
+             * [1]http://www.policyrouting.org/iproute2.doc.html#ss9.6.1 */
+            if (cur_rule->priority == NETPLAN_IP_RULE_PRIO_UNSPEC) {
+                g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED,
+                            "ERROR: %s: The priority setting is mandatory for NetworkManager routing-policy\n", def->id);
+                return FALSE;
+            }
+
+            tmp_key = g_strdup_printf("routing-rule%u", j);
+            tmp_val = g_string_sized_new(200);
+
+            g_string_printf(tmp_val, "priority %u", cur_rule->priority);
+
+            if (cur_rule->from)
+                g_string_append_printf(tmp_val, " from %s", cur_rule->from);
+            if (cur_rule->to)
+                g_string_append_printf(tmp_val, " to %s", cur_rule->to);
+            if (cur_rule->tos != NETPLAN_IP_RULE_TOS_UNSPEC)
+                g_string_append_printf(tmp_val, " tos %u", cur_rule->tos);
+            if (cur_rule->fwmark != NETPLAN_IP_RULE_FW_MARK_UNSPEC)
+                g_string_append_printf(tmp_val, " fwmark %u", cur_rule->fwmark);
+            if (cur_rule->table != NETPLAN_ROUTE_TABLE_UNSPEC)
+                g_string_append_printf(tmp_val, " table %u", cur_rule->table);
+
+            g_key_file_set_string(kf, group, tmp_key, tmp_val->str);
+            g_free(tmp_key);
+            g_string_free(tmp_val, TRUE);
+
+            j++;
+        }
+    }
+
     return TRUE;
 }
 
@@ -716,6 +774,8 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
             g_key_file_set_uint64(kf, "vrf", "table", def->vrf_table);
             if (!write_routes_nm(def, kf, AF_INET, error) || !write_routes_nm(def, kf, AF_INET6, error))
                 return FALSE;
+            if (!write_ip_rules_nm(def, kf, AF_INET, error) || !write_ip_rules_nm(def, kf, AF_INET6, error))
+                return FALSE;
         }
 
         if (def->type == NETPLAN_DEF_TYPE_VETH && def->veth_peer_link) {
@@ -871,6 +931,8 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
         write_search_domains(def, "ipv4", kf);
         if (!write_routes_nm(def, kf, AF_INET, error))
             return FALSE;
+        if (!write_ip_rules_nm(def, kf, AF_INET, error))
+            return FALSE;
     }
 
     if (!def->dhcp4_overrides.use_routes) {
@@ -915,6 +977,9 @@ write_nm_conf_access_point(const NetplanNetDefinition* def, const char* rootdir,
 
         /* We can only write valid routes if there is a DHCPv6 or static IPv6 address */
         if (!write_routes_nm(def, kf, AF_INET6, error))
+            return FALSE;
+
+        if (!write_ip_rules_nm(def, kf, AF_INET6, error))
             return FALSE;
 
         if (!def->dhcp6_overrides.use_routes) {

--- a/src/validation.c
+++ b/src/validation.c
@@ -526,7 +526,7 @@ adopt_and_validate_vrf_routes(__unused const NetplanParser *npp, GHashTable *net
                 if (r->table == nd->vrf_table) {
                     g_debug("%s: Ignoring redundant routing-policy table %d (matches VRF table)", nd->id, r->table);
                     continue;
-                } else if (r->table != NETPLAN_ROUTE_TABLE_UNSPEC && r->table != nd->vrf_table) {
+                } else if (r->table != NETPLAN_ROUTE_TABLE_UNSPEC) {
                     g_set_error(error, NETPLAN_VALIDATION_ERROR, NETPLAN_ERROR_CONFIG_GENERIC,
                             "%s: VRF routing-policy table mismatch (%d != %d)", nd->id, nd->vrf_table, r->table);
                     return FALSE;

--- a/src/validation.c
+++ b/src/validation.c
@@ -523,6 +523,9 @@ adopt_and_validate_vrf_routes(__unused const NetplanParser *npp, GHashTable *net
         if (nd->ip_rules) {
             for (size_t i = 0; i < nd->ip_rules->len; i++) {
                 NetplanIPRule* r = g_array_index(nd->ip_rules, NetplanIPRule*, i);
+                if (r->priority == NETPLAN_IP_RULE_PRIO_UNSPEC) {
+                    g_warning("%s: No priority specified for routing-policy %zu", nd->id, i);
+                }
                 if (r->table == nd->vrf_table) {
                     g_debug("%s: Ignoring redundant routing-policy table %d (matches VRF table)", nd->id, r->table);
                     continue;

--- a/tests/generator/test_vrfs.py
+++ b/tests/generator/test_vrfs.py
@@ -37,7 +37,8 @@ class NetworkManager(TestBase):
       - to: default
         via: 1.2.3.4
       routing-policy:
-      - from: 2.3.4.5''')
+      - from: 2.3.4.5
+        priority: 99''')
 
         self.assert_nm({'eth0': '''[connection]
 id=netplan-eth0
@@ -66,6 +67,7 @@ table=1005
 [ipv4]
 route1=0.0.0.0/0,1.2.3.4
 route1_options=table=1005
+routing-rule1=priority 99 from 2.3.4.5 table 1005
 method=link-local
 
 [ipv6]
@@ -224,3 +226,14 @@ From=2.3.4.5
 Table=1005
 ''',
                               'vrf1005.netdev': ND_VRF % ('vrf1005', 1005)})
+
+    def test_vrf_routing_policy_missing_priority_nm(self):
+        err = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  vrfs:
+    vrf1005:
+      table: 1005
+      routing-policy:
+      - from: 2.3.4.5''', expect_fail=True)
+        self.assertIn("ERROR: vrf1005: The priority setting is mandatory for NetworkManager routing-policy", err)

--- a/tests/integration/routing.py
+++ b/tests/integration/routing.py
@@ -317,6 +317,7 @@ class _CommonTests():
         via: 10.10.10.1
       routing-policy:
       - from: 10.10.10.42
+        priority: 99
 ''' % {'r': self.backend, 'ec': self.dev_e_client})
         self.generate_and_settle([self.dev_e_client])
         self.assert_iface_up(self.dev_e_client, ['inet 10.10.10.22', 'master vrf0'])  # wokeignore:rule=master
@@ -332,10 +333,8 @@ class _CommonTests():
         self.assertIn('11.11.11.0/24 via 10.10.10.2 dev {}'.format(self.dev_e_client), out)
 
         # verify routing policy was setup correctly to the VRF's table
-        # 'routing-policy' is not supported on NetworkManager
-        if self.backend == 'networkd':
-            out = subprocess.check_output(['ip', 'rule', 'show'], text=True)
-            self.assertIn('from 10.10.10.42 lookup 1000', out)
+        out = subprocess.check_output(['ip', 'rule', 'show'], text=True)
+        self.assertIn('from 10.10.10.42 lookup 1000', out)
 
     def test_route_advmss_v6(self):
         self.setup_eth(None)


### PR DESCRIPTION
## Description

NetworkManager supports ip rules via the "routing-ruleX" field.  Let's teach the networkmanager backend to emit "routing-ruleX" entries for each "routing-policy" entry in the netplan yaml.

For example, the following netplan configuration snippet:

```
    eth0:
      addresses:
      - "10.1.2.3/24"
      routing-policy:
        - to: 8.7.6.5
          table: 254
          priority: 10
        - to: 1.2.3.4
          from: 8.7.6.5
          table: 253
          mark: 18
          type-of-service: 4
          priority: 11
```

..should generate something like the following in the NetworkManager configuration:

```
    [ipv4]
    method=manual
    address1=10.1.2.3/24
    routing-rule1=to 8.7.6.5 table 254 priority 10
    routing-rule2=from 8.7.6.5 to 1.2.3.4 tos 4 fwmark 18 table 253 priority 11
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.
  - https://bugs.launchpad.net/netplan/+bug/2086544
