### PR TITLE
Utilize sd-nd-wait-online for waiting on DNS servers

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -48,6 +48,7 @@ jobs:
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
           sed -i 's|iproute2,|iproute2, ethtool,|' debian/control  # add ethtool as a dependency of netplan.io temporarily
+          sed -i 's|systemd (>= 257.2-3ubuntu1~),|systemd (>= 248~),|g' debian/control  # see https://github.com/canonical/netplan/pull/535
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"

--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -41,6 +41,7 @@ jobs:
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
+          sed -i 's|systemd (>= 257.2-3ubuntu1~),|systemd (>= 248~),|g' debian/control  # see https://github.com/canonical/netplan/pull/535
           echo "3.0 (native)" > debian/source/format  # force native build
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -207,12 +207,13 @@ class TestConfigArgs(TestBase):
             # eth99 does not exist on the system, so will not be listed
             self.assertEqual(f.read(), '''[Unit]
 ConditionPathIsSymbolicLink=/run/systemd/generator/network-online.target.wants/systemd-networkd-wait-online.service
+After=systemd-resolved.service
 
 [Service]
 ExecStart=
 ExecStart=/lib/systemd/systemd-networkd-wait-online -i eth99.43:carrier -i lo:carrier \
 -i eth99.42:carrier -i eth99.44:degraded -i bond0:degraded
-ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i eth99.43 -i eth99.45 -i bond0\n''')
+ExecStart=/lib/systemd/systemd-networkd-wait-online --any --dns -o routable -i eth99.43 -i eth99.45 -i bond0\n''')
 
         # should be a no-op the second time while the stamp exists
         out = subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir],
@@ -323,11 +324,12 @@ ExecStart=/lib/systemd/systemd-networkd-wait-online -i eth99.44:degraded
         with open(override, 'r') as f:
             self.assertEqual(f.read(), '''[Unit]
 ConditionPathIsSymbolicLink=/run/systemd/generator/network-online.target.wants/systemd-networkd-wait-online.service
+After=systemd-resolved.service
 
 [Service]
 ExecStart=
 ExecStart=/lib/systemd/systemd-networkd-wait-online -i br0:degraded
-ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i br0
+ExecStart=/lib/systemd/systemd-networkd-wait-online --any --dns -o routable -i br0
 ''')
 
     def test_systemd_generator_noconf(self):
@@ -395,11 +397,12 @@ ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i br0
             # eth99 does not exist on the system, so will not be listed
             self.assertEqual(f.read(), '''[Unit]
 ConditionPathIsSymbolicLink=/run/systemd/generator/network-online.target.wants/systemd-networkd-wait-online.service
+After=systemd-resolved.service
 
 [Service]
 ExecStart=
 ExecStart=/lib/systemd/systemd-networkd-wait-online -i a \\; b\\t; c\\t; d \\n 123 \\; echo :degraded
-ExecStart=/lib/systemd/systemd-networkd-wait-online --any -o routable -i a \\; b\\t; c\\t; d \\n 123 \\; echo \n''')
+ExecStart=/lib/systemd/systemd-networkd-wait-online --any --dns -o routable -i a \\; b\\t; c\\t; d \\n 123 \\; echo \n''')
 
         # should be a no-op the second time while the stamp exists
         out = subprocess.check_output([generator, '--root-dir', self.workdir.name, outdir, outdir, outdir],


### PR DESCRIPTION
## Description
networkd: wait-online wait for DNS servers to be assigned
    
As implemented in systemd (v258):
https://github.com/systemd/systemd/pull/34640

Spec: https://discourse.ubuntu.com/t/spec-definition-of-an-online-system/27838
Follow-up to: https://github.com/canonical/netplan/pull/482 https://github.com/canonical/netplan/pull/456

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

