### PR TITLE
Setup asan run's prefix to ensure openvswitch binaries are in the path

### DIFF
--- a/tools/run_asan.sh
+++ b/tools/run_asan.sh
@@ -7,10 +7,10 @@ BUILDDIR="_leakcheckbuild"
 CLEANBUILDDIR="_cleanbuild"
 CC=gcc
 
-meson setup ${BUILDDIR} -Db_sanitize=address,undefined
+meson setup ${BUILDDIR} -Db_sanitize=address,undefined -Dprefix=/usr
 meson compile -C ${BUILDDIR} --verbose
 
-meson setup ${CLEANBUILDDIR}
+meson setup ${CLEANBUILDDIR} -Dprefix=/usr
 meson compile -C ${CLEANBUILDDIR} --verbose
 
 ${CC} tools/keyfile_to_yaml.c -o tools/keyfile_to_yaml \


### PR DESCRIPTION
## Description

Setup asan run's prefix to ensure openvswitch binaries are in the path

## Checklist

- [ &check;] Runs `make check` successfully.
- [ &check;] Retains code coverage (`make check-coverage`).
- [ ] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Adds example YAML for new feature.
- [ ] \(Optional\) Closes an open bug in Launchpad.

