### PR TITLE
test:dbus: avoid dependency on dbus-launch (Closes: #1117099)

### DIFF
--- a/tests/netplan_dbus/test_dbus.py
+++ b/tests/netplan_dbus/test_dbus.py
@@ -60,15 +60,12 @@ class TestNetplanDBus(unittest.TestCase):
 
     def _create_mock_system_bus(self):
         env = {}
-        output = subprocess.check_output(["dbus-launch"], env={})
-        for s in output.decode("utf-8").split("\n"):
-            if s == "":
-                continue
-            k, v = s.split("=", 1)
-            env[k] = v
+        p = subprocess.Popen(["dbus-daemon", "--print-address=1", "--session"],
+                             env={}, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        env['DBUS_SESSION_BUS_ADDRESS'] = p.stdout.readline().strip().decode("ascii")
         # override system bus with the fake one
         os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = env["DBUS_SESSION_BUS_ADDRESS"]
-        self.addCleanup(os.kill, int(env["DBUS_SESSION_BUS_PID"]), 15)
+        self.addCleanup(p.kill)
 
     def _run_netplan_dbus_on_mock_bus(self):
         # run netplan-dbus in a fake system bus


### PR DESCRIPTION
## Description
test:dbus: avoid dependency on dbus-launch (Closes: #1117099)

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1117099

