### PR TITLE
parse: fix renderer validation for nm-devices (LP: #2091755)

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -3376,11 +3376,6 @@ handle_network_type(NetplanParser* npp, yaml_node_t* node, const char* key_prefi
             case NETPLAN_DEF_TYPE_NM:
                 g_debug("netplan: %s: handling NetworkManager passthrough device, settings are not fully supported.", npp->current.netdef->id);
                 handlers = ethernet_def_handlers;
-                if (npp->current.netdef->backend != NETPLAN_BACKEND_NM) {
-                    g_debug("nm-device: %s: the renderer for nm-devices must be NetworkManager, it will be used instead of the defined one.",
-                              npp->current.netdef->id);
-                    npp->current.netdef->backend = NETPLAN_BACKEND_NM;
-                }
                 break;
             default: g_assert_not_reached(); // LCOV_EXCL_LINE
         }
@@ -3407,6 +3402,12 @@ handle_network_type(NetplanParser* npp, yaml_node_t* node, const char* key_prefi
             } else {
                 return FALSE;
             }
+        }
+
+        if (npp->current.netdef->type == NETPLAN_DEF_TYPE_NM && npp->current.netdef->backend != NETPLAN_BACKEND_NM) {
+            g_debug("nm-device: %s: the renderer for nm-devices must be NetworkManager, it will be used instead of the defined one.",
+                    npp->current.netdef->id);
+            npp->current.netdef->backend = NETPLAN_BACKEND_NM;
         }
 
         /* Postprocessing */


### PR DESCRIPTION
When we process a nm-device we check to see if the renderer is NetworkManager. If it's not set to NetworkManager we log a warning message and change the backend.

This verification can be only done after the netdef is processed. Move the verification so it happens after the call to process_mapping().

Fixes LP: #2091755

Reproducer:

```yaml
network:
  version: 2
  nm-devices:
    NM-db5f0f67-1f4c-4d59-8ab8-3d278389cf87:
      renderer: NetworkManager
      networkmanager:
        uuid: "db5f0f67-1f4c-4d59-8ab8-3d278389cf87"
        name: "myvpnconnection"
        passthrough:
          connection.type: "vpn"
```

```
$ netplan --debug get --root-dir /tmp/fakeroot
** (process:70728): DEBUG: 15:57:33.741: starting new processing pass
** (process:70728): DEBUG: 15:57:33.741: netplan: NM-db5f0f67-1f4c-4d59-8ab8-3d278389cf87: handling NetworkManager passthrough device, settings are not fully supported.
** (process:70728): DEBUG: 15:57:33.741: nm-device: NM-db5f0f67-1f4c-4d59-8ab8-3d278389cf87: the renderer for nm-devices must be NetworkManager, it will be used instead of the defined one.
** (process:70728): DEBUG: 15:57:33.741: We have some netdefs, pass them through a final round of validation
** (process:70728): DEBUG: 15:57:33.741: Configuration is valid
network:
  version: 2
  nm-devices:
    NM-db5f0f67-1f4c-4d59-8ab8-3d278389cf87:
      renderer: NetworkManager
      networkmanager:
        uuid: "db5f0f67-1f4c-4d59-8ab8-3d278389cf87"
        name: "myvpnconnection"
        passthrough:
          connection.type: "vpn"
```

Note that the message `the renderer for nm-devices must be NetworkManager, it will be used instead of the defined one` is present even though the renderer is explicitly set to NetworkManager.

## Description


## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

