### PR TITLE
fix(build): update the netplan version field in the build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('netplan', 'c',
-        version: '1.1',
+        version: '1.2',
         license: 'GPL3',
         default_options: [
             'c_std=c99',


### PR DESCRIPTION
The Netplan release 1.2 was released months ago. The change updates the meson build configuration to reflect it.