### PR TITLE
Fix: support WireGuard link-local remotes with ifindex specifier

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -2647,11 +2647,16 @@ handle_wireguard_endpoint(NetplanParser* npp, yaml_node_t* node, __unused const 
         return yaml_error(npp, node, error, "invalid endpoint address or hostname '%s'", scalar(node));
     }
     if (endpoint[0] == '[') {
-        /* this is an ipv6 endpoint in [ad:rr:ee::ss]:port form */
+        /* this is an ipv6 endpoint in [ad:rr:ee::ss%zoneIdx]:port form. The zone index is optional */
         char *endbrace = strrchr(endpoint, ']');
         if (!endbrace)
             return yaml_error(npp, node, error, "invalid address in endpoint '%s'", scalar(node));
         address = endpoint + 1;
+        /* If a zone index is specified, use the % sign to delimit the ipv6 address portion of the endpoint */
+        char *zone_separator = strrchr(address, '%');
+        if (zone_separator) {
+            endbrace = zone_separator;
+        }
         *endbrace = '\0';
         port = strrchr(endbrace + 1, ':');
     } else {

--- a/tests/generator/test_tunnels.py
+++ b/tests/generator/test_tunnels.py
@@ -568,6 +568,30 @@ persistent-keepalive=23
 endpoint=[2001:fe:ad:de:ad:be:ef:11]:5
 allowed-ips=0.0.0.0/0;2001:fe:ad:de:ad:be:ef:1/24;''')})
 
+    def test_ipv6_linklocal_remote(self):
+        """[wireguard] Validate generation of wireguard config with v6 linklocal remote endpoint"""
+        config = prepare_wg_config(listen=12345, privkey='4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=',
+                                   peers=[{'public-key': 'M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=',
+                                           'allowed-ips': '[0.0.0.0/0, "::/0"]',
+                                           'keepalive': 23,
+                                           'endpoint': '"[fe80::5054:ff:fe75:5b1f%enp1s0]:5"'}], renderer=self.backend)
+        self.generate(config, expect_fail=False)
+        if self.backend == 'networkd':
+            self.assert_networkd({'wg0.netdev': ND_WG % ('=4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=', '12345', '''
+[WireGuardPeer]
+PublicKey=M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=
+AllowedIPs=0.0.0.0/0,::/0
+PersistentKeepalive=23
+Endpoint=[fe80::5054:ff:fe75:5b1f%enp1s0]:5'''),
+                                  'wg0.network': ND_WITHIPGW % ('wg0', '15.15.15.15/24', '2001:de:ad:be:ef:ca:fe:1/128',
+                                                                '20.20.20.21')})
+        elif self.backend == 'NetworkManager':
+            self.assert_nm({'wg0.nmconnection': NM_WG % ('4GgaQCy68nzNsUE5aJ9fuLzHhB65tAlwbmA72MWnOm8=', '12345', '''
+[wireguard-peer.M9nt4YujIOmNrRmpIRTmYSfMdrpvE7u6WkG8FY8WjG4=]
+persistent-keepalive=23
+endpoint=[fe80::5054:ff:fe75:5b1f%enp1s0]:5
+allowed-ips=0.0.0.0/0;::/0;''')})
+
     def test_vxlan(self):
         out = self.generate('''network:
   renderer: %(r)s


### PR DESCRIPTION
Netplan currently rejects Wireguard link-local remotes, if they specify an interfaces index.
For instance, setting `endpoint: "[fe80::5054:ff:fe75:5b1f%enp1s0]:51820"` on a peer fails with the following error:
```
# netplan apply
/run/netplan/10-lexnet.yaml:33:19: Error in network definition: invalid endpoint address or hostname '[fe80::5054:ff:fe75:5b1f%enp1s0]:51820'
        endpoint: "[fe80::5054:ff:fe75:5b1f%enp1s0]:51820"
                  ^
```

This is a bug as [these are valid IPv6 addresses](https://en.wikipedia.org/wiki/IPv6_address#Scoped_literal_IPv6_addresses_(with_zone_index)), and wireguard itself accepts them without any issue:
```
# wg
interface: wg0
  public key: REDACTED
  private key: (hidden)
  listening port: 51820

peer: REDACTED
  endpoint: [fe80::5054:ff:fe75:5b1f%enp1s0]:51820
  allowed ips: ::/0, 0.0.0.0/0
  latest handshake: 22 seconds ago
  transfer: 360 B received, 280 B sent
  persistent keepalive: every 10 seconds
```
This PR introduces support for an arbitrary ifindex string, within a Wireguard remote endpoint specification.


I wasn't yet able to file this as a bug on Launchpad as I'm not receiving the e-mail verification to create an account, but I'm opening the PR already as I had the fix ready.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`). (**the new lines are covered**)
- [x] New/changed keys in YAML format are documented. (**no YAML format changes**)
