### PR TITLE
Fix `netplan try` revert (LP: #2083029)

### DIFF
--- a/netplan_cli/cli/commands/try_command.py
+++ b/netplan_cli/cli/commands/try_command.py
@@ -139,7 +139,7 @@ class NetplanTry(utils.NetplanCommand):
         tempdir = tempfile.mkdtemp()
         confdir = os.path.join(tempdir, 'etc', 'netplan')
         os.makedirs(confdir)
-        self.config_manager._copy_tree('/etc/netplan', confdir, dirs_exist_ok=True)
+        self.config_manager.copy_tree('/etc/netplan', confdir, dirs_exist_ok=True)
         # restore previous state
         self.config_manager.revert()
         NetplanApply().command_apply(run_generate=False, sync=True, exit_on_error=False, state_dir=tempdir)

--- a/netplan_cli/cli/commands/try_command.py
+++ b/netplan_cli/cli/commands/try_command.py
@@ -139,7 +139,7 @@ class NetplanTry(utils.NetplanCommand):
         tempdir = tempfile.mkdtemp()
         confdir = os.path.join(tempdir, 'etc', 'netplan')
         os.makedirs(confdir)
-        shutil.copytree('/etc/netplan', confdir, dirs_exist_ok=True)
+        self.config_manager._copy_tree('/etc/netplan', confdir, dirs_exist_ok=True)
         # restore previous state
         self.config_manager.revert()
         NetplanApply().command_apply(run_generate=False, sync=True, exit_on_error=False, state_dir=tempdir)

--- a/netplan_cli/configmanager.py
+++ b/netplan_cli/configmanager.py
@@ -153,12 +153,18 @@ class ConfigManager(object):
 
     def _copy_tree(self, src, dst, missing_ok=False):
         try:
-            shutil.copytree(src, dst)
+            shutil.copytree(src, dst, copy_function=copy_with_ownership)
         except FileNotFoundError:
             if missing_ok:
                 pass
             else:
                 raise
+
+
+def copy_with_ownership(src, dst, follow_symlinks=True):
+    shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
+    stat = os.stat(src, follow_symlinks=follow_symlinks)
+    os.chown(dst, stat.st_uid, stat.st_gid, follow_symlinks=follow_symlinks)
 
 
 class ConfigurationError(Exception):

--- a/netplan_cli/configmanager.py
+++ b/netplan_cli/configmanager.py
@@ -89,6 +89,7 @@ class ConfigManager(object):
         # Convoluted way to dump the parsed config to the logs...
         with tempfile.TemporaryFile() as tmp:
             self.np_state._dump_yaml(output_file=tmp)
+            tmp.seek(0)
             logging.debug("Merged config:\n{}".format(tmp.read()))
 
         return self.np_state

--- a/netplan_cli/configmanager.py
+++ b/netplan_cli/configmanager.py
@@ -151,9 +151,9 @@ class ConfigManager(object):
     def _copy_file(self, src, dst):
         shutil.copy(src, dst)
 
-    def _copy_tree(self, src, dst, missing_ok=False):
+    def _copy_tree(self, src, dst, missing_ok=False, **kwargs):
         try:
-            shutil.copytree(src, dst, copy_function=copy_with_ownership)
+            shutil.copytree(src, dst, copy_function=copy_with_ownership, **kwargs)
         except FileNotFoundError:
             if missing_ok:
                 pass

--- a/netplan_cli/configmanager.py
+++ b/netplan_cli/configmanager.py
@@ -104,14 +104,14 @@ class ConfigManager(object):
 
     def backup(self, backup_config_dir=True):
         if backup_config_dir:
-            self._copy_tree(os.path.join(self.prefix, "etc/netplan"),
-                            os.path.join(self.temp_etc, "netplan"))
-        self._copy_tree(os.path.join(self.prefix, "run/NetworkManager/system-connections"),
-                        os.path.join(self.temp_run, "NetworkManager", "system-connections"),
-                        missing_ok=True)
-        self._copy_tree(os.path.join(self.prefix, "run/systemd/network"),
-                        os.path.join(self.temp_run, "systemd", "network"),
-                        missing_ok=True)
+            self.copy_tree(os.path.join(self.prefix, "etc/netplan"),
+                           os.path.join(self.temp_etc, "netplan"))
+        self.copy_tree(os.path.join(self.prefix, "run/NetworkManager/system-connections"),
+                       os.path.join(self.temp_run, "NetworkManager", "system-connections"),
+                       missing_ok=True)
+        self.copy_tree(os.path.join(self.prefix, "run/systemd/network"),
+                       os.path.join(self.temp_run, "systemd", "network"),
+                       missing_ok=True)
 
     def revert(self):
         try:
@@ -122,12 +122,12 @@ class ConfigManager(object):
             temp_networkd_path = "{}/systemd/network".format(self.temp_run)
             if os.path.exists(temp_nm_path):
                 shutil.rmtree(os.path.join(self.prefix, "run/NetworkManager/system-connections"))
-                self._copy_tree(temp_nm_path,
-                                os.path.join(self.prefix, "run/NetworkManager/system-connections"))
+                self.copy_tree(temp_nm_path,
+                               os.path.join(self.prefix, "run/NetworkManager/system-connections"))
             if os.path.exists(temp_networkd_path):
                 shutil.rmtree(os.path.join(self.prefix, "run/systemd/network"))
-                self._copy_tree(temp_networkd_path,
-                                os.path.join(self.prefix, "run/systemd/network"))
+                self.copy_tree(temp_networkd_path,
+                               os.path.join(self.prefix, "run/systemd/network"))
         except Exception as e:  # pragma: nocover (only relevant to filesystem failures)
             # If we reach here, we're in big trouble. We may have wiped out
             # file NM or networkd are using, and we most likely removed the
@@ -152,7 +152,7 @@ class ConfigManager(object):
     def _copy_file(self, src, dst):
         shutil.copy(src, dst)
 
-    def _copy_tree(self, src, dst, missing_ok=False, **kwargs):
+    def copy_tree(self, src, dst, missing_ok=False, **kwargs):
         try:
             shutil.copytree(src, dst, copy_function=copy_with_ownership, **kwargs)
         except FileNotFoundError:

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -489,7 +489,7 @@ method_try(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
        argv[0] = getenv("DBUS_TEST_NETPLAN_CMD");
 
     /* Delete any left-over netplan-try.ready stamp file, if it exists */
-    netplan_try_stamp = g_build_path("/", NETPLAN_ROOT, "run", "netplan", "netplan-try.ready", NULL);
+    netplan_try_stamp = g_build_path(G_DIR_SEPARATOR_S, NETPLAN_ROOT, "run", "netplan", "netplan-try.ready", NULL);
     unlink(netplan_try_stamp);
     /* Launch 'netplan try' child process, lock 'try_pid' to real PID */
     g_spawn_async_with_pipes("/", argv, NULL,
@@ -716,7 +716,7 @@ method_config(sd_bus_message *m, void *userdata, sd_bus_error *ret_error)
     int r = 0;
 
     /* Create state directory, according to "run/netplan/config-XXXXXX" template */
-    tmpl = g_build_path("/", NETPLAN_ROOT, "run", "netplan", "config-XXXXXX", NULL);
+    tmpl = g_build_path(G_DIR_SEPARATOR_S, NETPLAN_ROOT, "run", "netplan", "config-XXXXXX", NULL);
     dir = g_path_get_dirname(tmpl);
     r = g_mkdir_with_parents(dir, 0700);
     path = g_mkdtemp(tmpl); // returns pointer to tmpl (with modified string)

--- a/src/generate.c
+++ b/src/generate.c
@@ -341,7 +341,7 @@ int main(int argc, char** argv)
         }
         g_autofree char* glob_run = g_build_path(G_DIR_SEPARATOR_S,
                                                  rootdir != NULL ? rootdir : G_DIR_SEPARATOR_S,
-                                                 "run/systemd/system/netplan-*.service",
+                                                 "run", "systemd", "system", "netplan-*.service",
                                                  NULL);
         if (!glob(glob_run, 0, NULL, &gl)) {
             for (size_t i = 0; i < gl.gl_pathc; ++i) {

--- a/src/generate.c
+++ b/src/generate.c
@@ -208,6 +208,7 @@ int main(int argc, char** argv)
     /* are we being called as systemd generator? */
     gboolean called_as_generator = (strstr(argv[0], "systemd/system-generators/") != NULL);
     g_autofree char* generator_run_stamp = NULL;
+    g_autofree char* netplan_try_stamp = NULL;
     glob_t gl;
     int error_code = 0;
     char* ignore_errors_env = NULL;
@@ -241,6 +242,22 @@ int main(int argc, char** argv)
             g_fprintf(stderr, "netplan generate already ran, remove %s to force re-run\n", generator_run_stamp);
             return 0;
         }
+    }
+
+    // The file at netplan_try_stamp is created while `netplan try` is waiting
+    // for user confirmation. If generate is triggered while netplan try is
+    // running, we shouldn't regenerate the configuration.
+    // We can be called by either systemd (as a generator during daemon-reload)
+    // or by NetworkManager when it is reloading configuration (Ubuntu >23.10),
+    // see https://netplan.readthedocs.io/en/stable/netplan-everywhere/.
+    // LP #2083029
+    netplan_try_stamp = g_build_path(G_DIR_SEPARATOR_S,
+                                     rootdir != NULL ? rootdir : G_DIR_SEPARATOR_S,
+                                     "run", "netplan", "netplan-try.ready",
+                                     NULL);
+    if (g_access(netplan_try_stamp, F_OK) == 0) {
+        g_fprintf(stderr, "'netplan try' is restoring configuration, remove %s to force re-run.\n", netplan_try_stamp);
+        return 1;
     }
 
     if ((ignore_errors_env = getenv("NETPLAN_PARSER_IGNORE_ERRORS"))) {

--- a/src/util.c
+++ b/src/util.c
@@ -167,7 +167,7 @@ int _netplan_find_yaml_glob(const char* rootdir, glob_t* out_glob)
     int rc;
     g_autofree char* rglob = g_build_path(G_DIR_SEPARATOR_S,
                                           rootdir != NULL ? rootdir : G_DIR_SEPARATOR_S,
-                                          "{lib,etc,run}/netplan/*.yaml", NULL);
+                                          "{lib,etc,run}", "netplan", "*.yaml", NULL);
     rc = glob(rglob, GLOB_BRACE, NULL, out_glob);
     if (rc != 0 && rc != GLOB_NOMATCH) {
         // LCOV_EXCL_START

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -263,6 +263,7 @@ class TestBase(unittest.TestCase):
     def setUp(self):
         self.workdir = tempfile.TemporaryDirectory()
         self.confdir = os.path.join(self.workdir.name, 'etc', 'netplan')
+        self.rundir = os.path.join(self.workdir.name, 'run', 'netplan')
         self.nm_enable_all_conf = os.path.join(
             self.workdir.name, 'run', 'NetworkManager', 'conf.d', '10-globally-managed-devices.conf')
         self.maxDiff = None

--- a/tests/generator/test_args.py
+++ b/tests/generator/test_args.py
@@ -54,6 +54,12 @@ class TestConfigArgs(TestBase):
         self.assert_nm_udev(None)
         self.assert_ovs({'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
+    def test_generate_fails_during_try(self):
+        os.makedirs(self.rundir, mode=0o700, exist_ok=True)
+        open(os.path.join(self.rundir, "netplan-try.ready"), "w").close()
+
+        self.generate('network:\n  version: 2', expect_fail=True)
+
     def test_file_args(self):
         conf = os.path.join(self.workdir.name, 'config')
         with open(conf, 'w') as f:

--- a/tests/test_configmanager.py
+++ b/tests/test_configmanager.py
@@ -332,12 +332,12 @@ class TestConfigManager(unittest.TestCase):
         del self.configmanager
         self.assertFalse(os.path.exists(backup_dir))
 
-    def test__copy_tree(self):
-        self.configmanager._copy_tree(os.path.join(self.workdir.name, "etc"),
-                                      os.path.join(self.workdir.name, "etc2"))
+    def test_copy_tree(self):
+        self.configmanager.copy_tree(os.path.join(self.workdir.name, "etc"),
+                                     os.path.join(self.workdir.name, "etc2"))
         self.assertTrue(os.path.exists(os.path.join(self.workdir.name, "etc2/netplan/test.yaml")))
 
-    def test__copy_tree_missing_source(self):
+    def test_copy_tree_missing_source(self):
         with self.assertRaises(FileNotFoundError):
-            self.configmanager._copy_tree(os.path.join(self.workdir.name, "nonexistent"),
-                                          os.path.join(self.workdir.name, "nonexistent2"), missing_ok=False)
+            self.configmanager.copy_tree(os.path.join(self.workdir.name, "nonexistent"),
+                                         os.path.join(self.workdir.name, "nonexistent2"), missing_ok=False)


### PR DESCRIPTION
## Description
Fixes [LP#2083029](https://bugs.launchpad.net/netplan/+bug/2083029)

When using `systemd-networkd` as a backend, `netplan try` backs up `/run/systemd/network` before applying the new configuration. If the user fails to confirm the new configuration before the timeout is up, Netplan restores the old configuration by moving the backup into `/run/systemd/network` and invokes `networkctl reload` to apply the known-good configuration.

However, `networkd` will not/cannot read config files if their ownership is not `root:systemd-network`.

In effect, `netplan try` does not revert network changes _at all_ when using `networkd`.

Additionally, following the Ubuntu patches to NetworkManager in 23.10 (see [netplan everywhere](https://netplan.readthedocs.io/en/stable/netplan-everywhere/)), `netplan generate` is called (via DBus) when NetworkManager refreshes its config. This "reverts the revert" from `netplan try`, so restoring the old config doesn't work with `NetworkManager` in Ubuntu >23.10 either.

This PR adds an autopkg test for `netplan try` so as to catch these regressions before they are released.

## Implementation Notes
I took advantage of the [stamp](https://github.com/canonical/netplan/commit/e19441c32a35cc58770753dfa8e6783438db295b) that exists when `netplan try` is running. There doesn't appear to me to be a way to prevent NetworkManager from calling generate on reload.

I considered that this may be prone to races if NetworkManager takes its time reloading the configuration; however, it looks like `netplan try` calls `command_apply` with `sync=True`, so it shouldn't delete the stamp until [after NetworkManager has finished loading its config](https://github.com/canonical/netplan/blob/main/netplan_cli/cli/commands/apply.py#L305-L320).

## Test Plan
Using the default netplan configuration in a LXD instance:
```yaml
network:
    version: 2
    ethernets:
        enp5s0:
            dhcp4: true
```

Replace the configuration with a static IP and run `netplan try --timeout 3`, and allow the timeout to elapse.
```yaml
network:
    version: 2
    ethernets:
        enp5s0:
            dhcp4: false
            addresses:
              - 10.58.215.80/24
```

Before the fix in Jammy, the static IP remains assigned to `enp5s0` after the revert. In Noble and later, the interface has the IPv4 removed, but a new dhcp lease is not acquired.

`networkctl status --all` will report the device as `unmanaged`. In Jammy:
```
● 2: enp5s0
                     Link File: /usr/lib/systemd/network/99-default.link
                  Network File: /run/systemd/network/10-netplan-enp5s0.network
                          Type: ether
                         State: routable (unmanaged)
                  Online state: online
```

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] ~~New/changed keys in YAML format are documented.~~
- [ ] \(Optional\) ~~Adds example YAML for new feature.~~
- [x] \(Optional\) Closes an open bug in Launchpad. LP#2083029

Test failures look like Launchpad having trouble.