### PR TITLE
chore: add dev container support for simplicity

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,12 +2,12 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# netplan dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash-completion \
     build-essential \
     cmake \
     gcovr \
-    git \
     libcmocka-dev \
     libglib2.0-dev \
     libsystemd-dev \
@@ -24,16 +24,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pytest \
     python3-pytest-cov \
     python3-yaml \
-    sudo \
     systemd \
     udev \
     uuid-dev \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -s /bin/bash netplan && \
-    usermod -aG sudo netplan && \
-    echo "netplan ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/netplan
+# devcontainer dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    sudo \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "ubuntu ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/ubuntu \
+    && chmod 0440 /etc/sudoers.d/ubuntu
 
 WORKDIR /workspace
 
-USER netplan
+USER ubuntu

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash-completion \
+    build-essential \
+    cmake \
+    gcovr \
+    git \
+    libcmocka-dev \
+    libglib2.0-dev \
+    libsystemd-dev \
+    libyaml-dev \
+    meson \
+    network-manager \
+    pandoc \
+    pkg-config \
+    pycodestyle \
+    pyflakes3 \
+    python3-cffi \
+    python3-coverage \
+    python3-dev \
+    python3-pytest \
+    python3-pytest-cov \
+    python3-yaml \
+    sudo \
+    systemd \
+    udev \
+    uuid-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m -s /bin/bash netplan && \
+    usermod -aG sudo netplan && \
+    echo "netplan ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/netplan
+
+WORKDIR /workspace
+
+USER netplan

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
       "dockerfile": "Dockerfile",
       "context": ".."
     },
-  "remoteUser": "netplan"
+  "remoteUser": "ubuntu"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "Netplan Development",
+  "build": {
+      "dockerfile": "Dockerfile",
+      "context": ".."
+    },
+  "remoteUser": "netplan"
+}

--- a/HACKING.md
+++ b/HACKING.md
@@ -2,20 +2,6 @@
 
 ## Container Usage
 
-### Manual Docker Workflow
-
-Build the development image:
-
-```sh
-$ docker build -t netplan-dev -f .devcontainer/Dockerfile .
-```
-
-Run an interactive shell:
-
-```sh
-$ docker run -it --rm -v "$(pwd):/workspace" --name netplan-dev netplan-dev bash
-```
-
 ### VS Code Dev Container
 
 A devcontainer is provided under `.devcontainer/`.

--- a/HACKING.md
+++ b/HACKING.md
@@ -13,4 +13,4 @@ A devcontainer is provided under `.devcontainer/`.
 ## Notes
 
 - The Docker image is useful for reproducible builds and many tests.
-- Some system-level integration scenarios (for example, full network service lifecycle behavior) are better exercised in LXD or VM-based environments.
+- Some system-level integration scenarios (for example, full network service lifecycle behavior) are better exercised VM-based environments.

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,30 @@
+# Hacking Guide
+
+## Container Usage
+
+### Manual Docker Workflow
+
+Build the development image:
+
+```sh
+$ docker build -t netplan-dev -f .devcontainer/Dockerfile .
+```
+
+Run an interactive shell:
+
+```sh
+$ docker run -it --rm -v "$(pwd):/workspace" --name netplan-dev netplan-dev bash
+```
+
+### VS Code Dev Container
+
+A devcontainer is provided under `.devcontainer/`.
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+2. Open this repository in VS Code.
+3. Run `Dev Containers: Reopen in Container` from the Command Palette.
+
+## Notes
+
+- The Docker image is useful for reproducible builds and many tests.
+- Some system-level integration scenarios (for example, full network service lifecycle behavior) are better exercised in LXD or VM-based environments.

--- a/README.md
+++ b/README.md
@@ -43,24 +43,38 @@ If you face issues, refer to our [comprehensive contribution guide](https://netp
 
 A Docker-based development environment is available via `.devcontainer/` for consistent builds across machines.
 
-## Using the Dev Container
-
-### With VS Code
-
-1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-2. Open the workspace in a container: Open the Command Palette and run "Dev Containers: Reopen in Container"
-3. The container automatically installs all dependencies and configures the `ubuntu` user
-
-### Manual Docker Build
-
-```sh
-$ docker build -t netplan-dev -f .devcontainer/Dockerfile .
-$ docker run -it --rm -v $(pwd):/workspace --name netplan-dev netplan-dev bash
-```
+For development workflows (including VS Code container usage), see [HACKING.md](HACKING.md).
 
 # Build dependencies
 
-For a manual setup without containers, install the required build and test dependencies. The full list of dependencies is defined in [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile#L6) under the `# netplan dependencies` section.
+For a manual setup without containers, install the required build and test dependencies:
+
+```sh
+$ sudo apt install \
+    bash-completion \
+    build-essential \
+    cmake \
+    gcovr \
+    libcmocka-dev \
+    libglib2.0-dev \
+    libsystemd-dev \
+    libyaml-dev \
+    meson \
+    network-manager \
+    pandoc \
+    pkg-config \
+    pycodestyle \
+    pyflakes3 \
+    python3-cffi \
+    python3-coverage \
+    python3-dev \
+    python3-pytest \
+    python3-pytest-cov \
+    python3-yaml \
+    systemd \
+    udev \
+    uuid-dev \
+```
 
 # Build using Meson
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For development workflows (including VS Code container usage), see [HACKING.md](
 For a manual setup without containers, install the required build and test dependencies:
 
 ```sh
-$ sudo apt install \
+sudo apt install \
     build-essential \
     pkg-config \
     meson \
@@ -100,7 +100,7 @@ Convenience targets are available via `make`:
 - `make run ARGS='<command>'`  
   Run the locally built netplan CLI with the appropriate environment, for example, to run `netplan help`:
   ```sh
-  $ make run ARGS="help"
+  make run ARGS="help"
   ```
 
 # Test local build
@@ -108,14 +108,14 @@ Convenience targets are available via `make`:
 After running:
 
 ```sh
-$ make
-$ make install
+make
+make install
 ```
 
 the locally built `netplan` can be tested without installing it system-wide:
 
 ```sh
-$ make run ARGS="<command>"
+make run ARGS="<command>"
 ```
 
 This wrapper sets the required environment variables (such as `NETPLAN_GENERATE_PATH`) automatically. These are needed because the Python CLI resolves binary and library paths at runtime.
@@ -123,7 +123,7 @@ This wrapper sets the required environment variables (such as `NETPLAN_GENERATE_
 As an example, let's use `make run` to run `netplan info`:
 
 ```sh
-$ make run ARGS="info"
+make run ARGS="info"
 # output:
 netplan.io:
   website: "https://netplan.io/"

--- a/README.md
+++ b/README.md
@@ -39,38 +39,28 @@ To contribute documentation, these steps should get you started:
 
 If you face issues, refer to our [comprehensive contribution guide](https://netplan.readthedocs.io/en/stable/contribute-docs/).
 
-# Build dependencies
+# Development Container
 
-> If you prefer using a prebuilt development environment, see the dev container image definition in [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile).
+A Docker-based development environment is available via `.devcontainer/` for consistent builds across machines.
 
-Install the required build and test dependencies (Ubuntu/Debian):
+## Using the Dev Container
+
+### With VS Code
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Open the workspace in a container: Open the Command Palette and run "Dev Containers: Reopen in Container"
+3. The container automatically installs all dependencies and configures the `ubuntu` user
+
+### Manual Docker Build
 
 ```sh
-sudo apt install \
-    bash-completion \
-    build-essential \
-    cmake \
-    gcovr \
-    libcmocka-dev \
-    libglib2.0-dev \
-    libsystemd-dev \
-    libyaml-dev \
-    meson \
-    network-manager \
-    pandoc \
-    pkg-config \
-    pycodestyle \
-    pyflakes3 \
-    python3-cffi \
-    python3-coverage \
-    python3-dev \
-    python3-pytest \
-    python3-pytest-cov \
-    python3-yaml \
-    systemd \
-    udev \
-    uuid-dev
+$ docker build -t netplan-dev -f .devcontainer/Dockerfile .
+$ docker run -it --rm -v $(pwd):/workspace --name netplan-dev netplan-dev bash
 ```
+
+# Build dependencies
+
+For a manual setup without containers, install the required build and test dependencies. The full list of dependencies is defined in [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile#L6) under the `# netplan dependencies` section.
 
 # Build using Meson
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ To contribute documentation, these steps should get you started:
 
 If you face issues, refer to our [comprehensive contribution guide](https://netplan.readthedocs.io/en/stable/contribute-docs/).
 
-# Development Container
-
-A Docker-based development environment is available via `.devcontainer/` for consistent builds across machines.
-
 For development workflows (including VS Code container usage), see [HACKING.md](HACKING.md).
 
 # Build dependencies
@@ -51,29 +47,24 @@ For a manual setup without containers, install the required build and test depen
 
 ```sh
 $ sudo apt install \
-    bash-completion \
     build-essential \
-    cmake \
-    gcovr \
-    libcmocka-dev \
-    libglib2.0-dev \
-    libsystemd-dev \
-    libyaml-dev \
-    meson \
-    network-manager \
-    pandoc \
     pkg-config \
-    pycodestyle \
-    pyflakes3 \
+    meson \
+    libglib2.0-dev \
+    libyaml-dev \
+    libsystemd-dev \
+    uuid-dev \
+    bash-completion \
+    python3-dev \
     python3-cffi \
     python3-coverage \
-    python3-dev \
     python3-pytest \
     python3-pytest-cov \
-    python3-yaml \
-    systemd \
-    udev \
-    uuid-dev \
+    pyflakes3 \
+    pycodestyle \
+    libcmocka-dev \
+    gcovr \
+    pandoc
 ```
 
 # Build using Meson

--- a/README.md
+++ b/README.md
@@ -41,28 +41,35 @@ If you face issues, refer to our [comprehensive contribution guide](https://netp
 
 # Build dependencies
 
+> If you prefer using a prebuilt development environment, see the dev container image definition in [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile).
+
 Install the required build and test dependencies (Ubuntu/Debian):
 
 ```sh
 sudo apt install \
-    build-essential \
-    pkg-config \
-    meson \
-    libglib2.0-dev \
-    libyaml-dev \
-    libsystemd-dev \
-    uuid-dev \
     bash-completion \
-    python3-dev \
+    build-essential \
+    cmake \
+    gcovr \
+    libcmocka-dev \
+    libglib2.0-dev \
+    libsystemd-dev \
+    libyaml-dev \
+    meson \
+    network-manager \
+    pandoc \
+    pkg-config \
+    pycodestyle \
+    pyflakes3 \
     python3-cffi \
     python3-coverage \
+    python3-dev \
     python3-pytest \
     python3-pytest-cov \
-    pyflakes3 \
-    pycodestyle \
-    libcmocka-dev \
-    gcovr \
-    pandoc
+    python3-yaml \
+    systemd \
+    udev \
+    uuid-dev
 ```
 
 # Build using Meson


### PR DESCRIPTION
This pull request introduces a development container setup to streamline onboarding and development for the Netplan project. It also completes the dependencies list.

**Dev container environment:**

* `.devcontainer/Dockerfile` - define a reproducible Ubuntu 24.04-based development environment
* `.devcontainer/devcontainer.json` - configure the dev container

**Documentation updates:**

* Updated the `README.md` to mention the new dev container as an alternative to manual dependency installation, and revised the dependency list to match the packages installed in the dev container.

