### PR TITLE
ci: fix CI failures

### DIFF
--- a/.github/workflows/autopkgtest.yml
+++ b/.github/workflows/autopkgtest.yml
@@ -34,14 +34,30 @@ jobs:
       - name: Install dependencies
         run: |
           echo "APT::Get::Always-Include-Phased-Updates \"true\";" | sudo tee /etc/apt/apt.conf.d/90phased-updates
+          echo 'Acquire::Retries "6";' | sudo tee /etc/apt/apt.conf.d/80-retries
+          echo 'Acquire::http::Timeout "30";' | sudo tee /etc/apt/apt.conf.d/81-timeout
+          echo '--- apt retry/timeout config ---'
+          cat /etc/apt/apt.conf.d/80-retries /etc/apt/apt.conf.d/81-timeout
           sudo add-apt-repository -y -n -s ppa:slyon/netplan-ci
+          echo '--- apt sources ---'
+          cat /etc/apt/sources.list.d/*.list 2>/dev/null || true
           sudo apt update
           sudo apt install autopkgtest dnsmasq-base ubuntu-dev-tools devscripts openvswitch-switch linux-modules-extra-$(uname -r)
+          echo '--- installed versions ---'
+          dpkg-query -W autopkgtest lxd-installer 2>/dev/null || true
       # work around LP: #1878225 as fallback
       - name: Preparing autopkgtest-build-lxd
         run: |
           sudo patch /usr/share/autopkgtest/lib/build-lxd.sh .github/workflows/snapd.patch
           autopkgtest-build-lxd ubuntu-daily:noble
+          # Make apt inside the testbed more resilient to transient mirror issues.
+          lxc start autopkgtest/ubuntu/noble/amd64
+          lxc exec autopkgtest/ubuntu/noble/amd64 -- sh -ec 'echo "Acquire::Retries \"6\";" > /etc/apt/apt.conf.d/80-retries && echo "Acquire::http::Timeout \"30\";" > /etc/apt/apt.conf.d/81-timeout'
+          echo '--- apt config inside testbed ---'
+          lxc exec autopkgtest/ubuntu/noble/amd64 -- cat /etc/apt/apt.conf.d/80-retries /etc/apt/apt.conf.d/81-timeout
+          echo '--- LXD image list ---'
+          lxc image list
+          lxc stop autopkgtest/ubuntu/noble/amd64
       - name: Prepare test
         run: |
           # Ugly workaround for the "cloud-init.sh" test while waiting for 1.1.2-8 in Ubuntu
@@ -63,9 +79,25 @@ jobs:
           dch -v "$VER" "Autopkgtest CI testing (Noble)"
       - name: Run autopkgtest (incl. build)
         run: |
-          autopkgtest . -U \
-            --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 \
-            --env=NETPLAN_PARSER_IGNORE_ERRORS=1 \
-            --setup-commands='mkdir -p /etc/systemd/system/NetworkManager.service.d && echo "[Service]\nCapabilityBoundingSet=CAP_CHOWN\n" > /etc/systemd/system/NetworkManager.service.d/override.conf && systemctl daemon-reload' \
-            -- lxd autopkgtest/ubuntu/noble/amd64 \
-            || test $? -eq 2  # allow wifi test to be skipped (exit code = 2)
+          run_autopkgtest() {
+            autopkgtest . -U \
+              --env=DPKG_GENSYMBOLS_CHECK_LEVEL=0 \
+              --env=NETPLAN_PARSER_IGNORE_ERRORS=1 \
+              --setup-commands='mkdir -p /etc/systemd/system/NetworkManager.service.d && echo "[Service]\nCapabilityBoundingSet=CAP_CHOWN\n" > /etc/systemd/system/NetworkManager.service.d/override.conf && systemctl daemon-reload' \
+              -- lxd autopkgtest/ubuntu/noble/amd64
+          }
+
+          run_autopkgtest || {
+            rc=$?
+            echo "autopkgtest exited with code $rc"
+            # Retry once to absorb transient apt mirror sync mismatches in the testbed.
+            if [ "$rc" -ne 2 ]; then
+              echo "First autopkgtest attempt failed with exit code $rc, retrying once..."
+              echo '--- LXD container list before retry ---'
+              lxc list
+              run_autopkgtest
+              rc=$?
+              echo "autopkgtest retry exited with code $rc"
+            fi
+            test "$rc" -eq 0 -o "$rc" -eq 2  # allow wifi test to be skipped (exit code = 2)
+          }

--- a/.github/workflows/debci.yml
+++ b/.github/workflows/debci.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apparmor_parser -R /etc/apparmor.d/usr.bin.lxc-start
           sudo ln -s /etc/apparmor.d/usr.bin.lxc-start /etc/apparmor.d/disable/
           echo "lxc.apparmor.profile = unconfined" | sudo tee -a /etc/lxc/default.conf
-          sudo debci setup -s testing -a amd64 -b lxc
+          sudo debci setup -s stable -a amd64 -b lxc
       - name: Prepare test
         run: |
           # pull-debian-source netplan.io  # snapshot.debian.org is not up-to-date

--- a/doc/dbus-config.md
+++ b/doc/dbus-config.md
@@ -2,7 +2,7 @@
 
 See also:
 * [Netplan D-Bus reference](/netplan-dbus)
-* [`busctl` reference](https://www.freedesktop.org/software/systemd/man/busctl.html)
+* [`busctl` reference](https://man7.org/linux/man-pages/man1/busctl.1.html)
 
 Copy the current state from `/{etc,run,lib}/netplan/*.yaml` by creating a new configuration object:
 

--- a/doc/generator.md
+++ b/doc/generator.md
@@ -2,7 +2,7 @@
 title: "Netplan Generator"
 ---
 
-Netplan uses a [systemd-generator](https://www.freedesktop.org/software/systemd/man/latest/systemd.generator.html)
+Netplan uses a [systemd-generator](https://man7.org/linux/man-pages/man7/systemd.generator.7.html)
 to emit network configuration at boot time. This generator is called very early during the boot
 process to ensure that all the configuration needed will be available for the back end
 the user chose to use.


### PR DESCRIPTION
### Replace links with occasional protections
* Updated the `busctl` reference link in `doc/dbus-config.md` to point to the man7.org man page.
* Updated the `systemd-generator` reference link in `doc/generator.md` to use the man7.org man page.
### Switch to stable Debian release
Changed the `debci` test setup in `.github/workflows/debci.yml` to use the `stable` suite instead of `testing` for improved stability.
### Add retry mechanism for `apt update`
* Added apt retry (`Acquire::Retries "6"`) and timeout (`Acquire::http::Timeout "30"`) configuration to both the main environment and the LXD testbed in `.github/workflows/autopkgtest.yml`, along with additional logging of apt configuration, sources, and installed package versions.
* Wrapped the `autopkgtest` command in a shell function to allow for a single retry if the first attempt fails (except for exit code 2, which is allowed for skipped wifi tests), and added logging of LXD container state before retrying.

