### PR TITLE
Handle the spread repository URL change

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install spread
         run: |
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
       - name: Run the spread test inside LXD
         run: |
           ~/go/bin/spread -v lxd:

--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -87,7 +87,7 @@ class NetplanApply(utils.NetplanCommand):
             #      using core20 netplan binary/client/CLI on core18 base systems. Any change
             #      must be agreed upon with the snapd team, so we don't break support for
             #      base systems running older netplan versions.
-            #      https://github.com/snapcore/snapd/pull/5915
+            #      https://github.com/canonical/snapd/pull/5915
             res = subprocess.call([busctl, "call", "--quiet", "--system",
                                    "io.netplan.Netplan",  # the service
                                    "/io/netplan/Netplan",  # the object

--- a/netplan_cli/cli/commands/generate.py
+++ b/netplan_cli/cli/commands/generate.py
@@ -58,7 +58,7 @@ class NetplanGenerate(utils.NetplanCommand):
             #      using core20 netplan binary/client/CLI on core18 base systems. Any change
             #      must be agreed upon with the snapd team, so we don't break support for
             #      base systems running older netplan versions.
-            #      https://github.com/snapcore/snapd/pull/10212
+            #      https://github.com/canonical/snapd/pull/10212
             res = subprocess.call([busctl, "call", "--quiet", "--system",
                                    "io.netplan.Netplan",  # the service
                                    "/io/netplan/Netplan",  # the object


### PR DESCRIPTION
## Description
The spread github repository location is moved from from snapcore/spread to canonical/spread. This was leading to the failure of spread tests in the automated CI/CD workflow.

## Checklist

- [&check;] Runs `make check` successfully.
- [&check;] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

