### PR TITLE
feat(networkd): add use-mtu to ipv6 ra-overrides

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -732,6 +732,12 @@ networkd back end).
     > Some values are already in use to refer to specific routing tables:
     > see `{/etc,/usr/share}/iproute2/rt_tables`.
 
+  - **`use-mtu`** (boolean) - since X.X
+
+    > Default: `true`. When `true`, the MTU received in the Router
+    > Advertisement will be used. Currently only has an effect on
+    > the networkd back end.
+
 ## Routing
 
 Complex routing is possible with Netplan. Standard static routes as well

--- a/src/abi.h
+++ b/src/abi.h
@@ -78,6 +78,7 @@ typedef struct ra_overrides {
     NetplanTristate use_dns;
     NetplanUseDomainMode use_domains;
     guint table;
+    NetplanTristate use_mtu;
 } NetplanRAOverrides;
 
 typedef enum {

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -506,7 +506,8 @@ write_ra_overrides(yaml_event_t* event, yaml_emitter_t* emitter, const char* key
     if (DIRTY_COMPLEX(def, *data)
         || data->use_dns != NETPLAN_TRISTATE_UNSET
         || data->use_domains != NETPLAN_USE_DOMAIN_MODE_UNSET
-        || data->table != NETPLAN_ROUTE_TABLE_UNSPEC) {
+        || data->table != NETPLAN_ROUTE_TABLE_UNSPEC
+        || data->use_mtu != NETPLAN_TRISTATE_UNSET) {
         YAML_SCALAR_PLAIN(event, emitter, key);
         YAML_MAPPING_OPEN(event, emitter);
         YAML_BOOL_TRISTATE(def, event, emitter, "use-dns", data->use_dns);
@@ -518,6 +519,7 @@ write_ra_overrides(yaml_event_t* event, yaml_emitter_t* emitter, const char* key
             YAML_STRING_PLAIN(def, event, emitter, "use-domains", "route");
         }
         YAML_UINT_DEFAULT(def, event, emitter, "table", data->table, NETPLAN_ROUTE_TABLE_UNSPEC);
+        YAML_BOOL_TRISTATE(def, event, emitter, "use-mtu", data->use_mtu);
         YAML_MAPPING_CLOSE(event, emitter);
     }
     return TRUE;

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -322,6 +322,8 @@ ra_overrides_is_dirty(const NetplanRAOverrides* overrides) {
         return TRUE;
     if(overrides->table != NETPLAN_ROUTE_TABLE_UNSPEC)
         return TRUE;
+    if(overrides->use_mtu != NETPLAN_TRISTATE_UNSET)
+        return TRUE;
 
     return FALSE;
 }
@@ -993,6 +995,9 @@ _netplan_netdef_write_network_file(
         }
         if (def->ra_overrides.table != NETPLAN_ROUTE_TABLE_UNSPEC) {
             g_string_append_printf(network, "RouteTable=%d\n", def->ra_overrides.table);
+        }
+        if (def->ra_overrides.use_mtu != NETPLAN_TRISTATE_UNSET) {
+            g_string_append_printf(network, "UseMTU=%s\n", def->ra_overrides.use_mtu ? "true" : "false");
         }
     }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -2961,6 +2961,7 @@ static const mapping_entry_handler ra_overrides_handlers[] = {
     {"use-dns", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(ra_overrides.use_dns)},
     {"use-domains", YAML_SCALAR_NODE, {.generic=handle_netdef_use_domains}, netdef_offset(ra_overrides.use_domains)},
     {"table", YAML_SCALAR_NODE, {.generic=handle_netdef_guint}, netdef_offset(ra_overrides.table)},
+    {"use-mtu", YAML_SCALAR_NODE, {.generic=handle_netdef_tristate}, netdef_offset(ra_overrides.use_mtu)},
     {NULL},
 };
 

--- a/src/types.c
+++ b/src/types.c
@@ -157,6 +157,7 @@ reset_ra_overrides(NetplanRAOverrides* overrides)
     overrides->use_dns = NETPLAN_TRISTATE_UNSET;
     overrides->use_domains = NETPLAN_USE_DOMAIN_MODE_UNSET;
     overrides->table = NETPLAN_ROUTE_TABLE_UNSPEC;
+    overrides->use_mtu = NETPLAN_TRISTATE_UNSET;
 }
 
 void

--- a/tests/generator/test_ra_overrides.py
+++ b/tests/generator/test_ra_overrides.py
@@ -62,6 +62,7 @@ network:
         use-dns: false
         use-domains: route
         table: 701
+        use-mtu: false
 '''
         networkd_config = '''\
 [Match]
@@ -74,6 +75,7 @@ LinkLocalAddressing=ipv6
 UseDNS=false
 UseDomains=route
 RouteTable=701
+UseMTU=false
 '''
         self.generate(yaml_config)
         self.assert_networkd({'engreen.network': networkd_config})
@@ -89,6 +91,10 @@ RouteTable=701
 
     def test_ra_overrides_table(self):
         self.assert_ra_overrides_key_value('table', '727', 'RouteTable', '727')
+
+    def test_ra_overrides_use_mtu(self):
+        self.assert_ra_overrides_key_value('use-mtu', 'false', 'UseMTU', 'false')
+        self.assert_ra_overrides_key_value('use-mtu', 'true', 'UseMTU', 'true')
 
     def test_ra_overrides_all_fields(self):
         self.assert_ra_overrides_all_fields()


### PR DESCRIPTION
## Description
Option usefull when RA provides incorrect MTU and we want to ignore it.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

