### PR TITLE
doc: Add file extension note in yaml spec

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1,5 +1,9 @@
 # YAML configuration
 
+```{note}
+Netplan configuration files must use the `.yaml` extension; `.yml` files will not be read.
+```
+
 ## Top-level configuration structure
 
 The general structure of a Netplan YAML file is shown below.


### PR DESCRIPTION
Increase the visibility of [LP#1815734](https://bugs.launchpad.net/netplan/+bug/1815734)

## Description
It is out of scope for me to fix this properly (either by allowing `.yml` or emitting a warning when we see them), but this at least calls it out explicitly in the docs; every other mention is implicit (`/{lib,etc,run}/netplan/*.yaml`). 

## Checklist

- [ ] ~~Runs `make check` successfully.~~
- [ ] ~~Retains code coverage (`make check-coverage`).~~
- [ ] ~~New/changed keys in YAML format are documented.~~
- [ ] ~~\(Optional\) Adds example YAML for new feature.~~
- [x] \(Optional\) ~~Closes~~Addresses an open bug in Launchpad.

