### PR TITLE
docs: fix typo /etc/systemctl.conf to /etc/sysctl.conf

### DIFF
--- a/doc/reuse/configure-vm-disable-netfilter.md
+++ b/doc/reuse/configure-vm-disable-netfilter.md
@@ -2,7 +2,7 @@
 
 To allow communication between the host server, its virtual machines, and the devices in the local VLANs, disable netfilter for bridged interfaces:
 
-1. Add the following lines to the `/etc/systemctl.conf` configuration file:
+1. Add the following lines to the `/etc/sysctl.conf` configuration file:
 
     ```
     net.bridge.bridge-nf-call-iptables = 0


### PR DESCRIPTION
docs: fix typo /etc/systemctl.conf to /etc/sysctl.conf- #607

LP: #2160079

