### PR TITLE
Fail cleanly when systemd-networkd is not installed

### DIFF
--- a/netplan_cli/cli/state.py
+++ b/netplan_cli/cli/state.py
@@ -433,6 +433,9 @@ class SystemConfigState():
                               'but systemd-networkd.service is masked. '
                               'Please start it.')
                 sys.exit(1)
+            if not utils.systemctl_is_installed('systemd-networkd.service'):
+                logging.error('systemd-networkd is required for \'netplan status\' functionality')
+                sys.exit(1)
             logging.debug('systemd-networkd.service is not active. Starting...')
             utils.systemctl('start', ['systemd-networkd.service'], True)
 

--- a/netplan_cli/cli/utils.py
+++ b/netplan_cli/cli/utils.py
@@ -156,7 +156,7 @@ def systemctl_is_masked(unit_pattern):
 
 def systemctl_is_installed(unit_pattern):
     '''Return True if returncode is other than "not-found" (4)'''
-    res = subprocess.run(['systemctl', 'is-enabled', unit_pattern],
+    res = subprocess.run(['systemctl', 'status', unit_pattern],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                          text=True)
     if res.returncode != 4:

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -531,6 +531,18 @@ netplan-global-state:
         self.assertEqual(1, e.exception.code)
         self.assertIn('systemd-networkd.service is masked', cm.output[0])
 
+    @patch('netplan_cli.cli.utils.systemctl_is_installed')
+    @patch('netplan_cli.cli.utils.systemctl_is_active')
+    @patch('netplan_cli.cli.utils.systemctl_is_masked')
+    def test_call_cli_networkd_installed_false(self, is_installed_mock, is_active_mock, is_masked_mock):
+        is_active_mock.return_value = False
+        is_masked_mock.return_value = False
+        is_installed_mock.return_value = False
+        with self.assertLogs() as cm, self.assertRaises(SystemExit) as e:
+            self._call([])
+        self.assertEqual(1, e.exception.code)
+        self.assertIn('systemd-networkd is required for \'netplan status\' functionality', cm.output[0])
+
     @patch('netplan_cli.cli.state.NetplanConfigState.__init__')
     @patch('netplan_cli.cli.state_diff.NetplanDiffState.__init__')
     @patch('netplan_cli.cli.state_diff.NetplanDiffState.get_diff')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -402,7 +402,7 @@ class TestUtils(unittest.TestCase):
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         self.assertTrue(utils.systemctl_is_installed('some.service'))
         self.assertEqual(self.mock_cmd.calls(), [
-            ['systemctl', 'is-enabled', 'some.service']
+            ['systemctl', 'status', 'some.service']
         ])
 
     def test_systemctl_is_installed_false(self):
@@ -412,7 +412,7 @@ class TestUtils(unittest.TestCase):
         os.environ['PATH'] = os.path.dirname(self.mock_cmd.path) + os.pathsep + path_env
         self.assertFalse(utils.systemctl_is_installed('some.service'))
         self.assertEqual(self.mock_cmd.calls(), [
-            ['systemctl', 'is-enabled', 'some.service']
+            ['systemctl', 'status', 'some.service']
         ])
 
     def test_systemctl_daemon_reload(self):


### PR DESCRIPTION
## Description
This patch makes the failure case of `netplan status` cleaner when systemd-networkd is not present.  This is at least relevant to Fedora/EPEL use-cases.

Before:
```
[root@alma-9-srpm-test 1.el9]# netplan status
Failed to start systemd-networkd.service: Unit systemd-networkd.service not found.
Traceback (most recent call last):
  File "/usr/sbin/netplan", line 23, in <module>
    netplan.main()
  File "/usr/share/netplan/netplan_cli/cli/core.py", line 58, in main
    self.run_command()
  File "/usr/share/netplan/netplan_cli/cli/utils.py", line 332, in run_command
    self.func()
  File "/usr/share/netplan/netplan_cli/cli/commands/status.py", line 77, in run
    self.run_command()
  File "/usr/share/netplan/netplan_cli/cli/utils.py", line 332, in run_command
    self.func()
  File "/usr/share/netplan/netplan_cli/cli/commands/status.py", line 829, in command
    system_state = SystemConfigState(self.ifname, self.all)
  File "/usr/share/netplan/netplan_cli/cli/state.py", line 437, in __init__
    utils.systemctl('start', ['systemd-networkd.service'], True)
  File "/usr/share/netplan/netplan_cli/cli/utils.py", line 118, in systemctl
    subprocess.check_call(command)
  File "/usr/lib64/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['systemctl', 'start', 'systemd-networkd.service']' returned non-zero exit status 5.
```

After:
```
[root@alma-9-srpm-test 1.el9]# netplan status
systemd-networkd is required for 'netplan status' functionality
```

It also fixes a bug in the `systemctl_is_installed` def.  `systemctl is-enabled` only returns 1/0 so it needs to use `systemctl status` instead to be able to use the `4` exit code to determine if a given service is installed.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

