### PR TITLE
parse-nm: Mark dhcp4/dhcp6 as dirty when method=manual (LP: #2160170)

### DIFF
--- a/.github/workflows/lp2160170-nm-netplan.patch
+++ b/.github/workflows/lp2160170-nm-netplan.patch
@@ -1,0 +1,13 @@
+--- a/debian/tests/nm-netplan.py
++++ b/debian/tests/nm-netplan.py
+@@ -266,8 +266,8 @@ class TestNetplan(unittest.TestCase):
+         yaml_data = self._load_netplan_yaml_for_connection(connection)
+
+         # Validating some of the expected flags
+-        self.assertNotIn('dhcp4', yaml_data['network']['bridges']['bridge0'])
+-        self.assertNotIn('dhcp6', yaml_data['network']['bridges']['bridge0'])
++        self.assertFalse(yaml_data['network']['bridges']['bridge0']['dhcp4'])
++        self.assertFalse(yaml_data['network']['bridges']['bridge0']['dhcp6'])
+
+         addresses = yaml_data['network']['bridges']['bridge0']['addresses']
+         expected_addresses = ['10.20.30.40/24', '10.20.30.41/24', 'dead:beef::1/64', 'dead:beef::2/64']

--- a/.github/workflows/network-manager.yml
+++ b/.github/workflows/network-manager.yml
@@ -62,9 +62,12 @@ jobs:
           MIRROR=http://archive.ubuntu.com/ubuntu autopkgtest-build-lxd ubuntu-daily:resolute # LP: #2052639
       - name: Run autopkgtest
         run: |
-          # When we introduce ABI breaking changes, we need to rebuild NM in DEP-8
-          #pull-lp-source network-manager resolute
+          # LP#2160170 - Patch NM test to expect dhcp4/dhcp6: false when NM file method=manual
+          pull-lp-source network-manager resolute
+          cd network-manager-*/
+          patch -p1 < $GITHUB_WORKSPACE/.github/workflows/lp2160170-nm-netplan.patch
+          cd ../
           autopkgtest -U \
             --env=DEB_BUILD_OPTIONS=nocheck \
             --apt-pocket=proposed=src:network-manager \
-            debian/artifacts/*.deb network-manager -- lxd autopkgtest/ubuntu/resolute/amd64 || test $? -eq 2  # allow for skipped tests (exit code = 2)
+            debian/artifacts/*.deb network-manager-*/ -- lxd autopkgtest/ubuntu/resolute/amd64 || test $? -eq 2  # allow for skipped tests (exit code = 2)

--- a/src/parse-nm.c
+++ b/src/parse-nm.c
@@ -105,14 +105,16 @@ kf_matches(GKeyFile* kf, const gchar* group, const gchar* key, const gchar* matc
     return g_strcmp0(kf_value, match) == 0;
 }
 
-STATIC void
+STATIC gboolean
 set_true_on_match(GKeyFile* kf, const gchar* group, const gchar* key, const gchar* match, const void* dataptr)
 {
     g_assert(dataptr != NULL);
     if (kf_matches(kf, group, key, match)) {
         *((gboolean*) dataptr) = TRUE;
         _kf_clear_key(kf, group, key);
+        return TRUE;
     }
+    return FALSE;
 }
 
 STATIC void
@@ -678,6 +680,9 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
         nd_id = g_strconcat("NM-", uuid, NULL);
     g_free(tmp_str);
     nd = netplan_netdef_new(npp, nd_id, nd_type, NETPLAN_BACKEND_NM);
+    /* Required for explicit marking of 'false' values as dirty,
+     * so they are written to YAML */
+    npp->current.netdef = nd;
 
     /* Handle uuid & NM name/id */
     nd->backend_settings.uuid = g_strdup(uuid);
@@ -754,9 +759,22 @@ netplan_parser_load_keyfile(NetplanParser* npp, const char* filename, GError** e
         nd->has_match = TRUE;
     }
 
-    /* DHCPv4/v6 */
-    set_true_on_match(kf, "ipv4", "method", "auto", &nd->dhcp4);
-    set_true_on_match(kf, "ipv6", "method", "auto", &nd->dhcp6);
+    /* Handle IP Addressing method (auto or manual).
+     * Explicitly mark dhcp4/dhcp6 as dirty when method=manual,
+     * so the YAML serializer writes "dhcp4: false" / "dhcp6: false". */
+    if (!set_true_on_match(kf, "ipv4", "method", "auto", &nd->dhcp4)) {
+        g_autofree gchar *m4 = g_key_file_get_string(kf, "ipv4", "method", NULL);
+        if (m4 && g_strcmp0(m4, "manual") == 0) {
+            mark_data_as_dirty(npp, &nd->dhcp4);
+        }
+    }
+    if (!set_true_on_match(kf, "ipv6", "method", "auto", &nd->dhcp6)) {
+        g_autofree gchar *m6 = g_key_file_get_string(kf, "ipv6", "method", NULL);
+        if (m6 && g_strcmp0(m6, "manual") == 0) {
+            mark_data_as_dirty(npp, &nd->dhcp6);
+        }
+    }
+
     parse_dhcp_overrides(kf, "ipv4", &nd->dhcp4_overrides);
     parse_dhcp_overrides(kf, "ipv6", &nd->dhcp6_overrides);
 

--- a/tests/parser/test_keyfile.py
+++ b/tests/parser/test_keyfile.py
@@ -308,6 +308,8 @@ route2=4:5:6:7:8:9:0:1/63,,5
         - dead:beef::2
       gateway4: 6.6.6.6
       gateway6: 6:6::6
+      dhcp4: false
+      dhcp6: false
       ipv6-address-generation: "stable-privacy"
       ipv6-privacy: true
       routes:
@@ -358,6 +360,7 @@ address1=192.168.123.123/24
       renderer: NetworkManager
       addresses:
       - "192.168.123.123/24"
+      dhcp4: false
       networkmanager:
         uuid: "{}"
         name: "Test"
@@ -1035,6 +1038,7 @@ method=ignore
       renderer: NetworkManager
       addresses:
       - "1.2.3.4/24"
+      dhcp4: false
       id: 1
       link: "en1"
       networkmanager:
@@ -1327,6 +1331,8 @@ route4=5:6:7:8:9:0:1:2/62
         - 4.2.2.2
         - 1::cafe
         - 2::cafe
+      dhcp4: false
+      dhcp6: false
       ipv6-address-generation: "stable-privacy"
       mtu: 900
       routes:
@@ -1732,6 +1738,8 @@ dns-search=wallaceandgromit.com;
         - 4.2.2.2
         - 1::cafe
         - 2::cafe
+      dhcp4: false
+      dhcp6: false
       mtu: 900
       wakeonlan: true
       networkmanager:
@@ -1776,6 +1784,7 @@ method=auto
       renderer: NetworkManager
       addresses:
       - "1.2.3.4/24"
+      dhcp4: false
       dhcp6: true
       networkmanager:
         uuid: "{}"
@@ -2433,6 +2442,7 @@ route1_options=advmss=1400
         name: "engreen"
       addresses:
       - "192.168.14.2/24"
+      dhcp4: false
       routes:
       - to: "10.10.10.0/24"
         via: "192.168.1.20"
@@ -2506,6 +2516,7 @@ addr-gen-mode=default
       renderer: NetworkManager
       addresses:
       - "100.85.0.1/24"
+      dhcp4: false
       dhcp4-overrides:
         route-metric: 95
       networkmanager:
@@ -2546,6 +2557,7 @@ addr-gen-mode=default
       renderer: NetworkManager
       addresses:
       - "fdeb:446c:912d:8da::/64"
+      dhcp6: false
       dhcp6-overrides:
         route-metric: 95
       networkmanager:


### PR DESCRIPTION
When parsing NM keyfiles with method=manual, explicitly mark dhcp4/dhcp6 as dirty so the YAML serializer outputs "dhcp4: false" / "dhcp6: false".

This fixes an issue in multi-file setups where an earlier YAML config with dhcp4:true would not be overridden by a NM keyfile with method=manual, because the false value was not being written to the netplan file.

Also update test_keyfile_method_manual to verify the explicit false output.

