### PR TITLE
Extend 'critical' to accept KeepConfiguration scalar values

### DIFF
--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -372,11 +372,23 @@ Match devices by MAC when setting options like: `wakeonlan` or `*-offload`.
   > (networkd back end only) Allow the specified interface to be configured even
   > if it has no carrier.
 
-- **`critical`** (boolean)
+- **`critical`** (boolean or scalar)
 
   > Designate the connection as "critical to the system", meaning that special
   > care will be taken by to not release the assigned IP when the daemon is
   > restarted. (not recognised by NetworkManager)
+  >
+  > Accepts boolean values (`true`/`false`) for backwards compatibility, or
+  > one of the following scalar values that map directly to the systemd-networkd
+  > `KeepConfiguration=` setting:
+  >
+  > - `true` (default when set) – preserve all routes and addresses
+  > - `static` – preserve only static routes and addresses
+  > - `dynamic` – preserve dynamically assigned (DHCP/SLAAC) routes and addresses
+  > - `dynamic-on-stop` – preserve dynamic leases only when networkd stops
+  >
+  > The legacy aliases `dhcp` and `dhcp-on-stop` are also accepted as input
+  > (mapped to `dynamic` and `dynamic-on-stop` respectively).
 
 - **`dhcp-identifier`** (scalar)
 

--- a/python-cffi/netplan/__init__.py
+++ b/python-cffi/netplan/__init__.py
@@ -19,7 +19,7 @@ import os
 from typing import Union, List, IO
 
 from ._netplan_cffi import lib
-from .netdef import NetDefinition, NetDefinitionIterator
+from .netdef import NetDefinition, NetDefinitionIterator, KeepConfiguration
 from .parser import Parser
 from .state import State
 from ._utils import _checked_lib_call
@@ -67,6 +67,7 @@ def _create_yaml_patch(patch_object_path: List[str], patch_payload: Union[str, d
 
 # Re-export submodules
 __all__ = ['Parser', 'State', 'NetDefinition', 'NetDefinitionIterator',
+           'KeepConfiguration',
            '_dump_yaml_subtree', '_create_yaml_patch',
            'NetplanException', 'NetplanBackendException', 'NetplanEmitterException',
            'NetplanFileException', 'NetplanFormatException', 'NetplanParserException',

--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -120,6 +120,7 @@ ffibuilder.cdef("""
     gboolean _netplan_netdef_get_sriov_vlan_filter(const NetplanNetDefinition* netdef);
     guint _netplan_netdef_get_vlan_id(const NetplanNetDefinition* netdef);
     gboolean _netplan_netdef_get_critical(const NetplanNetDefinition* netdef);
+    int _netplan_netdef_get_keep_configuration(const NetplanNetDefinition* netdef);
     gboolean _netplan_netdef_get_delay_virtual_functions_rebind(const NetplanNetDefinition* netdef);
     gboolean _netplan_netdef_is_trivial_compound_itf(const NetplanNetDefinition* netdef);
     int _netplan_state_get_vf_count_for_def(

--- a/python-cffi/netplan/netdef.py
+++ b/python-cffi/netplan/netdef.py
@@ -14,10 +14,19 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import Optional
 
 from ._netplan_cffi import ffi, lib
 from ._utils import _string_realloc_call_no_error, NetplanException
+
+
+class KeepConfiguration(IntEnum):
+    FALSE = 0
+    TRUE = 1
+    STATIC = 2
+    DYNAMIC = 3
+    DYNAMIC_ON_STOP = 4
 
 
 class NetDefinition():
@@ -108,6 +117,10 @@ class NetDefinition():
     @property
     def critical(self) -> bool:
         return bool(lib._netplan_netdef_get_critical(self._ptr))
+
+    @property
+    def keep_configuration(self) -> KeepConfiguration:
+        return KeepConfiguration(lib._netplan_netdef_get_keep_configuration(self._ptr))
 
     @property
     def links(self) -> dict:

--- a/src/abi.h
+++ b/src/abi.h
@@ -87,6 +87,14 @@ typedef enum {
 } NetplanRAMode;
 
 typedef enum {
+    NETPLAN_KEEP_CONFIGURATION_FALSE = 0,
+    NETPLAN_KEEP_CONFIGURATION_TRUE,
+    NETPLAN_KEEP_CONFIGURATION_STATIC,
+    NETPLAN_KEEP_CONFIGURATION_DYNAMIC,
+    NETPLAN_KEEP_CONFIGURATION_DYNAMIC_ON_STOP,
+} NetplanKeepConfiguration;
+
+typedef enum {
     NETPLAN_IB_MODE_KERNEL,
     NETPLAN_IB_MODE_DATAGRAM,
     NETPLAN_IB_MODE_CONNECTED,
@@ -230,7 +238,7 @@ struct netplan_net_definition {
     /* status options */
     gboolean optional;
     NetplanOptionalAddressFlag optional_addresses;
-    gboolean critical;
+    NetplanKeepConfiguration critical;
 
     /* addresses */
     gboolean dhcp4;

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -773,8 +773,18 @@ _serialize_yaml(
 
     if (def->optional)
         YAML_NONNULL_STRING_PLAIN(event, emitter, "optional", "true");
-    if (def->critical)
-        YAML_NONNULL_STRING_PLAIN(event, emitter, "critical", "true");
+    if (def->critical) {
+        const char* critical_val = "true";
+        if (def->critical == NETPLAN_KEEP_CONFIGURATION_STATIC)
+            critical_val = "static";
+        else if (def->critical == NETPLAN_KEEP_CONFIGURATION_DYNAMIC)
+            critical_val = "dynamic";
+        else if (def->critical == NETPLAN_KEEP_CONFIGURATION_DYNAMIC_ON_STOP)
+            critical_val = "dynamic-on-stop";
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "critical", critical_val);
+    } else if DIRTY(def, def->critical) {
+        YAML_NONNULL_STRING_PLAIN(event, emitter, "critical", "false");
+    }
 
     if (def->ignore_carrier)
         YAML_NONNULL_STRING_PLAIN(event, emitter, "ignore-carrier", "true");

--- a/src/networkd.c
+++ b/src/networkd.c
@@ -846,8 +846,16 @@ _netplan_netdef_write_network_file(
     if (def->type >= NETPLAN_DEF_TYPE_VIRTUAL || def->ignore_carrier)
         g_string_append(network, "ConfigureWithoutCarrier=yes\n");
 
-    if (def->critical)
-        g_string_append_printf(network, "KeepConfiguration=true\n");
+    if (def->critical) {
+        if (def->critical == NETPLAN_KEEP_CONFIGURATION_TRUE)
+            g_string_append(network, "KeepConfiguration=true\n");
+        else if (def->critical == NETPLAN_KEEP_CONFIGURATION_STATIC)
+            g_string_append(network, "KeepConfiguration=static\n");
+        else if (def->critical == NETPLAN_KEEP_CONFIGURATION_DYNAMIC)
+            g_string_append(network, "KeepConfiguration=dynamic\n");
+        else if (def->critical == NETPLAN_KEEP_CONFIGURATION_DYNAMIC_ON_STOP)
+            g_string_append(network, "KeepConfiguration=dynamic-on-stop\n");
+    }
 
     if (def->bridge && def->backend != NETPLAN_BACKEND_OVS) {
         g_string_append_printf(network, "Bridge=%s\n", def->bridge);

--- a/src/parse.c
+++ b/src/parse.c
@@ -1317,6 +1317,42 @@ handle_accept_ra(NetplanParser* npp, yaml_node_t* node, const void* data, GError
 }
 
 STATIC gboolean
+handle_critical(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
+{
+    const char* val = scalar(node);
+    NetplanKeepConfiguration mode;
+
+    /* Backwards compatible: accept boolean values */
+    if (g_ascii_strcasecmp(val, "true") == 0 ||
+        g_ascii_strcasecmp(val, "on") == 0 ||
+        g_ascii_strcasecmp(val, "yes") == 0 ||
+        g_ascii_strcasecmp(val, "y") == 0)
+        mode = NETPLAN_KEEP_CONFIGURATION_TRUE;
+    else if (g_ascii_strcasecmp(val, "false") == 0 ||
+             g_ascii_strcasecmp(val, "off") == 0 ||
+             g_ascii_strcasecmp(val, "no") == 0 ||
+             g_ascii_strcasecmp(val, "n") == 0)
+        mode = NETPLAN_KEEP_CONFIGURATION_FALSE;
+    /* Scalar values matching systemd-networkd KeepConfiguration= */
+    else if (g_ascii_strcasecmp(val, "static") == 0)
+        mode = NETPLAN_KEEP_CONFIGURATION_STATIC;
+    else if (g_ascii_strcasecmp(val, "dynamic") == 0 ||
+             g_ascii_strcasecmp(val, "dhcp") == 0)
+        mode = NETPLAN_KEEP_CONFIGURATION_DYNAMIC;
+    else if (g_ascii_strcasecmp(val, "dynamic-on-stop") == 0 ||
+             g_ascii_strcasecmp(val, "dhcp-on-stop") == 0)
+        mode = NETPLAN_KEEP_CONFIGURATION_DYNAMIC_ON_STOP;
+    else
+        return yaml_error(npp, node, error,
+            "invalid value '%s' for critical, must be a boolean or one of "
+            "'static', 'dynamic', 'dynamic-on-stop'", val);
+
+    npp->current.netdef->critical = mode;
+    mark_data_as_dirty(npp, &npp->current.netdef->critical);
+    return TRUE;
+}
+
+STATIC gboolean
 handle_activation_mode(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
 {
     if (g_strcmp0(scalar(node), "manual") && g_strcmp0(scalar(node), "off"))
@@ -2969,7 +3005,7 @@ static const mapping_entry_handler ra_overrides_handlers[] = {
     {"accept-ra", YAML_SCALAR_NODE, {.generic=handle_accept_ra}, netdef_offset(accept_ra)}, \
     {"activation-mode", YAML_SCALAR_NODE, {.generic=handle_activation_mode}, netdef_offset(activation_mode)}, \
     {"addresses", YAML_SEQUENCE_NODE, {.generic=handle_addresses}, NULL}, \
-    {"critical", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(critical)}, \
+    {"critical", YAML_SCALAR_NODE, {.generic=handle_critical}, NULL}, \
     {"ignore-carrier", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(ignore_carrier)}, \
     {"dhcp4", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(dhcp4)}, \
     {"dhcp6", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(dhcp6)}, \

--- a/src/types.c
+++ b/src/types.c
@@ -234,7 +234,7 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
 
     netdef->optional = FALSE;
     netdef->optional_addresses = 0;
-    netdef->critical = FALSE;
+    netdef->critical = NETPLAN_KEEP_CONFIGURATION_FALSE;
 
     netdef->dhcp4 = FALSE;
     netdef->dhcp6 = FALSE;
@@ -627,6 +627,13 @@ _netplan_netdef_get_vlan_id(const NetplanNetDefinition* netdef)
 
 gboolean
 _netplan_netdef_get_critical(const NetplanNetDefinition* netdef)
+{
+    g_assert(netdef != NULL);
+    return netdef->critical != NETPLAN_KEEP_CONFIGURATION_FALSE;
+}
+
+NetplanKeepConfiguration
+_netplan_netdef_get_keep_configuration(const NetplanNetDefinition* netdef)
 {
     g_assert(netdef != NULL);
     return netdef->critical;

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -115,6 +115,9 @@ _netplan_netdef_get_sriov_vlan_filter(const NetplanNetDefinition* netdef);
 NETPLAN_INTERNAL gboolean
 _netplan_netdef_get_critical(const NetplanNetDefinition* netdef);
 
+NETPLAN_INTERNAL NetplanKeepConfiguration
+_netplan_netdef_get_keep_configuration(const NetplanNetDefinition* netdef);
+
 NETPLAN_INTERNAL gboolean
 _netplan_netdef_get_optional(const NetplanNetDefinition* netdef);
 

--- a/tests/generator/test_common.py
+++ b/tests/generator/test_common.py
@@ -478,6 +478,95 @@ LinkLocalAddressing=ipv6
 KeepConfiguration=true
 '''})
 
+    def test_critical_static(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      critical: static
+''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+KeepConfiguration=static
+'''})
+
+    def test_critical_dynamic(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      critical: dynamic
+''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+KeepConfiguration=dynamic
+'''})
+
+    def test_critical_dynamic_on_stop(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      critical: dynamic-on-stop
+''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+KeepConfiguration=dynamic-on-stop
+'''})
+
+    def test_critical_dhcp_alias(self):
+        """dhcp/dhcp-on-stop are accepted as legacy aliases for dynamic/dynamic-on-stop"""
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      critical: dhcp
+''', skip_generated_yaml_validation=True)
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+KeepConfiguration=dynamic
+'''})
+
+    def test_critical_false(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      critical: false
+''')
+
+        self.assert_networkd({'engreen.network': '''[Match]
+Name=engreen
+
+[Network]
+LinkLocalAddressing=ipv6
+'''})
+
+    def test_critical_invalid(self):
+        err = self.generate('''network:
+  version: 2
+  ethernets:
+    engreen:
+      critical: invalid-value
+''', expect_fail=True)
+        self.assertIn("invalid value 'invalid-value' for critical", err)
+
     def test_dhcp_identifier_mac(self):
         self.generate('''network:
   version: 2

--- a/tests/test_libnetplan.py
+++ b/tests/test_libnetplan.py
@@ -618,6 +618,28 @@ class TestNetDefinition(TestBase):
         self.assertTrue(state['eth0'].critical)
         self.assertFalse(state['eth1'].critical)
 
+    def test_keep_configuration(self):
+        state = state_from_yaml(self.confdir, '''network:
+  ethernets:
+    eth0:
+      critical: static
+    eth1:
+      critical: true
+    eth2:
+      critical: dynamic
+    eth3: {}''')
+
+        from netplan.netdef import KeepConfiguration
+        self.assertEqual(state['eth0'].keep_configuration, KeepConfiguration.STATIC)
+        self.assertEqual(state['eth1'].keep_configuration, KeepConfiguration.TRUE)
+        self.assertEqual(state['eth2'].keep_configuration, KeepConfiguration.DYNAMIC)
+        self.assertEqual(state['eth3'].keep_configuration, KeepConfiguration.FALSE)
+        # Backwards-compatible bool check
+        self.assertTrue(state['eth0'].critical)
+        self.assertTrue(state['eth1'].critical)
+        self.assertTrue(state['eth2'].critical)
+        self.assertFalse(state['eth3'].critical)
+
     def test_eq(self):
         state = state_from_yaml(self.confdir, '''network:
   ethernets:


### PR DESCRIPTION
## Description

Allow the `critical` key in netplan YAML to accept not just boolean values but also
systemd-networkd `KeepConfiguration=` scalar values: `static`, `dhcp`, and `dhcp-on-stop`.

This is backwards compatible: boolean values (`true`/`false`/`yes`/`no`) continue to work
as before, mapping to `KeepConfiguration=true`.

### New scalar values

| netplan YAML | Generated networkd config |
|---|---|
| `critical: true` | `KeepConfiguration=true` |
| `critical: static` | `KeepConfiguration=static` |
| `critical: dhcp` | `KeepConfiguration=dhcp` |
| `critical: dhcp-on-stop` | `KeepConfiguration=dhcp-on-stop` |
| `critical: false` | *(no KeepConfiguration line)* |

### Motivation

`KeepConfiguration=static` is critical for environments running BIRD/BGP alongside
systemd-networkd. When `networkctl reload` is triggered:

- `KeepConfiguration=true` causes networkd to attempt reconciliation of foreign (BIRD) routes,
  triggering a full reconfigure cycle that deletes and re-adds all routes (~2.2s disruption)
- `KeepConfiguration=static` precisely preserves only `proto static` routes and ignores
  foreign routes, enabling clean delta-only reloads with zero route disruption

Currently there is no way to set `KeepConfiguration=static` via netplan — the only option is
`critical: true` which maps to `KeepConfiguration=true`.

### Changes

- `src/abi.h`: New `NetplanKeepConfiguration` enum
- `src/parse.c`: New `handle_critical()` parser accepting booleans + scalar values
- `src/networkd.c`: Emit correct `KeepConfiguration=` value
- `src/netplan.c`: Serialize enum back to YAML
- `src/types.c`: Backwards-compatible bool getter + new enum getter
- `python-cffi/`: New `KeepConfiguration` Python enum and `.keep_configuration` property
- `doc/netplan-yaml.md`: Updated documentation
- Tests: 4 new generator tests + 1 new libnetplan test

### Supersedes

This is a clean re-implementation of #409 (which has been stale since Sept 2024 with
unresolved merge conflicts) on top of current main.

## Checklist

- [x] Retains backwards compatibility (boolean values still work)
- [x] New generator tests added
- [x] New libnetplan Python API tests added
- [x] Documentation updated
- [ ] Runs `make check` successfully (no build environment available locally)