### PR TITLE
fix(ci): Added setuptool package to the rpm build file

### DIFF
--- a/rpm/netplan.spec
+++ b/rpm/netplan.spec
@@ -37,6 +37,7 @@ BuildRequires:  python3-devel
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  %{_bindir}/pandoc
 BuildRequires:  python3dist(cffi)
+BuildRequires:  python3dist(setuptools)
 %if %{with tests}
 # For tests
 BuildRequires:  %{_sbindir}/ip


### PR DESCRIPTION
The build depends on distutils package. In python <3.12, this was available as part of standard library. In the python version >=3.12, setuptools package provides distutils. As the fedora releases moved to newer python version, the build started failing.

