### PR TITLE
fix: Prevent multiple default routes being written on netplan set (LP: #2160614)

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -172,5 +172,6 @@ enum NETPLAN_FORMAT_ERRORS {
  */
 enum NETPLAN_PARSER_FLAGS {
     NETPLAN_PARSER_IGNORE_ERRORS = 1 << 0, ///< Ignore parsing errors such as bad YAML files and definitions.
+    NETPLAN_PARSER_STRICT_DEFAULT_ROUTES = 1 << 1, ///< Treat conflicting default route declarations as a fatal error instead of a warning.
     NETPLAN_PARSER_FLAGS_MAX_,
 };

--- a/netplan_cli/cli/commands/set.py
+++ b/netplan_cli/cli/commands/set.py
@@ -23,6 +23,7 @@ import io
 
 from ..utils import NetplanCommand
 import netplan
+from netplan.parser import Flags
 
 FALLBACK_FILENAME = '70-netplan-set.yaml'
 GLOBAL_KEYS = ['renderer', 'version']
@@ -68,6 +69,8 @@ class NetplanSet(NetplanCommand):
         yaml_path = [s.replace(r'\.', '.') for s in re.split(r'(?<!\\)\.', key)]
 
         parser = netplan.Parser()
+        # Reject writing a configuration with conflicting default routes.
+        parser.flags = Flags.STRICT_DEFAULT_ROUTES
         with tempfile.TemporaryFile() as tmp:
             netplan._create_yaml_patch(yaml_path, value, tmp)
             tmp.flush()

--- a/python-cffi/netplan/parser.py
+++ b/python-cffi/netplan/parser.py
@@ -22,6 +22,7 @@ from ._utils import _checked_lib_call
 
 class Flags(IntEnum):
     IGNORE_ERRORS = 1 << 0
+    STRICT_DEFAULT_ROUTES = 1 << 1
 
 
 class Parser():

--- a/src/parse.c
+++ b/src/parse.c
@@ -3709,6 +3709,13 @@ netplan_state_import_parser_results(NetplanState* np_state, NetplanParser* npp, 
             return FALSE;
 
         if (!validate_default_route_consistency(npp, npp->parsed_defs, &recoverable)) {
+            // When strict mode is requested (e.g. by `netplan set`), treat a
+            // conflicting default route as a fatal error so the invalid config
+            // is not written to disk.
+            if (npp->flags & NETPLAN_PARSER_STRICT_DEFAULT_ROUTES) {
+                g_propagate_error(error, recoverable);
+                return FALSE;
+            }
             g_warning("Problem encountered while validating default route consistency."
                       "Please set up multiple routing tables and use `routing-policy` instead.\n"
                       "Error: %s", (recoverable) ? recoverable->message : "");

--- a/tests/cli/test_get_set.py
+++ b/tests/cli/test_get_set.py
@@ -187,6 +187,31 @@ class TestSet(unittest.TestCase):
             yml = yaml.safe_load(f)
             self.assertEqual(1005, yml['network']['vrfs']['vrf0']['table'])
 
+    def test_set_conflicting_default_route_not_written(self):
+        defaults = os.path.join(self.workdir.name, 'etc', 'netplan', '0-existing.yaml')
+        with open(defaults, 'w') as f:
+            f.write('''network:
+  version: 2
+  ethernets:
+    ens33:
+      routes:
+      - to: default
+        via: 192.168.17.253
+        metric: 200
+''')
+        with self.assertRaises(NetplanException) as e:
+            self._set(['ethernets.ens33.routes=[{to: default, via: 192.168.17.252, metric: 200}]'])
+        self.assertIn('Conflicting default route declarations for IPv4', str(e.exception))
+        # the fallback output file should not have been written
+        self.assertFalse(os.path.isfile(self.path))
+        # the original (pre-existing) file should stay untouched
+        self.assertTrue(os.path.isfile(defaults))
+        with open(defaults, 'r') as f:
+            yml = yaml.safe_load(f)
+            routes = yml['network']['ethernets']['ens33']['routes']
+            self.assertEqual(1, len(routes))
+            self.assertEqual('192.168.17.253', routes[0]['via'])
+
     def test_set_origin_hint_extend(self):
         p = os.path.join(self.workdir.name, 'etc', 'netplan', '90-snapd-config.yaml')
         with open(p, 'w') as f:


### PR DESCRIPTION
Fixes LP: #2160614 by introducing a flag for when `netplan set` is run that ensures that a conflicting default route error is fatal. It also adds a test case for this scenario. 

## Checklist

- [X] Runs `make check` successfully.
- [X] Retains code coverage (`make check-coverage`).
- [X] (Optional) Closes an open bug in Launchpad. (LP: #2160614)

