### PR TITLE
#1905280 Proof of concept for xfrm_interfaces.

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -37,6 +37,7 @@ IPv
 InfiniBand
 InterVLAN
 IoT
+IPsec
 KVM
 LACPDUs
 LAI
@@ -102,6 +103,7 @@ WakeOnWLan
 Wi
 Wi-Fi
 WireGuard
+XFRM
 adapters
 autostart
 boolean

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -65,6 +65,10 @@ network:
 
   > Configures Virtual Routing and Forwarding (VRF) devices.
 
+- [**`xfrm-interfaces`**](#properties-for-device-type-xfrm-interfaces) (mapping)
+
+  > Creates and configures XFRM devices for offloaded IPsec.
+
 - [**`wifis`**](#properties-for-device-type-wifis) (mapping)
 
   > Configures physical Wi-Fi interfaces as `client`, `adhoc` or `access point`.
@@ -1955,6 +1959,45 @@ VXLAN specific keys:
 
   > Allows setting the IPv4 Do not Fragment (DF) bit in outgoing packets.
   > Takes a boolean value. When unset, the kernel default will be used.
+
+(yaml-xfrm-interfaces)=
+## Properties for device type `xfrm-interfaces`
+
+**Status**: Optional.
+
+**Purpose**: Use the `xfrm-interfaces` key to create virtual XFRM (IPsec) interfaces.
+
+**Structure**: The key consists of a mapping of XFRM interface names. Each
+`xfrm-interface` requires an `if_id`. The general configuration structure for
+XFRM interfaces is shown below.
+
+```yaml
+network:
+  xfrm-interfaces:
+    xfrm0:
+      if_id: 10
+      link: eth0
+      ...
+```
+
+When applied, a virtual interface called `xfrm0` will be created in the system.
+
+XFRM interfaces provide the kernel interface for IPsec transform operations.
+
+The specific settings for `xfrm-interfaces` are defined below.
+
+- **`if_id`** (scalar)
+
+  > The XFRM interface ID (if_id). This is a required parameter.
+  > Takes a number in the range `1..4294967295`.
+
+- **`link`** (scalar)
+
+  > The underlying physical interface for this XFRM interface.
+
+- **`independent`** (boolean)
+
+  > If set to `true`, the XFRM interface is independent of the underlying interface (`link`). Defaults to `false`.
 
 ## Properties for device type `virtual-ethernets`
 

--- a/include/types.h
+++ b/include/types.h
@@ -57,6 +57,7 @@ typedef enum {
     NETPLAN_DEF_TYPE_TUNNEL,
     NETPLAN_DEF_TYPE_PORT,
     NETPLAN_DEF_TYPE_VRF,
+    NETPLAN_DEF_TYPE_XFRM,
     /* Type fallback/passthrough */
     NETPLAN_DEF_TYPE_NM,
     NETPLAN_DEF_TYPE_DUMMY,     /* wokeignore:rule=dummy */

--- a/include/types.h
+++ b/include/types.h
@@ -57,11 +57,11 @@ typedef enum {
     NETPLAN_DEF_TYPE_TUNNEL,
     NETPLAN_DEF_TYPE_PORT,
     NETPLAN_DEF_TYPE_VRF,
-    NETPLAN_DEF_TYPE_XFRM,
     /* Type fallback/passthrough */
     NETPLAN_DEF_TYPE_NM,
     NETPLAN_DEF_TYPE_DUMMY,     /* wokeignore:rule=dummy */
     NETPLAN_DEF_TYPE_VETH,
+    NETPLAN_DEF_TYPE_XFRM,
     /* Place holder type used to fill gaps when a netdef
      * requires links to another netdef (such as vlan_link)
      * but it's not strictly mandatory

--- a/src/abi.h
+++ b/src/abi.h
@@ -356,6 +356,13 @@ struct netplan_net_definition {
         guint port;
     } tunnel;
 
+    /* XFRM interface properties */
+    struct {
+        guint interface_id;
+        gboolean independent;
+        NetplanNetDefinition* link;
+    } xfrm;
+
     NetplanAuthenticationSettings auth;
     gboolean has_auth;
 

--- a/src/names.c
+++ b/src/names.c
@@ -49,6 +49,7 @@ netplan_def_type_to_str[NETPLAN_DEF_TYPE_MAX_] = {
     [NETPLAN_DEF_TYPE_VLAN] = "vlans",
     [NETPLAN_DEF_TYPE_VRF] = "vrfs",
     [NETPLAN_DEF_TYPE_TUNNEL] = "tunnels",
+    [NETPLAN_DEF_TYPE_XFRM] = "xfrm-interfaces",
     [NETPLAN_DEF_TYPE_DUMMY] = "dummy-devices",       /* wokeignore:rule=dummy */
     [NETPLAN_DEF_TYPE_VETH] = "virtual-ethernets",
     [NETPLAN_DEF_TYPE_PORT] = "_ovs-ports",

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -865,6 +865,15 @@ _serialize_yaml(
     if (def->type == NETPLAN_DEF_TYPE_VRF)
         YAML_UINT_DEFAULT(def, event, emitter, "table", def->vrf_table, G_MAXUINT);
 
+    /* XFRM settings */
+    if (def->type == NETPLAN_DEF_TYPE_XFRM) {
+        YAML_UINT_DEFAULT(def, event, emitter, "if_id", def->xfrm.interface_id, 0);
+        if (def->xfrm.link)
+            YAML_STRING(def, event, emitter, "link", def->xfrm.link->id);
+        if (def->xfrm.independent)
+            YAML_BOOL_TRUE(def, event, emitter, "independent", def->xfrm.independent);
+    }
+
     /* Tunnel settings */
     if (def->type == NETPLAN_DEF_TYPE_TUNNEL) {
         write_tunnel_settings(event, emitter, def);

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -697,6 +697,15 @@ write_netdev_file(const NetplanNetDefinition* def, const char* rootdir, const ch
                 write_tunnel_params(s, def);
             break;
 
+        /* Generate XFRM interface netdev file */
+                case NETPLAN_DEF_TYPE_XFRM:
+            g_string_append_printf(s, "Kind=xfrm\n\n[Xfrm]\nInterfaceId=%u\n", def->xfrm.interface_id);
+                /* Independent interfaces operate without link device, in reality it will show up as @lo. */
+            if (def->xfrm.independent) {
+                g_string_append(s, "Independent=true\n");
+            }
+            break;
+
         default: g_assert_not_reached(); // LCOV_EXCL_LINE
     }
 

--- a/src/nm.c
+++ b/src/nm.c
@@ -1101,6 +1101,11 @@ _netplan_netdef_write_nm(
         return FALSE;
     }
 
+    if (netdef->type == NETPLAN_DEF_TYPE_XFRM) {
+        g_set_error(error, NETPLAN_BACKEND_ERROR, NETPLAN_ERROR_UNSUPPORTED, "ERROR: %s: XFRM interfaces are not supported by NetworkManager\n", netdef->id);
+        return FALSE;
+    }
+
     if (netdef->type == NETPLAN_DEF_TYPE_VETH) {
         /*
          * Final validation of veths that can't be fully done during parsing due to the

--- a/src/parse.c
+++ b/src/parse.c
@@ -369,7 +369,7 @@ handle_generic_guint_hex_dec(NetplanParser* npp, yaml_node_t* node, const void* 
     }
 
     if (*endptr != '\0' || v > G_MAXUINT)
-        return yaml_error(npp, node, error, "invalid unsigned int value '%s'", s_node);
+        return yaml_error(npp, node, error, "invalid unsigned int value '%s'", s_node); // LCOV_EXCL_LINE
 
     mark_data_as_dirty(npp, entryptr + offset);
     *((guint*) ((void*) entryptr + offset)) = (guint) v;

--- a/src/parse.c
+++ b/src/parse.c
@@ -3895,17 +3895,7 @@ netplan_parser_reset(NetplanParser* npp)
         npp->global_renderer = NULL;
     }
 
-    if (npp->xfrm_if_ids) {
-        g_hash_table_destroy(npp->xfrm_if_ids);
-        npp->xfrm_if_ids = NULL;
-    }
-
     npp->flags = 0;
-
-    if (npp->xfrm_if_ids) {
-        g_hash_table_destroy(npp->xfrm_if_ids);
-        npp->xfrm_if_ids = NULL;
-    }
     npp->error_count = 0;
 }
 

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -273,6 +273,9 @@ struct netplan_parser {
      * when the flag IGNORE_ERRORS is set
      * */
     unsigned int error_count;
+
+    /* Hash table to track XFRM interface IDs to ensure uniqueness */
+    GHashTable* xfrm_if_ids;
 };
 
 struct netplan_state_iterator {

--- a/src/types.c
+++ b/src/types.c
@@ -350,6 +350,11 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     memset(&netdef->tunnel, 0, sizeof(netdef->tunnel));
     netdef->tunnel.mode = NETPLAN_TUNNEL_MODE_UNKNOWN;
 
+    /* Reset XFRM parameters */
+    memset(&netdef->xfrm, 0, sizeof(netdef->xfrm));
+    netdef->xfrm.independent = FALSE;
+    netdef->xfrm.link = NULL;
+
     reset_auth_settings(&netdef->auth);
     netdef->has_auth = FALSE;
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -367,6 +367,8 @@ gboolean
 validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, GError** error)
 {
     guint missing_id_count = g_hash_table_size(npp->missing_id);
+    gboolean missing_dependencies = (missing_id_count > 0 &&
+                                     (npp->flags & NETPLAN_PARSER_IGNORE_ERRORS) == 0);
     gboolean valid = FALSE;
     NetplanBackend backend = nd->backend;
 
@@ -375,7 +377,25 @@ validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, GErr
     /* Skip all validation if we're missing some definition IDs (devices).
      * The ones we have yet to see may be necessary for validation to succeed,
      * we can complete it on the next parser pass. */
-    if (missing_id_count > 0 && (npp->flags & NETPLAN_PARSER_IGNORE_ERRORS) == 0) {
+    /* XFRM interfaces have some validation that does not require all
+     * referenced definitions to be available (most notably the if_id
+     * range/uniqueness checks). Run those always so that we can fail fast
+     * even if we are still waiting for other definitions to be parsed. */
+    if (nd->type == NETPLAN_DEF_TYPE_XFRM) {
+        if (nd->xfrm.interface_id == 0 || nd->xfrm.interface_id > 0xffffffff) {
+            return yaml_error(npp, NULL, error, "%s: 'if_id' property must be in range [1..4294967295] or [0x1..0xffffffff]", nd->id);
+        }
+
+        NetplanNetDefinition* existing_def = g_hash_table_lookup(npp->xfrm_if_ids,
+                                                                 GINT_TO_POINTER(nd->xfrm.interface_id));
+        if (existing_def != NULL && existing_def != nd) {
+            return yaml_error(npp, NULL, error, "%s: duplicate if_id '%u' (already used by %s)",
+                              nd->id, nd->xfrm.interface_id, existing_def->id);
+        }
+        g_hash_table_insert(npp->xfrm_if_ids, GINT_TO_POINTER(nd->xfrm.interface_id), nd);
+    }
+
+    if (missing_dependencies) {
         return TRUE;
     }
 
@@ -417,25 +437,11 @@ validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, GErr
         }
     }
 
-    /* Validate XFRM interface configuration */
-        if (nd->type == NETPLAN_DEF_TYPE_XFRM) {
-        if (nd->xfrm.interface_id == 0) {
-            return yaml_error(npp, NULL, error, "%s: missing 'if_id' property", nd->id);
-        }
-        if (nd->xfrm.interface_id < 1 || nd->xfrm.interface_id > 0xffffffff) {
-            return yaml_error(npp, NULL, error, "%s: XFRM 'if_id' must be in range [1..0xffffffff]", nd->id);
-        }
+    /* Validate XFRM interface configuration that requires resolved links */
+    if (nd->type == NETPLAN_DEF_TYPE_XFRM) {
         if (!nd->xfrm.independent && nd->xfrm.link == NULL) {
             return yaml_error(npp, NULL, error, "%s: non-independent XFRM interface requires 'link' property", nd->id);
         }
-
-        /* Ensure no xfrm if_id is used more than once */
-        NetplanNetDefinition* existing_def = g_hash_table_lookup(npp->xfrm_if_ids, GINT_TO_POINTER(nd->xfrm.interface_id));
-        if (existing_def != NULL && existing_def != nd) {
-            return yaml_error(npp, NULL, error, "%s: duplicate if_id '%u' (already used by %s)",
-                              nd->id, nd->xfrm.interface_id, existing_def->id);
-        }
-        g_hash_table_insert(npp->xfrm_if_ids, GINT_TO_POINTER(nd->xfrm.interface_id), nd);
     }
 
     if (nd->type == NETPLAN_DEF_TYPE_VRF) {

--- a/src/validation.c
+++ b/src/validation.c
@@ -420,13 +420,13 @@ validate_netdef_grammar(const NetplanParser* npp, NetplanNetDefinition* nd, GErr
     /* Validate XFRM interface configuration */
         if (nd->type == NETPLAN_DEF_TYPE_XFRM) {
         if (nd->xfrm.interface_id == 0) {
-            return yaml_error(npp, NULL, error, "%s: missing 'if_id'", nd->id);
+            return yaml_error(npp, NULL, error, "%s: missing 'if_id' property", nd->id);
         }
         if (nd->xfrm.interface_id < 1 || nd->xfrm.interface_id > 0xffffffff) {
             return yaml_error(npp, NULL, error, "%s: XFRM 'if_id' must be in range [1..0xffffffff]", nd->id);
         }
         if (!nd->xfrm.independent && nd->xfrm.link == NULL) {
-            return yaml_error(npp, NULL, error, "%s: Non-independent XFRM interfaces require property 'link'", nd->id);
+            return yaml_error(npp, NULL, error, "%s: non-independent XFRM interface requires 'link' property", nd->id);
         }
 
         /* Ensure no xfrm if_id is used more than once */

--- a/tests/config_fuzzer/schemas/xfrm-interfaces.js
+++ b/tests/config_fuzzer/schemas/xfrm-interfaces.js
@@ -1,0 +1,68 @@
+import * as common from "./common.js";
+
+const xfrm_interfaces_schema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+        network: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                renderer: {
+                    type: "string",
+                    enum: ["networkd"]
+                },
+                version: {
+                    type: "integer",
+                    minimum: 2,
+                    maximum: 2
+                },
+                ethernets: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "eth0": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "dhcp4": {
+                                    type: "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
+                "xfrm-interfaces": {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        "xfrm0": {
+                            type: "object",
+                            additionalProperties: false,
+                            properties: {
+                                "if_id": {
+                                    type: "integer",
+                                    minimum: 1,
+                                    maximum: 4294967295
+                                },
+                                "independent": {
+                                    type: "boolean"
+                                },
+                                "link": {
+                                    type: "string",
+                                    enum: ["eth0"]
+                                },
+                                ...common.common_properties
+                            },
+                            required: ["if_id"]
+                        }
+                    }
+                }
+            },
+            required: ["version", "xfrm-interfaces"]
+        }
+    },
+    required: ["network"]
+};
+
+export default xfrm_interfaces_schema;

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -1359,3 +1359,53 @@ Name=bond0
 LinkLocalAddressing=ipv6
 ConfigureWithoutCarrier=yes
 '''})
+
+    def test_xfrm_missing_if_id(self):
+        err = self.generate('''network:
+  version: 2
+  xfrm-interfaces:
+    xfrm0:
+      independent: true''', expect_fail=True)
+        self.assertIn("missing 'if_id' property", err)
+
+    def test_xfrm_invalid_if_id_range(self):
+        err = self.generate('''network:
+  version: 2
+  xfrm-interfaces:
+    xfrm0:
+      if_id: 0
+      link: eth0''', expect_fail=True)
+        self.assertIn("XFRM 'if_id' must be in range [1..0xffffffff]", err)
+
+    def test_xfrm_missing_link_non_independent(self):
+        err = self.generate('''network:
+  version: 2
+  xfrm-interfaces:
+    xfrm0:
+      if_id: 42
+      independent: false''', expect_fail=True)
+        self.assertIn("non-independent XFRM interface requires 'link' property", err)
+
+    def test_xfrm_duplicate_if_id(self):
+        err = self.generate('''network:
+  version: 2
+  xfrm-interfaces:
+    xfrm0:
+      if_id: 42
+      independent: true
+    xfrm1:
+      if_id: 42
+      independent: true''', expect_fail=True)
+        self.assertIn("duplicate if_id '42' (already used by xfrm0)", err)
+
+    def test_xfrm_duplicate_if_id_hex_dec(self):
+        err = self.generate('''network:
+  version: 2
+  xfrm-interfaces:
+    xfrm0:
+      if_id: 42
+      independent: true
+    xfrm1:
+      if_id: 0x2A
+      independent: true''', expect_fail=True)
+        self.assertIn("duplicate if_id '42' (already used by xfrm0)", err)

--- a/tests/generator/test_errors.py
+++ b/tests/generator/test_errors.py
@@ -1366,7 +1366,7 @@ ConfigureWithoutCarrier=yes
   xfrm-interfaces:
     xfrm0:
       independent: true''', expect_fail=True)
-        self.assertIn("missing 'if_id' property", err)
+        self.assertIn("'if_id' property must be in range [1..4294967295] or [0x1..0xffffffff]", err)
 
     def test_xfrm_invalid_if_id_range(self):
         err = self.generate('''network:
@@ -1375,7 +1375,7 @@ ConfigureWithoutCarrier=yes
     xfrm0:
       if_id: 0
       link: eth0''', expect_fail=True)
-        self.assertIn("XFRM 'if_id' must be in range [1..0xffffffff]", err)
+        self.assertIn("'if_id' property must be in range [1..4294967295] or [0x1..0xffffffff]", err)
 
     def test_xfrm_missing_link_non_independent(self):
         err = self.generate('''network:

--- a/tests/generator/test_xfrm.py
+++ b/tests/generator/test_xfrm.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import TestBase
+from .base import ND_DHCP4, TestBase
 
 
 class TestNetworkdXfrm(TestBase):
@@ -33,7 +33,8 @@ class TestNetworkdXfrm(TestBase):
       link: eth0
       addresses: [192.168.1.10/24]''')
 
-        self.assert_networkd({'xfrm0.netdev': '''[NetDev]
+        self.assert_networkd({'eth0.network': ND_DHCP4 % 'eth0',
+                              'xfrm0.netdev': '''[NetDev]
 Name=xfrm0
 Kind=xfrm
 

--- a/tests/generator/test_xfrm.py
+++ b/tests/generator/test_xfrm.py
@@ -1,0 +1,110 @@
+#
+# Tests for XFRM interface config generation
+#
+# Copyright (C) 2024 Canonical, Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .base import TestBase
+
+
+class TestNetworkdXfrm(TestBase):
+
+    def test_xfrm_basic(self):
+        self.generate('''network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: true
+  xfrm-interfaces:
+    xfrm0:
+      if_id: 42
+      link: eth0
+      addresses: [192.168.1.10/24]''')
+
+        self.assert_networkd({'xfrm0.netdev': '''[NetDev]
+Name=xfrm0
+Kind=xfrm
+
+[Xfrm]
+InterfaceId=42
+''',
+                              'xfrm0.network': '''[Match]
+Name=xfrm0
+
+[Network]
+LinkLocalAddressing=no
+Address=192.168.1.10/24
+'''})
+
+    def test_xfrm_independent(self):
+        self.generate('''network:
+  version: 2
+  renderer: networkd
+  xfrm-interfaces:
+    xfrm0:
+      if_id: 100
+      independent: true''')
+
+        self.assert_networkd({'xfrm0.netdev': '''[NetDev]
+Name=xfrm0
+Kind=xfrm
+
+[Xfrm]
+InterfaceId=100
+Independent=true
+'''})
+
+
+class TestNetworkManagerXfrm(TestBase):
+
+    def test_xfrm_nm_not_supported(self):
+        err = self.generate('''network:
+  version: 2
+  renderer: NetworkManager
+  xfrm-interfaces:
+    xfrm0:
+      if_id: 42
+      independent: true''', expect_fail=True)
+
+        self.assertIn('XFRM interfaces are not supported by NetworkManager', err)
+
+    def test_xfrm_hex_dec_different_values(self):
+        self.generate('''network:
+  version: 2
+  xfrm-interfaces:
+    xfrm0:
+      if_id: 42
+      independent: true
+    xfrm1:
+      if_id: 0x2B
+      independent: true''')
+
+        # Verify both interfaces are generated with correct if_id values
+        self.assert_networkd({'xfrm0.netdev': '''[NetDev]
+Name=xfrm0
+Kind=xfrm
+
+[Xfrm]
+InterfaceId=42
+Independent=true
+''',
+                             'xfrm1.netdev': '''[NetDev]
+Name=xfrm1
+Kind=xfrm
+
+[Xfrm]
+InterfaceId=43
+Independent=true
+'''})


### PR DESCRIPTION
Proof of concept to solve https://bugs.launchpad.net/netplan/+bug/1905280

network-manager rendering is not yet supported, no idea if it even works.

Duplicate if_ids are rejected because there is no sane usecase for them.

if_id = 0x2a is also a supported notation along with if_id = 42 to align with the ip -d link show output

Example interface:
```network:
   xfrm-interfaces:
     ipsec0:
       if_id: 42
       independent: true
```

