### PR TITLE
Fix function prototypes for *_new() functions of parser and state

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -35,7 +35,7 @@
  * @return  An empty @ref NetplanParser
  */
 NETPLAN_PUBLIC NetplanParser*
-netplan_parser_new();
+netplan_parser_new(void);
 
 /**
  * @brief   Reset a @ref NetplanParser to its initial default values.

--- a/include/state.h
+++ b/include/state.h
@@ -31,7 +31,7 @@
  * @return  An empty @ref NetplanState
  */
 NETPLAN_PUBLIC NetplanState*
-netplan_state_new();
+netplan_state_new(void);
 
 /**
  * @brief   Reset a @ref NetplanState to its initial default values.


### PR DESCRIPTION
The state.h and parse.h files are part of the public api of libnetplan. These function prototypes declared there should adhere the c-standard.
Function prototypes for functions that don't take any parameters should have `void` as the parameter list. Function prototypes with an empty parameter list are treated by the compiler as accepting any arbitrary parameter.

