### PR TITLE
meson: make more things configurable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,10 +17,23 @@ libsystemd = dependency('libsystemd')
 
 meson_make_symlink = meson.current_source_dir() + '/tools/meson-make-symlink.sh'
 
-systemd = dependency('systemd')
-completions = dependency('bash-completion')
-systemd_generator_dir = systemd.get_variable(pkgconfig: 'systemdsystemgeneratordir')
-bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', default_value: '/etc/bash_completion.d')
+service_dir = get_option('systemdsystemunitdir')
+if service_dir == ''
+    systemd = dependency('systemd')
+    service_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
+endif
+
+systemd_generator_dir = get_option('systemdsystemgeneratordir')
+if systemd_generator_dir == ''
+    systemd = dependency('systemd')
+    systemd_generator_dir = systemd.get_variable(pkgconfig: 'systemdsystemgeneratordir')
+endif
+
+bash_completions_dir = get_option('completionsdir')
+if bash_completions_dir == ''
+    completions = dependency('bash-completion')
+    bash_completions_dir = completions.get_variable(pkgconfig: 'completionsdir', default_value: '/etc/bash_completion.d')
+endif
 
 # Order: Fedora/Mageia/openSUSE || Debian/Ubuntu
 pyflakes = find_program('pyflakes-3', 'pyflakes3', required: get_option('testing'))
@@ -56,16 +69,19 @@ pkg_mod.generate(
     filebase: 'netplan',
     description: 'YAML network configuration abstraction runtime library')
 
-install_data(
-    'netplan.completions',
-    rename: 'netplan',
-    install_dir: bash_completions_dir)
+if bash_completions_dir != 'no'
+    install_data    (
+        'netplan.completions',
+        rename: 'netplan',
+        install_dir: bash_completions_dir)
+endif
 
-service_dir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
-# XXX: should we use configure_file() instead?
-install_data(
-    'netplan-configure.service',
-    install_dir: service_dir)
+if service_dir != 'no'
+    # XXX: should we use configure_file() instead?
+    install_data(
+        'netplan-configure.service',
+        install_dir: service_dir)
+endif
 
 ###########
 # Testing #

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,9 @@
 option('testing', type: 'boolean', value: true)
 option('unit_testing', type: 'boolean', value: true)
+
+option('systemdsystemunitdir', type : 'string',
+       description : 'directory to install systemd system units into ["no" disables]')
+option('systemdsystemgeneratordir', type : 'string',
+       description : 'directory to install systemd system generators into ["no" disables]')
+option('completionsdir', type : 'string',
+       description : 'directory to install bash completions into ["no" disables]')

--- a/src/meson.build
+++ b/src/meson.build
@@ -45,9 +45,11 @@ executable(
     dependencies: [glib, gio, yaml, uuid],
     install_dir: libexec_netplan,
     install: true)
-meson.add_install_script(meson_make_symlink,
-    join_paths(get_option('prefix'), libexec_netplan, 'generate'),
-    join_paths(systemd_generator_dir, 'netplan'))
+if systemd_generator_dir != 'no'
+    meson.add_install_script(meson_make_symlink,
+        join_paths(get_option('prefix'), libexec_netplan, 'generate'),
+        join_paths(systemd_generator_dir, 'netplan'))
+endif
 executable(
     'configure',
     'configure.c',


### PR DESCRIPTION
For NixOS (and I assume other distros) it is really useful to make some paths configurable as everything is built and installed in a sandbox. Thus, for example, we cannot just install bash completions into the location provided by the pkg-config variable for the bash-completions package.

This change makes service_dir, systemd_generator_dir, and bash_completions_dir configurable but keeps the previous default behaviour. If these are not configured in meson they behave as before.

Installation of these files can also be entirely disabled now by setting these options to 'no'. This is the same behaviour systemd offers in their meson files.

I'm doing this in an effort to make netplan usable on NixOS.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] (Optional) Adds example YAML for new feature.
- [ ] (Optional) Closes an open bug in Launchpad.

