### PR TITLE
Allows non standard OVS setups

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,8 @@ find = find_program('find')
 
 add_project_arguments(
     '-DSBINDIR="' + join_paths(get_option('prefix'), get_option('sbindir')) + '"',
+    '-DPREFIX="' + get_option('prefix') + '"',
+    '-DBINDIR="' + get_option('bindir') + '"',
     '-D_GNU_SOURCE',
     '-Wconversion',
     language: 'c')

--- a/src/openvswitch.h
+++ b/src/openvswitch.h
@@ -29,3 +29,6 @@ _netplan_netdef_write_ovs(
 
 NETPLAN_INTERNAL gboolean
 _netplan_ovs_cleanup(const char* rootdir);
+
+const char *
+_get_netplan_openvswitch_ovs_vsctl_path(void);

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -24,6 +24,18 @@
 #include <glib.h>
 #include "netplan.h"
 
+#ifndef PREFIX
+#define PREFIX "/usr"
+#endif
+
+#ifndef BINDIR
+#define BINDIR "bin"
+#endif
+
+#ifndef SNAPBINDIR
+#define SNAPBINDIR "/snap/bin"
+#endif
+
 #define SET_OPT_OUT_PTR(ptr,val) { if (ptr) *ptr = val; }
 
 #define __unused __attribute__((unused))
@@ -63,8 +75,6 @@ wifi_get_freq5(guint channel);
 
 gchar*
 systemd_escape(char* string);
-
-#define OPENVSWITCH_OVS_VSCTL "/usr/bin/ovs-vsctl"
 
 void
 mark_data_as_dirty(NetplanParser* npp, const void* data_ptr);

--- a/src/validation.c
+++ b/src/validation.c
@@ -30,6 +30,7 @@
 #include "error.h"
 #include "util-internal.h"
 #include "validation.h"
+#include "openvswitch.h"
 
 /* Check coherence for address types */
 
@@ -441,7 +442,7 @@ validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, GErr
 
     if (nd->backend == NETPLAN_BACKEND_OVS) {
         // LCOV_EXCL_START
-        if (!g_file_test(OPENVSWITCH_OVS_VSCTL, G_FILE_TEST_EXISTS)) {
+        if (!g_file_test(_get_netplan_openvswitch_ovs_vsctl_path(), G_FILE_TEST_EXISTS)) {
             /* Tested via integration test */
             return yaml_error(npp, NULL, error, "%s: The 'ovs-vsctl' tool is required to setup OpenVSwitch interfaces.", nd->id);
         }

--- a/tests/cli/test_get_set.py
+++ b/tests/cli/test_get_set.py
@@ -26,7 +26,7 @@ import glob
 import yaml
 
 from netplan_cli.cli.commands.set import FALLBACK_FILENAME
-from netplan_cli.cli.ovs import OPENVSWITCH_OVS_VSCTL
+from netplan_cli.cli.ovs import OVS_VSCTL_PATH
 
 from netplan import NetplanException
 from tests.test_utils import call_cli
@@ -520,7 +520,7 @@ class TestSet(unittest.TestCase):
         self.assertNotIn('eno2', out['network']['bridges']['br0']['parameters']['port-priority'])
         self.assertEqual(14, out['network']['bridges']['br0']['parameters']['port-priority']['eno1'])
 
-    @unittest.skipIf(not os.path.exists(OPENVSWITCH_OVS_VSCTL),
+    @unittest.skipIf(not os.path.exists(OVS_VSCTL_PATH),
                      'OpenVSwitch not installed')
     def test_set_delete_ovs_other_config(self):
         with open(self.path, 'w') as f:

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -35,6 +35,7 @@ import re
 from io import StringIO
 
 import netplan
+from netplan_cli.cli.ovs import OVS_VSCTL_PATH
 
 exe_generate = os.environ.get('NETPLAN_GENERATE_PATH',
                               os.path.join(os.path.dirname(os.path.dirname(
@@ -65,14 +66,15 @@ Wants=ovsdb-server.service\nAfter=ovsdb-server.service\n'
 OVS_PHYSICAL = _OVS_BASE + 'Requires=sys-subsystem-net-devices-%(iface)s.device\nAfter=sys-subsystem-net-devices-%(iface)s\
 .device\nAfter=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
 OVS_VIRTUAL = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n%(extra)s'
-OVS_BR_DEFAULT = 'ExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan=\"true\"\nExecStart=/usr/bin/ovs-vsctl \
-set-fail-mode %(iface)s standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/global/set-fail-mode=\
-\"standalone\"\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set \
-Bridge %(iface)s external-ids:netplan/mcast_snooping_enable="false"\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
-rstp_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/rstp_enable=\"false\"\n'
+OVS_BR_DEFAULT = 'ExecStart=' + OVS_VSCTL_PATH + ' set Bridge %(iface)s external-ids:netplan=\"true\"\n\
+ExecStart=' + OVS_VSCTL_PATH + ' set-fail-mode %(iface)s standalone\nExecStart=' + OVS_VSCTL_PATH + ' set Bridge %(iface)s \
+external-ids:netplan/global/set-fail-mode=\"standalone\"\nExecStart=' + OVS_VSCTL_PATH + ' set Bridge %(iface)s \
+mcast_snooping_enable=false\nExecStart=' + OVS_VSCTL_PATH + ' set Bridge %(iface)s external-ids:netplan/mcast_snooping_enable=\
+"false"\nExecStart=' + OVS_VSCTL_PATH + ' set Bridge %(iface)s rstp_enable=false\nExecStart=' + OVS_VSCTL_PATH + ' \
+set Bridge %(iface)s external-ids:netplan/rstp_enable=\"false\"\n'
 OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
-Type=oneshot\nTimeoutStartSec=10s\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
-OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\
+Type=oneshot\nTimeoutStartSec=10s\nExecStart=' + OVS_VSCTL_PATH + ' --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
+OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=' + OVS_VSCTL_PATH + '\nBefore=network.target\nWants=network.target\n\n\
 [Service]\nType=oneshot\nTimeoutStartSec=10s\nStartLimitBurst=0\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
 UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
 UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'

--- a/tests/generator/test_ovs.py
+++ b/tests/generator/test_ovs.py
@@ -20,14 +20,14 @@
 import os
 import unittest
 
-from netplan_cli.cli.ovs import OPENVSWITCH_OVS_VSCTL
+from netplan_cli.cli.ovs import OVS_VSCTL_PATH
 from .base import TestBase, ND_EMPTY, ND_WITHIP, ND_DHCP4, ND_DHCP6, \
                             OVS_PHYSICAL, OVS_VIRTUAL, \
                             OVS_BR_EMPTY, OVS_BR_DEFAULT, \
                             OVS_CLEANUP
 
 
-@unittest.skipIf(not os.path.exists(OPENVSWITCH_OVS_VSCTL),
+@unittest.skipIf(not os.path.exists(OVS_VSCTL_PATH),
                  'OpenVSwitch not installed')
 class TestOpenVSwitch(TestBase):
     '''OVS output'''
@@ -56,9 +56,9 @@ class TestOpenVSwitch(TestBase):
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs0
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs0 eth1
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs0 eth0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br ovs0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port ovs0 eth1
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port ovs0 eth0
 ''' + OVS_BR_DEFAULT % {'iface': 'ovs0'}},
                          'eth0.service': OVS_PHYSICAL % {'iface': 'eth0', 'extra': '''\
 Requires=netplan-ovs-ovs0.service
@@ -67,10 +67,10 @@ After=netplan-ovs-ovs0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id="myhostname"
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/external-ids/iface-id="myhostname"
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band="true"
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/other-config/disable-in-band="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth0 external-ids:iface-id="myhostname"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth0 external-ids:netplan/external-ids/iface-id="myhostname"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth0 other-config:disable-in-band="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth0 external-ids:netplan/other-config/disable-in-band="true"
 '''},
                          'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'extra': '''\
 Requires=netplan-ovs-ovs0.service
@@ -79,8 +79,8 @@ After=netplan-ovs-ovs0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band="false"
-ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-config/disable-in-band="false"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth1 other-config:disable-in-band="false"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth1 external-ids:netplan/other-config/disable-in-band="false"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -118,10 +118,10 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-confi
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id="myhostname"
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/external-ids/iface-id="myhostname"
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band="true"
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/other-config/disable-in-band="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set open_vswitch . external-ids:iface-id="myhostname"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set open_vswitch . external-ids:netplan/external-ids/iface-id="myhostname"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set open_vswitch . other-config:disable-in-band="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set open_vswitch . external-ids:netplan/other-config/disable-in-band="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -140,10 +140,10 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/other-confi
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br ovs0
 ''' + OVS_BR_DEFAULT % {'iface': 'ovs0'} + '''\
-ExecStart=/usr/bin/ovs-vsctl set Bridge ovs0 protocols=OpenFlow10,OpenFlow11,OpenFlow12
-ExecStart=/usr/bin/ovs-vsctl set Bridge ovs0 external-ids:netplan/protocols="OpenFlow10,OpenFlow11,OpenFlow12"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge ovs0 protocols=OpenFlow10,OpenFlow11,OpenFlow12
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge ovs0 external-ids:netplan/protocols="OpenFlow10,OpenFlow11,OpenFlow12"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -197,12 +197,12 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:iface-id="myhostname"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/external-ids/iface-id="myhostname"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-bond br0 bond0 eth1 eth2
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 lacp=off
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan/lacp="off"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:iface-id="myhostname"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan/external-ids/iface-id="myhostname"
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -266,10 +266,10 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="active"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-bond br0 bond0 eth1 eth2
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 lacp=active
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan/lacp="active"
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -332,12 +332,12 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=balance-tcp
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode="balance-tcp"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-bond br0 bond0 eth1 eth2
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 lacp=off
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan/lacp="off"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 bond_mode=balance-tcp
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan/bond_mode="balance-tcp"
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -372,12 +372,12 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 bond_mode=active-backup
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode="active-backup"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-bond br0 bond0 eth1 eth2
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 lacp=off
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan/lacp="off"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 bond_mode=active-backup
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan/bond_mode="active-backup"
 '''},
                          'br0.service': OVS_BR_EMPTY % {'iface': 'br0'},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
@@ -424,9 +424,9 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode="acti
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port br0 eth1
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port br0 eth2
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -449,12 +449,12 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id="myhostname"
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/external-ids/iface-id="myhostname"
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 other-config:disable-in-band="true"
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/other-config/disable-in-band="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 external-ids:iface-id="myhostname"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 external-ids:netplan/external-ids/iface-id="myhostname"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 other-config:disable-in-band="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 external-ids:netplan/other-config/disable-in-band="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the bridge has been only configured for OVS
@@ -480,16 +480,16 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/other-config/di
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan="true"
-ExecStart=/usr/bin/ovs-vsctl set-fail-mode br0 secure
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-fail-mode="secure"
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 mcast_snooping_enable=true
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/mcast_snooping_enable="true"
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 rstp_enable=true
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/rstp_enable="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port br0 eth1
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port br0 eth2
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set-fail-mode br0 secure
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 external-ids:netplan/global/set-fail-mode="secure"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 mcast_snooping_enable=true
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 external-ids:netplan/mcast_snooping_enable="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 rstp_enable=true
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 external-ids:netplan/rstp_enable="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -540,10 +540,10 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/rstp_enable="tr
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/protocols="OpenFlow10,OpenFlow11,OpenFlow15"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 external-ids:netplan/protocols="OpenFlow10,OpenFlow11,OpenFlow15"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -590,22 +590,22 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/protocols="Open
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
-ExecStart=/usr/bin/ovs-vsctl set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 \
-tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 unix:/some/path punix:other/path
-ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/global/set-controller="ptcp:,ptcp:1337,\
+ExecStart=''' + OVS_VSCTL_PATH + ''' set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] \
+ssl:10.10.10.1 tcp:127.0.0.1:1337 tcp:[fe80::1234%eth0] tcp:[fe80::1]:1337 unix:/some/path punix:other/path
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Bridge br0 external-ids:netplan/global/set-controller="ptcp:,ptcp:1337,\
 ptcp:1337:[fe80::1234%eth0],pssl:1337:[fe80::1],ssl:10.10.10.1,tcp:127.0.0.1:1337,tcp:[fe80::1234%eth0],tcp:[fe80::1]:1337,\
 unix:/some/path,punix:other/path"
-ExecStart=/usr/bin/ovs-vsctl set Controller br0 connection-mode=out-of-band
-ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-mode="out-of-band"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Controller br0 connection-mode=out-of-band
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Controller br0 external-ids:netplan/connection-mode="out-of-band"
 '''},
                          'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl="/key/path,/some/path,/another/path"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set-ssl /key/path /some/path /another/path
+ExecStart=''' + OVS_VSCTL_PATH + ''' set open_vswitch . external-ids:netplan/global/set-ssl="/key/path,/some/path,/another/path"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -702,8 +702,8 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
-ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl="/key/path,/some/path,/another/path"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set-ssl /key/path /some/path /another/path
+ExecStart=''' + OVS_VSCTL_PATH + ''' set open_vswitch . external-ids:netplan/global/set-ssl="/key/path,/some/path,/another/path"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -807,10 +807,10 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-bond br0 bond0 eth1 eth2
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 lacp=off
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan/lacp="off"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
@@ -856,8 +856,8 @@ Bond=bond0
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx -- set Interface patchx type=patch options:peer=patchy
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br1
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port br1 patchx -- set Interface patchx type=patch options:peer=patchy
 ''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
                          'bond0.service': OVS_VIRTUAL % {'iface': 'bond0', 'extra':
                                                          '''Requires=netplan-ovs-br0.service
@@ -866,10 +866,11 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0 -- set Interface patchy type=patch options:peer=patchx
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan="true"
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
-ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/lacp="off"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-bond br0 bond0 patchy eth0 -- set Interface patchy type=patch \
+options:peer=patchx
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 lacp=off
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port bond0 external-ids:netplan/lacp="off"
 '''},
                          'patchx.service': OVS_VIRTUAL % {'iface': 'patchx', 'extra':
                                                           '''Requires=netplan-ovs-br1.service
@@ -878,7 +879,7 @@ After=netplan-ovs-br1.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port patchx external-ids:netplan="true"
 '''},
                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
                                                           '''Requires=netplan-ovs-bond0.service
@@ -887,7 +888,7 @@ After=netplan-ovs-bond0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface patchy external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.170.1.1/24'),
@@ -915,15 +916,15 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan="true"
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1 -- set Interface patch0-1 type=patch options:peer=patch1-0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port br0 patch0-1 -- set Interface patch0-1 type=patch options:peer=patch1-0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0 -- set Interface patch1-0 type=patch options:peer=patch0-1
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br1
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port br1 patch1-0 -- set Interface patch1-0 type=patch options:peer=patch0-1
 ''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
                          'patch0-1.service': OVS_VIRTUAL % {'iface': 'patch0-1', 'extra':
                                                             '''Requires=netplan-ovs-br0.service
@@ -932,7 +933,7 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port patch0-1 external-ids:netplan="true"
 '''},
                          'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
                                                             '''Requires=netplan-ovs-br1.service
@@ -941,7 +942,7 @@ After=netplan-ovs-br1.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Port patch1-0 external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         self.assert_networkd({'br0.network': ND_WITHIP % ('br0', '192.168.1.1/24'),
@@ -966,7 +967,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan="true"
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br0
 ''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
                          'br0.100.service': OVS_VIRTUAL % {'iface': 'br0.100', 'extra':
                                                            '''Requires=netplan-ovs-br0.service
@@ -975,8 +976,8 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br0.100 br0 100
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface br0.100 external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -1005,8 +1006,8 @@ After=netplan-ovs-br0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
-ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br0.100 br0 100
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface br0.100 external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -1042,8 +1043,8 @@ ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan="true"
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs-br
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs-br non-ovs-bond
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br ovs-br
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port ovs-br non-ovs-bond
 ''' + OVS_BR_DEFAULT % {'iface': 'ovs-br'}},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane
@@ -1097,13 +1098,13 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs-br non-ovs-bond
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br123
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br123 nic1
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br br123
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port br123 nic1
 ''' + OVS_BR_DEFAULT % {'iface': 'br123'} + ('\
-ExecStart=/usr/bin/ovs-vsctl set Bridge br123 protocols=OpenFlow10,OpenFlow11,OpenFlow12\n\
-ExecStart=/usr/bin/ovs-vsctl set Bridge br123 external-ids:netplan/protocols="OpenFlow10,OpenFlow11,OpenFlow12"\n\
-ExecStart=/usr/bin/ovs-vsctl set-controller br123 tcp:127.0.0.1:6653\n\
-ExecStart=/usr/bin/ovs-vsctl set Bridge br123 external-ids:netplan/global/set-controller="tcp:127.0.0.1:6653"\n\
+ExecStart=' + OVS_VSCTL_PATH + ' set Bridge br123 protocols=OpenFlow10,OpenFlow11,OpenFlow12\n\
+ExecStart=' + OVS_VSCTL_PATH + ' set Bridge br123 external-ids:netplan/protocols="OpenFlow10,OpenFlow11,OpenFlow12"\n\
+ExecStart=' + OVS_VSCTL_PATH + ' set-controller br123 tcp:127.0.0.1:6653\n\
+ExecStart=' + OVS_VSCTL_PATH + ' set Bridge br123 external-ids:netplan/global/set-controller="tcp:127.0.0.1:6653"\n\
 ')},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
@@ -1135,8 +1136,8 @@ After=netplan-ovs-abc%2F..%2F..%2F123.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br abc/../../123.100 abc/../../123 100
-ExecStart=/usr/bin/ovs-vsctl set Interface abc/../../123.100 external-ids:netplan="true"
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br abc/../../123.100 abc/../../123 100
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface abc/../../123.100 external-ids:netplan="true"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
 
@@ -1164,9 +1165,9 @@ ExecStart=/usr/bin/ovs-vsctl set Interface abc/../../123.100 external-ids:netpla
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs0
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs0 eth1
-ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs0 eth0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-br ovs0
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port ovs0 eth1
+ExecStart=''' + OVS_VSCTL_PATH + ''' --may-exist add-port ovs0 eth0
 ''' + OVS_BR_DEFAULT % {'iface': 'ovs0'}},
                          'eth0.service': OVS_PHYSICAL % {'iface': 'eth0', 'extra': '''\
 Requires=netplan-ovs-ovs0.service
@@ -1175,10 +1176,12 @@ After=netplan-ovs-ovs0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:a\\n1\\ra=" \\; a \\; 1 ;a; ;b\\t;\\t3 ;\\ta\\t; 1"
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/external-ids/a\\n1\\ra=",;,a,;,1,;a;,;b\\t;\\t3,;\\ta\\t;,1"
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:a\\n1\\ra=" \\; a \\; 1 ;a; ;b\\t;\\t3 ;\\ta\\t; 1"
-ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/other-config/a\\n1\\ra=",;,a,;,1,;a;,;b\\t;\\t3,;\\ta\\t;,1"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth0 external-ids:a\\n1\\ra=" \\; a \\; 1 ;a; ;b\\t;\\t3 ;\\ta\\t; 1"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth0 \
+external-ids:netplan/external-ids/a\\n1\\ra=",;,a,;,1,;a;,;b\\t;\\t3,;\\ta\\t;,1"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth0 other-config:a\\n1\\ra=" \\; a \\; 1 ;a; ;b\\t;\\t3 ;\\ta\\t; 1"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth0 \
+external-ids:netplan/other-config/a\\n1\\ra=",;,a,;,1,;a;,;b\\t;\\t3,;\\ta\\t;,1"
 '''},
                          'eth1.service': OVS_PHYSICAL % {'iface': 'eth1', 'extra': '''\
 Requires=netplan-ovs-ovs0.service
@@ -1187,8 +1190,8 @@ After=netplan-ovs-ovs0.service
 [Service]
 Type=oneshot
 TimeoutStartSec=10s
-ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band="false"
-ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-config/disable-in-band="false"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth1 other-config:disable-in-band="false"
+ExecStart=''' + OVS_VSCTL_PATH + ''' set Interface eth1 external-ids:netplan/other-config/disable-in-band="false"
 '''},
                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
         # Confirm that the networkd config is still sane

--- a/tests/integration/ovs.py
+++ b/tests/integration/ovs.py
@@ -474,7 +474,7 @@ class _CommonTests():
         p = subprocess.Popen(['netplan', 'apply'], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, text=True)
         (_, err) = p.communicate()
-        self.assertIn('Cannot call Open vSwitch: ovsdb-server.service is not running.', err)
+        self.assertIn("OpenvSwitch database is not running", err)
         self.assertEqual(p.returncode, 0)
 
     def test_settings_tag_cleanup(self):

--- a/tests/test_configmanager.py
+++ b/tests/test_configmanager.py
@@ -22,7 +22,7 @@ import tempfile
 import unittest
 
 from netplan_cli.configmanager import ConfigManager, ConfigurationError
-from netplan_cli.cli.ovs import OPENVSWITCH_OVS_VSCTL
+from netplan_cli.cli.ovs import OVS_VSCTL_PATH
 
 
 class TestConfigManager(unittest.TestCase):
@@ -230,7 +230,7 @@ class TestConfigManager(unittest.TestCase):
         self.assertIn('eth0',    state.ethernets)
         self.assertIn('eth42',   state.ethernets)
 
-    @unittest.skipIf(not os.path.exists(OPENVSWITCH_OVS_VSCTL),
+    @unittest.skipIf(not os.path.exists(OVS_VSCTL_PATH),
                      'OpenVSwitch not installed')
     def test_parse_merging_ovs(self):
         state = self.configmanager.parse(extra_config=[os.path.join(self.workdir.name, "ovs_merging.yaml")])

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -30,7 +30,7 @@ from parser.base import capture_stderr
 
 from utils import state_from_yaml
 from netplan_cli.cli.commands.set import FALLBACK_FILENAME
-from netplan_cli.cli.ovs import OPENVSWITCH_OVS_VSCTL
+from netplan_cli.cli.ovs import OVS_VSCTL_PATH
 
 import netplan
 from netplan.netdef import NetplanRoute
@@ -642,7 +642,7 @@ class TestNetDefinition(TestBase):
         netdef = state['eth0']
         self.assertEqual(os.path.join(self.confdir, "a.yaml"), netdef.filepath)
 
-    @unittest.skipIf(not os.path.exists(OPENVSWITCH_OVS_VSCTL),
+    @unittest.skipIf(not os.path.exists(OVS_VSCTL_PATH),
                      'OpenVSwitch not installed')
     def test_filepath_for_ovs_ports(self):
         state = state_from_yaml(self.confdir, '''network:
@@ -663,7 +663,7 @@ class TestNetDefinition(TestBase):
         self.assertEqual(os.path.join(self.confdir, "a.yaml"), netdef_port1.filepath)
         self.assertEqual(os.path.join(self.confdir, "a.yaml"), netdef_port2.filepath)
 
-    @unittest.skipIf(not os.path.exists(OPENVSWITCH_OVS_VSCTL),
+    @unittest.skipIf(not os.path.exists(OVS_VSCTL_PATH),
                      'OpenVSwitch not installed')
     def test_filepath_for_ovs_ports_when_conf_is_redefined(self):
         state = netplan.State()
@@ -847,7 +847,7 @@ class TestNetDefinition(TestBase):
 
         self.assertIsNone(state['eth0'].links.get('vrf'))
 
-    @unittest.skipIf(not os.path.exists(OPENVSWITCH_OVS_VSCTL),
+    @unittest.skipIf(not os.path.exists(OVS_VSCTL_PATH),
                      'OpenVSwitch not installed')
     def test_interface_has_pointer_to_peer(self):
         state = state_from_yaml(self.confdir, '''network:

--- a/tests/test_ovs.py
+++ b/tests/test_ovs.py
@@ -19,7 +19,7 @@ import os
 import unittest
 
 from unittest.mock import patch, call
-from netplan_cli.cli.ovs import OPENVSWITCH_OVS_VSCTL as OVS
+from netplan_cli.cli.ovs import OVS_VSCTL_PATH as OVS_PATH
 
 import netplan_cli.cli.ovs as ovs
 
@@ -27,14 +27,14 @@ from utils import state_from_yaml
 import tempfile
 
 
-@unittest.skipIf(not os.path.exists(OVS),
+@unittest.skipIf(not os.path.exists(OVS_PATH),
                  'OpenVSwitch not installed')
 class TestOVS(unittest.TestCase):
 
     @patch('subprocess.check_call')
     def test_clear_settings_tag(self, mock):
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/external-ids/key', 'value')
-        mock.assert_called_with([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/external-ids/key'])
+        mock.assert_called_with([OVS_PATH, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/external-ids/key'])
 
     @patch('subprocess.check_output')
     @patch('subprocess.check_call')
@@ -45,10 +45,10 @@ Certificate: /another/cert.pem
 CA Certificate: /some/ca-cert.pem
 Bootstrap: false'''
         ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/private/key.pem,/another/cert.pem,/some/ca-cert.pem')
-        mock_out.assert_called_once_with([OVS, 'get-ssl'], text=True)
+        mock_out.assert_called_once_with([OVS_PATH, 'get-ssl'], text=True)
         mock.assert_has_calls([
-            call([OVS, 'del-ssl']),
-            call([OVS, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
+            call([OVS_PATH, 'del-ssl']),
+            call([OVS_PATH, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
         ])
 
     @patch('subprocess.check_output')
@@ -60,9 +60,9 @@ Certificate: /another/cert.pem
 CA Certificate: /some/ca-cert.pem
 Bootstrap: false'''
         ovs.clear_setting('Open_vSwitch', '.', 'netplan/global/set-ssl', '/some/key.pem,/other/cert.pem,/some/cert.pem')
-        mock_out.assert_called_once_with([OVS, 'get-ssl'], text=True)
+        mock_out.assert_called_once_with([OVS_PATH, 'get-ssl'], text=True)
         mock.assert_has_calls([
-            call([OVS, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
+            call([OVS_PATH, 'remove', 'Open_vSwitch', '.', 'external-ids', 'netplan/global/set-ssl'])
         ])
 
     def test_clear_global_unknown(self):
@@ -74,10 +74,10 @@ Bootstrap: false'''
     def test_clear_global(self, mock, mock_out):
         mock_out.return_value = 'tcp:127.0.0.1:1337\nunix:/some/socket'
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337,unix:/some/socket')
-        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], text=True)
+        mock_out.assert_called_once_with([OVS_PATH, 'get-controller', 'ovs0'], text=True)
         mock.assert_has_calls([
-            call([OVS, 'del-controller', 'ovs0']),
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
+            call([OVS_PATH, 'del-controller', 'ovs0']),
+            call([OVS_PATH, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
         ])
 
     @patch('subprocess.check_output')
@@ -85,41 +85,41 @@ Bootstrap: false'''
     def test_no_clear_global_different(self, mock, mock_out):
         mock_out.return_value = 'unix:/var/run/openvswitch/ovs0.mgmt'
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/global/set-controller', 'tcp:127.0.0.1:1337,unix:/some/socket')
-        mock_out.assert_called_once_with([OVS, 'get-controller', 'ovs0'], text=True)
+        mock_out.assert_called_once_with([OVS_PATH, 'get-controller', 'ovs0'], text=True)
         mock.assert_has_calls([
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
+            call([OVS_PATH, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/global/set-controller'])
         ])
 
     @patch('subprocess.check_call')
     def test_clear_dict(self, mock):
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key', 'value')
         mock.assert_has_calls([
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key=\"value\"']),
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
+            call([OVS_PATH, 'remove', 'Bridge', 'ovs0', 'other-config', 'key=\"value\"']),
+            call([OVS_PATH, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
         ])
 
     @patch('subprocess.check_call')
     def test_clear_col(self, mock):
         ovs.clear_setting('Port', 'bond0', 'netplan/bond_mode', 'balance-tcp')
         mock.assert_has_calls([
-            call([OVS, 'remove', 'Port', 'bond0', 'bond_mode', 'balance-tcp']),
-            call([OVS, 'remove', 'Port', 'bond0', 'external-ids', 'netplan/bond_mode'])
+            call([OVS_PATH, 'remove', 'Port', 'bond0', 'bond_mode', 'balance-tcp']),
+            call([OVS_PATH, 'remove', 'Port', 'bond0', 'external-ids', 'netplan/bond_mode'])
         ])
 
     @patch('subprocess.check_call')
     def test_clear_col_default(self, mock):
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/rstp_enable', 'true')
         mock.assert_has_calls([
-            call([OVS, 'set', 'Bridge', 'ovs0', 'rstp_enable=false']),
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/rstp_enable'])
+            call([OVS_PATH, 'set', 'Bridge', 'ovs0', 'rstp_enable=false']),
+            call([OVS_PATH, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/rstp_enable'])
         ])
 
     @patch('subprocess.check_call')
     def test_clear_dict_colon(self, mock):
         ovs.clear_setting('Bridge', 'ovs0', 'netplan/other-config/key', 'fa:16:3e:4b:19:3a')
         mock.assert_has_calls([
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'other-config', 'key=\"fa:16:3e:4b:19:3a\"']),
-            call([OVS, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
+            call([OVS_PATH, 'remove', 'Bridge', 'ovs0', 'other-config', 'key=\"fa:16:3e:4b:19:3a\"']),
+            call([OVS_PATH, 'remove', 'Bridge', 'ovs0', 'external-ids', 'netplan/other-config/key'])
         ])
         mock.mock_calls
 


### PR DESCRIPTION
Changes the checks to be based around the availability of the command line OVS tools instead of the availability of the service installed under apt. This allows netplan to consume OVS when it is provided as part of another package such as in snap environments.

This involves minor changes to lots of the OVS code and also modifies the unit tests as to handle OVS from both standard and nonstandard setups.

## Checklist

- [X] Runs `make check` successfully.
- [X] Retains code coverage (`make check-coverage`).

