### PR TITLE
ci: replace freedesktop links with man7

### DIFF
--- a/doc/dbus-config.md
+++ b/doc/dbus-config.md
@@ -2,7 +2,7 @@
 
 See also:
 * [Netplan D-Bus reference](/netplan-dbus)
-* [`busctl` reference](https://www.freedesktop.org/software/systemd/man/busctl.html)
+* [`busctl` reference](https://man7.org/linux/man-pages/man1/busctl.1.html)
 
 Copy the current state from `/{etc,run,lib}/netplan/*.yaml` by creating a new configuration object:
 

--- a/doc/generator.md
+++ b/doc/generator.md
@@ -2,7 +2,7 @@
 title: "Netplan Generator"
 ---
 
-Netplan uses a [systemd-generator](https://www.freedesktop.org/software/systemd/man/latest/systemd.generator.html)
+Netplan uses a [systemd-generator](https://man7.org/linux/man-pages/man7/systemd.generator.7.html)
 to emit network configuration at boot time. This generator is called very early during the boot
 process to ensure that all the configuration needed will be available for the back end
 the user chose to use.


### PR DESCRIPTION
Freedesktop links have enabled "AI scraper block / go-away page" protection, which can occasionally cause CI failures.

Documentation link updates:

* Updated the `busctl` reference link in `doc/dbus-config.md` to use the man7.org man page
* Updated the `systemd-generator` reference link in `doc/generator.md` to use the man7.org man page
