### PR TITLE
cli:apply: skip apply rename when predictable interface names disabled

### DIFF
--- a/netplan_cli/cli/utils.py
+++ b/netplan_cli/cli/utils.py
@@ -236,6 +236,14 @@ def get_interface_macaddress(interface: str) -> Optional[str]:
     return mac
 
 
+def get_kernel_cmdline() -> str:
+    try:
+        with open('/proc/cmdline') as f:
+            return f.read().strip()
+    except Exception:
+        return ""
+
+
 def find_matching_iface(interfaces: list, netdef):
     assert isinstance(netdef, NetDefinition)
     assert netdef._has_match


### PR DESCRIPTION
## skip apply udev rules rename when predictable interface names disabled

* skip net_setup_link when predictable interface names disabled
* `devices_after_udev = utils.get_interfaces()` will be useless when `changes` is  empty， add a check

## Checklist

- [x] Runs `make check` successfully.
- [ ] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

