### PR TITLE
Update netplan-yaml.md

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1573,6 +1573,7 @@ The specific settings for bonds are defined below.
     > Set whether to set all ports to the same MAC address when adding
     > them to the bond, or how else the system should handle MAC addresses.
     > The possible values are `none`, `active` and `follow`.
+    > This only works with specific bonding modes such as active-backup.
 
   - **`gratuitous-arp`** (scalar)
 


### PR DESCRIPTION
fail-over-mac-poliy does not work with `mode: 802.3ad` and therefore it is needed in the documentation.


## Description
documentation update on yaml for bonding option: `fail-over-mac-poliy`

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

