### PR TITLE
Do not execute generator during daemon-reload

### DIFF
--- a/src/generate.c
+++ b/src/generate.c
@@ -236,7 +236,9 @@ int main(int argc, char** argv)
             g_fprintf(stderr, "%s can not be called directly, use 'netplan generate'.", argv[0]);
             return 1;
         }
-        generator_run_stamp = g_build_path(G_DIR_SEPARATOR_S, files[0], "netplan.stamp", NULL);
+        /* Write generator.stamp in /run/netplan/generator.stamp, this is due to
+         * /run/systemd/generator/... being cleaned on every daemon-reload. */
+        generator_run_stamp = g_build_path(G_DIR_SEPARATOR_S, rootdir, "run", "netplan", "generator.stamp", NULL);
         if (g_access(generator_run_stamp, F_OK) == 0) {
             g_fprintf(stderr, "netplan generate already ran, remove %s to force re-run\n", generator_run_stamp);
             return 0;
@@ -318,6 +320,7 @@ int main(int argc, char** argv)
 
         /* Leave a stamp file so that we don't regenerate the configuration
          * multiple times and userspace can wait for it to finish */
+        _netplan_safe_mkdir_p_dir(generator_run_stamp);
         FILE* f = fopen(generator_run_stamp, "w");
         g_assert(f != NULL);
         fclose(f);

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -222,7 +222,8 @@ ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i eth99.4
 
         # after removing the stamp it generates again, and not trip over the
         # existing enablement symlink
-        os.unlink(os.path.join(outdir, 'netplan.stamp'))
+        run_netplan = os.path.join(self.workdir.name, 'run', 'netplan')
+        os.unlink(os.path.join(run_netplan, 'generator.stamp'))
         subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir])
         self.assertTrue(os.path.exists(n))
 
@@ -340,7 +341,7 @@ ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i br0
 
         subprocess.check_call([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir])
         # no enablement symlink here
-        self.assertEqual(os.listdir(outdir), ['netplan.stamp'])
+        self.assertEqual(os.listdir(outdir), [])
 
     def test_systemd_generator_badcall(self):
         outdir = os.path.join(self.workdir.name, 'out')
@@ -409,6 +410,7 @@ ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i a \\; b
 
         # after removing the stamp it generates again, and not trip over the
         # existing enablement symlink
-        os.unlink(os.path.join(outdir, 'netplan.stamp'))
+        run_netplan = os.path.join(self.workdir.name, 'run', 'netplan')
+        os.unlink(os.path.join(run_netplan, 'generator.stamp'))
         subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir])
         self.assertTrue(os.path.exists(n))

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -127,7 +127,7 @@ class IntegrationTestsBase(unittest.TestCase):
         subprocess.call(['udevadm', 'trigger', '--attr-match=subsystem=net'])
         subprocess.call(['udevadm', 'settle'])
         try:
-            os.remove('/run/systemd/generator/netplan.stamp')
+            os.remove('/run/netplan/generator.stamp')
         except FileNotFoundError:
             pass
         # Keep the management network (eth0/ens3 from 20-wired.network) up


### PR DESCRIPTION
## Description
As intended when originally implemented the netplan generator.stamp is supposed to avoid re-generating all of the Netplan configuration during 'systemd daemon-reload'.

The stamp has originally been placed in /run/systemd/generator/, which is nowadays cleaned during 'daemon-reload', leading to Netplan regenerating its configuration during each such call.

Let's move the stamp file into /run/netplan/generator.stamp instead to avoid that. Triggering the Netplan generator only at reboot, or when called explicitly.

Original intend: d2a45b3066cb20f8cfeb3e778af025ecdfbc6461

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

