### PR TITLE
gen-networkd: wpa supplicant unit requires netplan-configure.service

### DIFF
--- a/src/gen-networkd.c
+++ b/src/gen-networkd.c
@@ -178,6 +178,7 @@ write_wpa_unit(const NetplanNetDefinition* def, const char* generator_dir, gbool
     g_string_append(s, "DefaultDependencies=no\n");
     g_string_append_printf(s, "Requires=sys-subsystem-net-devices-%s.device\n", stdouth);
     g_string_append_printf(s, "After=sys-subsystem-net-devices-%s.device\n", stdouth);
+    g_string_append(s, "Requires=netplan-configure.service\nAfter=netplan-configure.service\n");
     g_string_append(s, "Before=network.target\nWants=network.target\n\n");
     g_string_append(s, "[Service]\nType=simple\n");
     g_string_append_printf(s, "ExecStart=/sbin/wpa_supplicant -c /run/netplan/wpa-%s.conf -i%s", stdouth, stdouth);

--- a/tests/generator/base.py
+++ b/tests/generator/base.py
@@ -98,6 +98,8 @@ Description=WPA supplicant for netplan %(iface)s
 DefaultDependencies=no
 Requires=sys-subsystem-net-devices-%(iface)s.device
 After=sys-subsystem-net-devices-%(iface)s.device
+Requires=netplan-configure.service
+After=netplan-configure.service
 Before=network.target
 Wants=network.target
 


### PR DESCRIPTION
## Description

wpa_supplicant reads its configuration from
/run/netplan/wpa-<iface>.conf, which is written by netplan-configure.service. Without an explicit Requires=/After= dependency, wpa_supplicant could start before the config file is available, causing it to fail.

LP: #2145061

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [x] \(Optional\) Closes an open bug in Launchpad.

