### PR TITLE
generate: order service After=systemd-sysusers.service

### DIFF
--- a/netplan-configure.service
+++ b/netplan-configure.service
@@ -8,9 +8,9 @@ Wants=systemd-udevd.service
 Conflicts=shutdown.target
 Before=shutdown.target network-pre.target
 Before=systemd-networkd.service NetworkManager.service
-# Run After=nss-user-lookup.target, to allow lookup of the "systemd-network" GID
+# Run After=systemd-sysusers.service, to allow lookup of the "systemd-network" GID
 # (LP: #2071747)
-After=local-fs.target nss-user-lookup.target systemd-udevd-control.socket
+After=local-fs.target systemd-sysusers.service systemd-udevd-control.socket
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Description

netplan-configure.service needs to resolve the "systemd-network" GID. To do that, is ordered After=nss-user-lookup.target. However, if this target is After= another service that is itself
After=network-online.target (for example, winbind.service), this causes an ordering cycle.

```
Mar 23 18:02:51 netplan-winbind systemd[1]: network.target: Found ordering cycle: winbind.service/stop after nss-user-lookup.target/stop after netplan-configure.service/stop after network-pre.target/stop after network.target/stop - after winbind.service
Mar 23 18:02:51 netplan-winbind systemd[1]: network.target: Job winbind.service/stop deleted to break ordering cycle starting with network.target/stop
```

Since "systemd-network" is created early by systemd-sysusers, we can order the service After=systemd-sysusers.service to ensure that the group already exists without triggering network-related cycles.

Related: https://code.launchpad.net/~puida/ubuntu/+source/netplan.io/+git/netplan.io/+merge/502503 and https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2071747 (comment #<!-->5 onwards)

## Checklist

- [ ] Runs `make check` successfully.
- [ ] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

