### PR TITLE
doc: Add note of compatibility with iproute2 src option

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -787,6 +787,8 @@ network:
 
     > Set a source IP address for traffic going through the route.
     > (NetworkManager: as of v1.8.0)
+    >
+    > This is equivalent to iproute2's `src` route option.
 
   - **`to`** (scalar)
 


### PR DESCRIPTION
## Description

Often while migrating from manual scripts i search for same or similar options by keyword. In this case, i failed to find until i started to search into sources with purpose of implementing "missing" option, which is not missing, just named differently.

## Checklist
There is no changes in the code
