### PR TITLE
cli:apply: Ignore udevadm errors triggering devices (LP: #2095203)

### DIFF
--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -256,7 +256,7 @@ class NetplanApply(utils.NetplanCommand):
         try:
             subprocess.check_call(['udevadm', 'trigger', '--action=move', '--subsystem-match=net', '--settle'])
         except subprocess.CalledProcessError as e:
-            logging.warning("Ignoring device trigger error: {}".format(e))
+            logging.warning('Ignoring device trigger error: {}'.format(e))
 
         # apply any SR-IOV related changes, if applicable
         NetplanApply.process_sriov_config(config_manager, exit_on_error)

--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -252,7 +252,11 @@ class NetplanApply(utils.NetplanCommand):
                                       stderr=subprocess.DEVNULL)
 
         subprocess.check_call(['udevadm', 'control', '--reload'])
-        subprocess.check_call(['udevadm', 'trigger', '--action=move', '--subsystem-match=net', '--settle'])
+
+        try:
+            subprocess.check_call(['udevadm', 'trigger', '--action=move', '--subsystem-match=net', '--settle'])
+        except subprocess.CalledProcessError as e:
+            logging.warning("Ignoring device trigger error: {}".format(e))
 
         # apply any SR-IOV related changes, if applicable
         NetplanApply.process_sriov_config(config_manager, exit_on_error)

--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -256,6 +256,8 @@ class NetplanApply(utils.NetplanCommand):
         try:
             subprocess.check_call(['udevadm', 'trigger', '--action=move', '--subsystem-match=net', '--settle'])
         except subprocess.CalledProcessError as e:
+            # udevadm trigger returns 1 if it cannot trigger devices since
+            # systemd v248, e.g. in containers (LP: #2095203)
             logging.warning('Ignoring device trigger error: {}'.format(e))
 
         # apply any SR-IOV related changes, if applicable


### PR DESCRIPTION
Fixes LP: [#2095203](https://bugs.launchpad.net/netplan/+bug/2095203)

## Description
This is a first draft to get the discussion going as requested in the LP. Based on the `udevadm` teardown from the [related snapd PR](https://github.com/canonical/snapd/pull/11056#pullrequestreview-806332045), I think this is very unlikely to cause a regression.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] ~~New/changed keys in YAML format are documented.~~
- [ ] ~~\(Optional\) Adds example YAML for new feature.~~
- [x] \(Optional\) Closes an open bug in Launchpad. LP#2095203

