### PR TITLE
CI: Fix fedora:latest (F41) failure

### DIFF
--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -34,4 +34,4 @@ jobs:
           dnf -y builddep rpm/netplan.spec
           adduser test
           chown -R test:test .
-          su test -c 'rpmbuild -bi --build-in-place rpm/netplan.spec'
+          su test -c 'rpmbuild -bi -D "debug_package %{nil}" --build-in-place rpm/netplan.spec'

--- a/src/parse.c
+++ b/src/parse.c
@@ -1909,7 +1909,7 @@ handle_vxlan_tristate(NetplanParser* npp, yaml_node_t* node, const void* data, G
 STATIC int
 get_ip_family(const char* address)
 {
-    g_autofree char *ip_str;
+    g_autofree char *ip_str = NULL;
     char *prefix_len;
 
     ip_str = g_strdup(address);


### PR DESCRIPTION
## Description
Ignore debuginfo packages in our local CI to avoid this error:

```
Processing files: netplan-debugsource-0.106-0.fc41.x86_64 error: Empty %files file /home/test/rpmbuild/BUILD/netplan-0.106-build/netplan-0.106/debugsourcefiles.list
    Empty %files file /home/test/rpmbuild/BUILD/netplan-0.106-build/netplan-0.106/debugsourcefiles.list
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

