### PR TITLE
docs: define member interfaces in bonding example

### DIFF
--- a/doc/examples.md
+++ b/doc/examples.md
@@ -217,12 +217,17 @@ See also: [NetworkManager default configuration](/nm-all)
 
 # How to configure interface bonding
 
-Bonding is configured by declaring a bond interface with a list of physical interfaces and a bonding mode:
+Bonding is configured by declaring a bond interface with a list of physical interfaces and a bonding mode. The member interfaces must also be defined under `ethernets` (or another interface type):
 
 ```yaml
 network:
   version: 2
   renderer: networkd
+  ethernets:
+    enp3s0:
+      dhcp4: no
+    enp4s0:
+      dhcp4: no
   bonds:
     bond0:
       dhcp4: yes


### PR DESCRIPTION
## Summary
- The first bonding example in `doc/examples.md` looked like a complete Netplan file but never defined the member interfaces under `ethernets`.
- That causes `netplan generate` to fail with `interface '...' is not defined`.
- Define `enp3s0` / `enp4s0` the same way the multi-bond example already does, and note that bond members must be declared.

Fixes canonical/netplan.io#84

## Test plan
- [x] Copy the updated example into a Netplan YAML file and run `sudo netplan generate` (with matching interface names available or after adapting names)
- [x] Confirm the example still matches the style of neighbouring snippets in `doc/examples.md`