### PR TITLE
tests: only consider netplan-generated files in integration tests

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -478,7 +478,7 @@ class IntegrationTestsBase(unittest.TestCase):
 
         # Check systemd-networkd files
         base_path = '/run/systemd/network'
-        files = glob.glob(f'{base_path}/*.network') + glob.glob(f'{base_path}/*.netdev')
+        files = glob.glob(f'{base_path}/*netplan*.network') + glob.glob(f'{base_path}/*netplan*.netdev')
         for file in files:
             res = os.stat(file)
             user = pwd.getpwuid(res.st_uid)
@@ -489,7 +489,7 @@ class IntegrationTestsBase(unittest.TestCase):
 
         # Check Network Manager files
         base_path = '/run/NetworkManager/system-connections'
-        files = glob.glob(f'{base_path}/*.nmconnection')
+        files = glob.glob(f'{base_path}/*netplan*.nmconnection')
         for file in files:
             res = os.stat(file)
             user = pwd.getpwuid(res.st_uid)

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -478,7 +478,7 @@ class IntegrationTestsBase(unittest.TestCase):
 
         # Check systemd-networkd files
         base_path = '/run/systemd/network'
-        files = glob.glob(f'{base_path}/*.network') + glob.glob(f'{base_path}/*.netdev')
+        files = glob.glob(f'{base_path}/10-netplan*.network') + glob.glob(f'{base_path}/10-netplan*.netdev')
         for file in files:
             res = os.stat(file)
             user = pwd.getpwuid(res.st_uid)
@@ -489,7 +489,7 @@ class IntegrationTestsBase(unittest.TestCase):
 
         # Check Network Manager files
         base_path = '/run/NetworkManager/system-connections'
-        files = glob.glob(f'{base_path}/*.nmconnection')
+        files = glob.glob(f'{base_path}/netplan*.nmconnection')
         for file in files:
             res = os.stat(file)
             user = pwd.getpwuid(res.st_uid)


### PR DESCRIPTION
## Description

Some files not managed by netplan can exist in those locations. Netplan tests should only consider files actually generated by netplan itself.

This fixes autopkgtest failures due to dracut-network installing /run/systemd/network/zzzz-dracut-default.network.


## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

