### PR TITLE
fix: added fix to handle exception on file permission issue

### DIFF
--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -115,7 +115,7 @@ class NetplanApply(utils.NetplanCommand):
             old_ovs_glob.remove(ovs_cleanup_service)
         old_files_ovs = bool(old_ovs_glob)
         old_nm_glob = glob.glob('/run/NetworkManager/system-connections/netplan-*')
-        nm_ifaces = utils.nm_interfaces(old_nm_glob, utils.get_interfaces())
+        nm_ifaces = NetplanApply._get_nm_interfaces(old_nm_glob, utils.get_interfaces(), exit_on_error)
         old_files_nm = bool(old_nm_glob)
 
         configure = []
@@ -157,7 +157,7 @@ class NetplanApply(utils.NetplanCommand):
             restart_networkd = True
 
         restart_nm_glob = glob.glob('/run/NetworkManager/system-connections/netplan-*')
-        nm_ifaces.update(utils.nm_interfaces(restart_nm_glob, devices))
+        nm_ifaces.update(NetplanApply._get_nm_interfaces(restart_nm_glob, devices, exit_on_error))
         restart_nm = bool(restart_nm_glob)
         if not restart_nm and old_files_nm:
             restart_nm = True
@@ -289,7 +289,7 @@ class NetplanApply(utils.NetplanCommand):
         if restart_nm:
             # Flush all IP addresses of NM managed interfaces, to avoid NM creating
             # new, non netplan-* connection profiles, using the existing IPs.
-            nm_interfaces = utils.nm_interfaces(restart_nm_glob, devices)
+            nm_interfaces = NetplanApply._get_nm_interfaces(restart_nm_glob, devices, exit_on_error)
             for iface in nm_interfaces:
                 utils.ip_addr_flush(iface)
             # clear NM state, especially the [device].managed=true config, as that might have been
@@ -412,3 +412,13 @@ class NetplanApply(utils.NetplanCommand):
             logging.warning('Cannot call Open vSwitch: {}.'.format(e))
         except OvsDbServerNotInstalled as e:
             logging.debug('Cannot call Open vSwitch: %s.', e)
+
+    @staticmethod
+    def _get_nm_interfaces(paths, devices, exit_on_error):
+        try:
+            return utils.nm_interfaces(paths, devices)
+        except PermissionError as e:
+            logging.error('%s', e)
+            if exit_on_error:
+                sys.exit(os.EX_NOPERM)
+            raise

--- a/tests/cli/test_units.py
+++ b/tests/cli/test_units.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import errno
 import os
 import shutil
 import sys
@@ -214,3 +215,28 @@ class TestCLI(unittest.TestCase):
 
             args = log.call_args.args
             self.assertIn("VRF routes table mismatch", args[0])
+
+    @patch('netplan_cli.cli.utils.nm_interfaces')
+    def test_get_nm_interfaces_permission_error_exits(self, mock_nm):
+        """LP#2154081: PermissionError with exit_on_error=True must exit
+        cleanly with EX_NOPERM, not crash with an uncaught exception."""
+        file_path = '/run/NetworkManager/system-connections/netplan-eth0.nmconnection'
+        mock_nm.side_effect = PermissionError(errno.EACCES, os.strerror(errno.EACCES), file_path)
+        with self.assertLogs('', level='ERROR') as ctx:
+            with self.assertRaises(SystemExit) as e:
+                NetplanApply._get_nm_interfaces([file_path],
+                                                ['eth0'], exit_on_error=True)
+        self.assertEqual(e.exception.code, os.EX_NOPERM)
+        self.assertTrue(any(os.strerror(errno.EACCES) in msg for msg in ctx.output))
+
+    @patch('netplan_cli.cli.utils.nm_interfaces')
+    def test_get_nm_interfaces_permission_error_raises(self, mock_nm):
+        """LP#2154081: PermissionError with exit_on_error=False must re-raise
+        so that netplan try can catch it and trigger a revert."""
+        file_path = '/run/NetworkManager/system-connections/netplan-eth0.nmconnection'
+        mock_nm.side_effect = PermissionError(errno.EACCES, os.strerror(errno.EACCES), file_path)
+        with self.assertLogs('', level='ERROR') as ctx:
+            with self.assertRaises(PermissionError):
+                NetplanApply._get_nm_interfaces([file_path],
+                                                ['eth0'], exit_on_error=False)
+        self.assertTrue(any(os.strerror(errno.EACCES) in msg for msg in ctx.output))


### PR DESCRIPTION
With NetworkManager as backend, the netplan apply command was leading to uncaught exception and triggering Apport crash report. The crash was due to uncaught permission exception thrown while accessing network configuration files. The added fix catches exception and exits with the corresponding error code.

Tests: The issue was recreated in a VM with NetworkManager as backend. Later the fixed repository code was installed in the same VM and the exception backtrace was not seen.

Closes  LP#2154081