### PR TITLE
tests:wifi: Replace deprecated ISC dhclient & fail properly

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -48,6 +48,7 @@ jobs:
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
           sed -i 's|iproute2,|iproute2, ethtool,|' debian/control  # add ethtool as a dependency of netplan.io temporarily
+          sed -i 's|systemd (>= 257.2-3ubuntu1~),|systemd (>= 248~),|g' debian/control  # see https://github.com/canonical/netplan/pull/535
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision
           VER="$TAG+git~$REV"

--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -58,4 +58,5 @@ jobs:
           autopkgtest . -U \
             --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 \
             --env=NETPLAN_PARSER_IGNORE_ERRORS=1 \
-            -- lxd autopkgtest/ubuntu/noble/amd64
+            -- lxd autopkgtest/ubuntu/noble/amd64 \
+            || test $? -eq 2  # allow wifi test to be skipped (exit code = 2)

--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -41,6 +41,7 @@ jobs:
           pull-lp-source netplan.io
           cp -r netplan.io-*/debian .
           rm -r debian/patches/  # clear any distro patches
+          sed -i 's|systemd (>= 257.2-3ubuntu1~),|systemd (>= 248~),|g' debian/control  # see https://github.com/canonical/netplan/pull/535
           echo "3.0 (native)" > debian/source/format  # force native build
           TAG=$(git describe --tags $(git rev-list --tags --max-count=1))  # find latest (stable) tag
           REV=$(git rev-parse --short HEAD)  # get current git revision

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -558,7 +558,8 @@ class IntegrationTestsWifi(IntegrationTestsBase):
     @classmethod
     def setUpClass(klass):
         super().setUpClass()
-        # ensure we have this so that iw works
+        klass.orig_country = None
+        # ensure we have cfg80211 so that iw works
         try:
             subprocess.check_call(['modprobe', 'cfg80211'])
             # set regulatory domain "EU", so that we can use 80211.a 5 GHz channels
@@ -567,20 +568,34 @@ class IntegrationTestsWifi(IntegrationTestsBase):
             assert m
             klass.orig_country = m.group(1)
             subprocess.check_call(['iw', 'reg', 'set', 'EU'])
-        except Exception:
-            raise unittest.SkipTest("cfg80211 (wireless) is unavailable, can't test")
+        except subprocess.CalledProcessError:
+            print('cfg80211 (wireless) is unavailable, can\'t test', file=sys.stderr)
+            raise
 
     @classmethod
     def tearDownClass(klass):
-        subprocess.check_call(['iw', 'reg', 'set', klass.orig_country])
+        if klass.orig_country is not None:
+            subprocess.check_call(['iw', 'reg', 'set', klass.orig_country])
         super().tearDownClass()
 
     @classmethod
     def create_devices(klass):
         '''Create Access Point and Client devices with mac80211_hwsim and veth'''
+        # TODO: Consider using some trickery, to allow loading modules on the
+        # host by name/alias from within a container.
+        # https://github.com/weaveworks/weave/issues/3115
+        # https://x.com/lucabruno/status/902934379835662336
+        # https://github.com/docker-library/docker/blob/master/modprobe.sh  # wokeignore:rule=master
+        # https://github.com/torvalds/linux/blob/master/net/core/dev_ioctl.c:dev_load()  # wokeignore:rule=master
+        # e.g. via netdev ioctl SIOCGIFINDEX:
+        # https://github.com/weaveworks/go-odp/blob/master/odp/dpif.go#L67  # wokeignore:rule=master
+        #
+        # Or alternatively, port the WiFi testing to virt_wifi, which can be
+        # auto-loaded via "ip link add link eth0 name wlan42 type virt_wifi"
+        # inside a (privileged) LXC container, as used by autopkgtest.
+
         if os.path.exists('/sys/module/mac80211_hwsim'):
             raise SystemError('mac80211_hwsim module already loaded')
-        super().create_devices()
         # create virtual wlan devs
         before_wlan = set([c for c in os.listdir('/sys/class/net') if c.startswith('wlan')])
         subprocess.check_call(['modprobe', 'mac80211_hwsim'])
@@ -602,6 +617,7 @@ class IntegrationTestsWifi(IntegrationTestsBase):
         # don't let NM trample over our fake AP
         with open('/etc/NetworkManager/conf.d/99-test-denylist-wifi.conf', 'w') as f:
             f.write('[keyfile]\nunmanaged-devices+=%s\n' % klass.dev_w_ap)
+        super().create_devices()
 
     @classmethod
     def shutdown_devices(klass):

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -34,6 +34,7 @@ import sys
 import tempfile
 import time
 import unittest
+import pathlib
 
 import gi
 
@@ -209,6 +210,9 @@ class IntegrationTestsBase(unittest.TestCase):
         self.workdir = self.workdir_obj.name
         self.config = '/etc/netplan/01-main.yaml'
         os.makedirs('/etc/netplan', exist_ok=True)
+        # prepare common config file with proper permissions
+        pathlib.Path(self.config).touch()
+        os.chmod(self.config, 0o600)
 
         # create static entropy file to avoid draining/blocking on /dev/random
         self.entropy_file = os.path.join(self.workdir, 'entropy')

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -88,7 +88,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
             f.write('''network:
   renderer: %(r)s
   version: 2''' % {'r': self.backend})
-            os.chmod(self.config, mode=0o600)
         p = subprocess.Popen(['netplan', 'try'], bufsize=1, text=True,
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(2)
@@ -103,7 +102,6 @@ class TestNetworkd(IntegrationTestsBase, _CommonTests):
             f.write('''network:
   renderer: %(r)s
   version: 2''' % {'r': self.backend})
-            os.chmod(self.config, mode=0o600)
         p = subprocess.Popen(['netplan', 'try'], bufsize=1, text=True,
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         time.sleep(2)
@@ -151,7 +149,6 @@ class TestNetworkManager(IntegrationTestsBase, _CommonTests):
     br54:
       addresses:
       - "10.0.0.20/24"''' % {'r': self.backend})
-            os.chmod(self.config, mode=0o600)
         del os.environ['PATH']  # clear PATH, to test for LP: #1959570
         p = subprocess.Popen(['/usr/sbin/netplan', 'try'], bufsize=1, text=True,
                              stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/tests/integration/wifi.py
+++ b/tests/integration/wifi.py
@@ -209,9 +209,9 @@ class TestNetworkManager(IntegrationTestsWifi, _CommonTests):
         # connect the other end
         subprocess.check_call(['ip', 'link', 'set', self.dev_w_ap, 'up'])
         subprocess.check_call(['iw', 'dev', self.dev_w_ap, 'connect', 'fake net'])
-        out = subprocess.check_output(['dhclient', '-1', '-v', self.dev_w_ap],
+        out = subprocess.check_output(['dhcpcd', '-w', '-d', self.dev_w_ap],
                                       stderr=subprocess.STDOUT, text=True)
-        self.assertIn('DHCPACK', out)
+        self.assertIn('acknowledged 10.', out)
         out = subprocess.check_output(['iw', 'dev', self.dev_w_ap, 'info'],
                                       text=True)
         self.assertIn('type managed', out)


### PR DESCRIPTION
## Description
* [tests:wifi: use dhcpcd istead of deprecated ISC dhclient](https://github.com/canonical/netplan/pull/541/commits/85402e3d7340043cb65434fa6bc2030703faa921)
  We cannot rely blindly on ISC `dhclient` (which is deprecated and not pre-installed in Ubuntu anymore) leading to failures, like:
```
2315s ======================================================================
2315s ERROR: test_wifi_ap_open (__main__.TestNetworkManager.test_wifi_ap_open)
2315s ----------------------------------------------------------------------
2315s Traceback (most recent call last):
2315s   File "/tmp/autopkgtest.M08ut1/build.PMg/src/tests/integration/wifi.py", line 175, in test_wifi_ap_open
2315s     out = subprocess.check_output(['dhclient', '-1', '-v', self.dev_w_ap],
2315s           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2315s   File "/usr/lib/python3.12/subprocess.py", line 466, in check_output
2315s     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
2315s            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2315s   File "/usr/lib/python3.12/subprocess.py", line 548, in run
2315s     with Popen(*popenargs, **kwargs) as process:
2315s          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2315s   File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
2315s     self._execute_child(args, executable, preexec_fn, close_fds,
2315s   File "/usr/lib/python3.12/subprocess.py", line 1955, in _execute_child
2315s     raise child_exception_type(errno_num, err_msg, err_filename)
2315s FileNotFoundError: [Errno 2] No such file or directory: 'dhclient'
```
* [tests:wifi: Fail properly, don't indicate 'OK (skipped=all) PASS'](https://github.com/canonical/netplan/pull/541/commits/2d833adaa554710263ecf82c73a3bb3ce64a0a4b)
  Also, we should not just SKIP tests which then report as Success (OK/PASS), but rather check the conditions (ability to `modprobe cfg80211` & `modprobe mac80211_hwsim`) and SKIP if those are not given. Avoiding false-positives like this:
```
2278s setUpClass (__main__.TestNetworkManager) ... skipped "cfg80211 (wireless) is unavailable, can't test"
2278s modprobe: FATAL: Module cfg80211 not found in directory /lib/modules/6.11.0-8-generic
2278s setUpClass (__main__.TestNetworkd) ... skipped "cfg80211 (wireless) is unavailable, can't test"
2278s 
2278s ----------------------------------------------------------------------
2278s Ran 0 tests in 0.895s
2278s 
2278s OK (skipped=2)
2278s modprobe: FATAL: Module cfg80211 not found in directory /lib/modules/6.11.0-8-generic
2279s autopkgtest [01:33:19]: test wifi: -----------------------]
2279s autopkgtest [01:33:19]: test wifi:  - - - - - - - - - - results - - - - - - - - - -
2279s wifi                 PASS
```




This should go hand-in-hand with (and CI will only PASS again, once that's in Debian testing / Ubuntu devel):
* "d/t/control: Avoid flaky 'wifi' DEP8 test, instead, SKIP if conditions are not met"
  https://salsa.debian.org/debian/netplan.io/-/commit/268f63ed128af009e8e6778643db93bdd4fc1d4f
* "d/t/control: Add test dependency on dhcpcd-base, replacing ISC dhclient"
  https://salsa.debian.org/debian/netplan.io/-/commit/51bc66b47ad065eb1651d3e9391492c88a3ba949

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

