### PR TITLE
fix(cli): return nonzero exit code on error

### DIFF
--- a/netplan_cli/cli/core.py
+++ b/netplan_cli/cli/core.py
@@ -20,6 +20,7 @@
 
 import logging
 import os
+import sys
 
 from . import utils
 from netplan import NetplanException, NetplanValidationException, NetplanParserException
@@ -59,7 +60,10 @@ class Netplan(utils.NetplanCommand):
         except NetplanParserException as e:
             message = f'{e.filename}:{e.line}:{e.column}: {e}'
             logging.warning(f'Command failed: {message}')
+            sys.exit(1)
         except NetplanValidationException as e:
             logging.warning(f'Command failed: {e.filename}: {e}')
+            sys.exit(1)
         except NetplanException as e:
             logging.warning(f'Command failed: {e}')
+            sys.exit(1)

--- a/tests/cli/test_units.py
+++ b/tests/cli/test_units.py
@@ -144,7 +144,9 @@ class TestCLI(unittest.TestCase):
             old_argv = sys.argv
             args = ['get', '--root-dir', self.tmproot]
             sys.argv = [old_argv[0]] + args
-            Netplan().main()
+            with self.assertRaises(SystemExit) as e:
+                Netplan().main()
+            self.assertEqual(1, e.exception.code)
             sys.argv = old_argv
 
             args = log.call_args.args
@@ -164,7 +166,9 @@ class TestCLI(unittest.TestCase):
             old_argv = sys.argv
             args = ['get', '--root-dir', self.tmproot]
             sys.argv = [old_argv[0]] + args
-            Netplan().main()
+            with self.assertRaises(SystemExit) as e:
+                Netplan().main()
+            self.assertEqual(1, e.exception.code)
             sys.argv = old_argv
 
             args = log.call_args.args
@@ -181,8 +185,11 @@ class TestCLI(unittest.TestCase):
             old_argv = sys.argv
             args = ['get', '--root-dir', self.tmproot]
             sys.argv = [old_argv[0]] + args
-            Netplan().main()
+            with self.assertRaises(SystemExit) as e:
+                Netplan().main()
+            self.assertEqual(1, e.exception.code)
             sys.argv = old_argv
+
             args = log.call_args.args
             self.assertIn('etc/netplan/test.yaml: Error in network definition', args[0])
 
@@ -200,7 +207,10 @@ class TestCLI(unittest.TestCase):
             old_argv = sys.argv
             args = ['get', '--root-dir', self.tmproot]
             sys.argv = [old_argv[0]] + args
-            Netplan().main()
+            with self.assertRaises(SystemExit) as e:
+                Netplan().main()
+            self.assertEqual(1, e.exception.code)
             sys.argv = old_argv
+
             args = log.call_args.args
             self.assertIn("VRF routes table mismatch", args[0])

--- a/tools/run_asan.sh
+++ b/tools/run_asan.sh
@@ -28,6 +28,12 @@ mkdir -p ${BUILDDIR}/fakeroot/{etc/netplan,run}
 
 for yaml in examples/*.yaml
 do
+    ## Ignore OpenVSwitch-related files for this test
+    ## As ovs is an optional dependency, it may not be available
+    if [[ "${yaml}" == *"openvswitch"* ]]; then
+        echo "Skipping OpenVSwitch file ${yaml}"
+        continue
+    fi
     filepath=${BUILDDIR}/fakeroot/etc/netplan/${yaml##*/}
     filename=$(basename ${filepath})
     cp ${yaml} ${BUILDDIR}/fakeroot/etc/netplan/

--- a/tools/run_asan.sh
+++ b/tools/run_asan.sh
@@ -28,12 +28,6 @@ mkdir -p ${BUILDDIR}/fakeroot/{etc/netplan,run}
 
 for yaml in examples/*.yaml
 do
-    ## Ignore OpenVSwitch-related files for this test
-    ## As ovs is an optional dependency, it may not be available
-    if [[ "${yaml}" == *"openvswitch"* ]]; then
-        echo "Skipping OpenVSwitch file ${yaml}"
-        continue
-    fi
     filepath=${BUILDDIR}/fakeroot/etc/netplan/${yaml##*/}
     filename=$(basename ${filepath})
     cp ${yaml} ${BUILDDIR}/fakeroot/etc/netplan/


### PR DESCRIPTION
## Description

This is the successor of https://github.com/canonical/netplan/pull/551/changes.


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad. LP#2104373

