### PR TITLE
cli: handle insufficient user privilege error gracefully

### DIFF
--- a/netplan_cli/cli/commands/apply.py
+++ b/netplan_cli/cli/commands/apply.py
@@ -134,7 +134,12 @@ class NetplanApply(utils.NetplanCommand):
                     raise ConfigurationError("the configuration could not be generated")
             # Running 'systemctl daemon-reload' will re-run the netplan systemd generator.
             logging.debug('executing Netplan systemd-generator via daemon-reload')
-            utils.systemctl_daemon_reload()
+            res = utils.systemctl_daemon_reload()
+            if res != 0:
+                if exit_on_error:
+                    sys.exit(res)
+                else:
+                    raise RuntimeError("systemctl daemon-reload call failed: error %d" % res)
 
         devices = utils.get_interfaces()
 

--- a/netplan_cli/cli/commands/generate.py
+++ b/netplan_cli/cli/commands/generate.py
@@ -124,7 +124,10 @@ class NetplanGenerate(utils.NetplanCommand):
                 # automatically reloads systemd, as we might have changed
                 # service units, such as
                 # /run/systemd/generator.late/systemd-networkd-wait-online.service.d/10-netplan.conf
-                utils.systemctl_daemon_reload()
+                res = utils.systemctl_daemon_reload()
+                if res != 0:
+                    logging.error("systemctl daemon-reload call failed: error %d", res)
+                    sys.exit(res)
 
             logging.debug('command configure: running %s', argv)
             res = subprocess.call(argv)

--- a/netplan_cli/cli/utils.py
+++ b/netplan_cli/cli/utils.py
@@ -170,7 +170,7 @@ def systemctl_is_installed(unit_pattern):
 
 def systemctl_daemon_reload():
     '''Reload systemd unit files from disk and re-calculate its dependencies'''
-    subprocess.check_call(['systemctl', 'daemon-reload', '--no-ask-password'])
+    return subprocess.call(['systemctl', 'daemon-reload', '--no-ask-password'])
 
 
 def ip_addr_flush(iface):

--- a/tests/integration/regressions.py
+++ b/tests/integration/regressions.py
@@ -38,6 +38,36 @@ class _CommonTests():
             f.write('''''')
         self.generate_and_settle([])
 
+    def test_unprivileged_user_no_traceback(self):
+        """LP#2161924: netplan commands should not trigger sys.excepthook
+        (which would cause apport crash reports) when run without privileges."""
+
+        # Create a temporary user for testing the scenario of a regular user (non-root)
+        # running netplan commands without sudo privileges.
+        test_user = 'netplantest'
+        subprocess.run(['userdel', '-rf', test_user],
+                       stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+        subprocess.run(['useradd', '-m', '-s', '/bin/sh', test_user], check=True)
+        self.addCleanup(subprocess.run, ['userdel', '-rf', test_user],
+                        stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+
+        for command in ['generate', 'apply', 'try']:
+            with self.subTest(command=command):
+                result = subprocess.run(
+                    ['runuser', '-u', test_user, '--',
+                     'netplan', command],
+                    capture_output=True,
+                    text=True,
+                    timeout=30
+                )
+                # Check that no Python traceback was printed to stderr
+                # (tracebacks indicate unhandled exceptions that trigger apport)
+                self.assertNotIn(
+                    'Traceback (most recent call last):',
+                    result.stderr,
+                    f"netplan {command} produced a traceback (unhandled exception):\n"
+                    f"STDERR: {result.stderr}")
+
 
 @unittest.skipIf("networkd" not in test_backends,
                  "skipping as networkd backend tests are disabled")


### PR DESCRIPTION
Insufficient privileges is leading to unhandled exception and these trigger apport crash reports. The fix is to check the return code and exit cleanly with an error message.

On similar lines, the netplan try's revert() is modified to catch exceptions rather than letting it propagate as an unhandled exception.

[LP: #2161924](https://bugs.launchpad.net/netplan/+bug/2161924)
