### PR TITLE
sriov: add support for devlink device parameters and PCIe Sub-Functions (SFs)

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -66,6 +66,7 @@ OpenVPN
 OVS
 performant
 PCI
+PCIe
 PSK
 QEMU
 RDNSS
@@ -73,6 +74,8 @@ RSA
 SIGINT
 SIGUSR
 SLAAC
+SF
+SFs
 SR
 SSID
 SSIDs
@@ -110,6 +113,7 @@ checksums
 config
 curtin
 decrypt
+devlink
 dir
 dmz
 failover
@@ -137,9 +141,10 @@ renderer
 reselection
 runtime
 stateful
-stateful
 statelessly
 subnet
+subfunction
+subfunctions
 systemd
 udev
 unconfigured

--- a/doc/netplan-yaml.md
+++ b/doc/netplan-yaml.md
@@ -1063,6 +1063,32 @@ some additional properties that can be used for SR-IOV devices.
   >
   > **Requires feature: `infiniband`**
 
+- **`devlink-params`** (mapping) – since 1.2
+
+  > (SR-IOV devices only) A key-value mapping of generic and vendor-specific devlink
+  > parameters to set on the PCI device (e.g. `flow_steering_mode: smfs`).
+  >
+  > **Requires feature: `devlink-params`**
+
+- **`sub-functions`** (sequence of mappings) – since 1.2
+
+  > (SR-IOV devices only) A list of PCIe Sub-Functions (SFs) to configure on the
+  > Physical Function using devlink.
+  >
+  > - **`sfnum`** (scalar)
+  >
+  >   > The subfunction number.
+  >
+  > - **`hw-address`** (scalar)
+  >
+  >   > The hardware address (MAC) for the subfunction port.
+  >
+  > - **`state`** (scalar)
+  >
+  >   > The operational state of the subfunction (`active` or `inactive`).
+  >
+  > **Requires feature: `sub-functions`**
+
 (yaml-modems)=
 ## Properties for device type `modems`
 

--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -17,6 +17,7 @@ dbus
 DBus
 decrypt
 dev
+devlink
 dhcp
 dir
 distil
@@ -76,6 +77,7 @@ nmconnection
 openvswitch
 ovs
 passthrough
+PCIe
 pre
 prefixtlb
 preshared
@@ -85,10 +87,14 @@ recognise
 renderer
 reselection
 rulebook
+SF
+SFs
 SSIDs
 stateful
 statelessly
 subnet
+subfunction
+subfunctions
 subtree
 systemd
 tcp

--- a/netplan_cli/cli/sriov.py
+++ b/netplan_cli/cli/sriov.py
@@ -19,6 +19,7 @@
 import json
 import logging
 import os
+import shutil
 import subprocess
 import typing
 from typing import Dict, List, Optional, Set
@@ -179,6 +180,120 @@ class PCIDevice(object):
         # {"dev":{}}
         return json_output.get("dev", {}).get(pci, {}).get('mode', '__undetermined')
 
+    def devlink_param_set(self, name: str, value: str, cmode: str = "runtime"):
+        """Set devlink parameter for the PCI device
+        :param name: parameter name
+        :type: str
+        :param value: parameter value
+        :type: str
+        :param cmode: configuration mode (default: runtime)
+        :type: str
+        """
+        devlink_bin = shutil.which("devlink") or "/sbin/devlink"
+        param_name = name.replace("-", "_")
+        subprocess.check_call(
+            [
+                devlink_bin,
+                "dev",
+                "param",
+                "set",
+                f"pci/{self.pci_addr}",
+                "name",
+                param_name,
+                "value",
+                str(value),
+                "cmode",
+                cmode,
+            ]
+        )
+
+    def devlink_get_ports(self) -> dict:
+        """Query devlink ports
+        :return: dictionary of devlink ports
+        :rtype: dict
+        """
+        devlink_bin = shutil.which("devlink") or "/sbin/devlink"
+        try:
+            output = subprocess.check_output(
+                [
+                    devlink_bin,
+                    "-j",
+                    "port",
+                    "show",
+                ],
+                stderr=subprocess.DEVNULL,
+            )
+            json_output = json.loads(output)
+            return json_output.get("port", {})
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            return {}
+
+    def devlink_add_sf(self, port_index: int, sfnum: int, pfnum: int = 0):
+        """Add devlink subfunction port
+        :param port_index: port index number
+        :type: int
+        :param sfnum: subfunction number
+        :type: int
+        :param pfnum: physical function number
+        :type: int
+        """
+        devlink_bin = shutil.which("devlink") or "/sbin/devlink"
+        port = f"pci/{self.pci_addr}/{port_index}"
+        subprocess.check_call(
+            [
+                devlink_bin,
+                "port",
+                "add",
+                port,
+                "flavour",
+                "pcisf",
+                "pfnum",
+                str(pfnum),
+                "sfnum",
+                str(sfnum),
+            ]
+        )
+
+    def devlink_set_sf_hw_addr(self, port_identifier: str, hw_addr: str):
+        """Set subfunction HW address
+        :param port_identifier: port identifier (e.g. pci/0000:03:00.0/1)
+        :type: str
+        :param hw_addr: MAC address
+        :type: str
+        """
+        devlink_bin = shutil.which("devlink") or "/sbin/devlink"
+        subprocess.check_call(
+            [
+                devlink_bin,
+                "port",
+                "function",
+                "set",
+                port_identifier,
+                "hw_addr",
+                hw_addr,
+            ]
+        )
+
+    def devlink_set_sf_state(self, port_identifier: str, state: str):
+        """Set subfunction state
+        :param port_identifier: port identifier (e.g. pci/0000:03:00.0/1)
+        :type: str
+        :param state: state (active or inactive)
+        :type: str
+        """
+        devlink_bin = shutil.which("devlink") or "/sbin/devlink"
+        subprocess.check_call(
+            [
+                devlink_bin,
+                "port",
+                "function",
+                "set",
+                port_identifier,
+                "state",
+                state,
+            ]
+        )
+
     def __str__(self) -> str:
         """String represenation of object
         :return: PCI address of string
@@ -281,9 +396,8 @@ def _get_physical_functions(np_state: netplan.State) -> Dict[str, str]:
             if iface := _get_interface_name_for_netdef(np_state[link.id]):
                 pfs[link.id] = iface
         else:
-            # If a netdef also defines the embedded_switch_mode key we consider it's a PF
-            # This enables us to change the eswitch mode even when the PF has no VFs.
-            if netdef._embedded_switch_mode:
+            # If a netdef also defines embedded_switch_mode, devlink_params, or sub_functions, we consider it's a PF
+            if netdef._embedded_switch_mode or netdef._devlink_params or netdef._sub_functions:
                 if iface := _get_interface_name_for_netdef(netdef):
                     pfs[netdef.id] = iface
 
@@ -532,6 +646,59 @@ def apply_sriov_config(config_manager, rootdir='/'):
                     if pcidev.vfs:
                         if not netdef._delay_virtual_functions_rebind:
                             bind_vfs(pcidev.vfs, pcidev.driver)
+
+    # Walk the SR-IOV PFs and configure devlink parameters
+    for netdef_id, iface in pfs.items():
+        netdef = np_state[netdef_id]
+        if devlink_params := netdef._devlink_params:
+            pci_addr = _get_pci_slot_name(iface)
+            pcidev = PCIDevice(pci_addr)
+            for param_name, param_val in devlink_params.items():
+                logging.debug(f'Setting devlink param {param_name}={param_val} on {netdef_id} ({pci_addr})')
+                try:
+                    pcidev.devlink_param_set(param_name, param_val)
+                except Exception as e:
+                    logging.warning(f'Failed to set devlink param {param_name}={param_val} on {netdef_id}: {str(e)}')
+
+    # Walk the SR-IOV PFs and configure sub-functions
+    for netdef_id, iface in pfs.items():
+        netdef = np_state[netdef_id]
+        if sub_functions := netdef._sub_functions:
+            pci_addr = _get_pci_slot_name(iface)
+            pcidev = PCIDevice(pci_addr)
+            existing_ports = pcidev.devlink_get_ports()
+            existing_sfs = {}
+            for port_id, port_data in existing_ports.items():
+                if port_id.startswith(f"pci/{pci_addr}/"):
+                    if port_data.get("flavour") == "pcisf" and "sfnum" in port_data:
+                        existing_sfs[int(port_data["sfnum"])] = (port_id, port_data)
+
+            for sf in sub_functions:
+                sfnum = sf.sfnum
+                if sfnum in existing_sfs:
+                    port_id, port_data = existing_sfs[sfnum]
+                else:
+                    port_id = f"pci/{pci_addr}/{sfnum}"
+                    logging.debug(f'Adding SF sfnum={sfnum} on {netdef_id} as {port_id}')
+                    try:
+                        pcidev.devlink_add_sf(port_index=sfnum, sfnum=sfnum)
+                    except Exception as e:
+                        logging.warning(f'Failed to add SF {sfnum} on {netdef_id}: {str(e)}')
+                        continue
+
+                if sf.hw_address:
+                    try:
+                        logging.debug(f'Setting hw_addr={sf.hw_address} on SF {port_id}')
+                        pcidev.devlink_set_sf_hw_addr(port_id, sf.hw_address)
+                    except Exception as e:
+                        logging.warning(f'Failed to set hw_addr on SF {port_id}: {str(e)}')
+
+                if sf.state:
+                    try:
+                        logging.debug(f'Setting state={sf.state} on SF {port_id}')
+                        pcidev.devlink_set_sf_state(port_id, sf.state)
+                    except Exception as e:
+                        logging.warning(f'Failed to set state on SF {port_id}: {str(e)}')
 
     filtered_vlans_set = set()
     for vlan, netdef in np_state.vlans.items():

--- a/python-cffi/netplan/_build_cffi.py
+++ b/python-cffi/netplan/_build_cffi.py
@@ -44,6 +44,8 @@ ffibuilder.cdef("""
     struct address_iter { ...; };
     struct nameserver_iter { ...; };
     struct route_iter { ...; };
+    struct devlink_params_iter { ...; };
+    struct sub_function_iter { ...; };
 
     // TODO: Introduce getters for all these fields to avoid exposing the raw struct
     typedef struct {
@@ -61,6 +63,18 @@ ffibuilder.cdef("""
         guint advertised_receive_window;
         guint advmss;
     } NetplanIPRoute;
+
+    typedef enum {
+        NETPLAN_SUBFUNCTION_STATE_UNSET = 0,
+        NETPLAN_SUBFUNCTION_STATE_INACTIVE,
+        NETPLAN_SUBFUNCTION_STATE_ACTIVE,
+    } NetplanSubFunctionState;
+
+    typedef struct {
+        guint sfnum;
+        char* hw_address;
+        NetplanSubFunctionState state;
+    } NetplanSubFunction;
 
     // Error handling
     uint64_t netplan_error_code(NetplanError* error);
@@ -144,6 +158,12 @@ ffibuilder.cdef("""
     struct route_iter* _netplan_netdef_new_route_iter(NetplanNetDefinition* netdef);
     NetplanIPRoute* _netplan_route_iter_next(struct route_iter* it);
     void _netplan_route_iter_free(struct route_iter* it);
+    struct devlink_params_iter* _netplan_netdef_new_devlink_params_iter(NetplanNetDefinition* netdef);
+    gboolean _netplan_devlink_params_iter_next(struct devlink_params_iter* it, const char** out_key, const char** out_val);
+    void _netplan_devlink_params_iter_free(struct devlink_params_iter* it);
+    struct sub_function_iter* _netplan_netdef_new_sub_function_iter(NetplanNetDefinition* netdef);
+    NetplanSubFunction* _netplan_sub_function_iter_next(struct sub_function_iter* it);
+    void _netplan_sub_function_iter_free(struct sub_function_iter* it);
 
     // Utils
     gboolean netplan_util_dump_yaml_subtree(const char* prefix, int input_fd, int output_fd, NetplanError** error);

--- a/python-cffi/netplan/netdef.py
+++ b/python-cffi/netplan/netdef.py
@@ -189,6 +189,47 @@ class NetDefinition():
         '''
         return bool(lib._netplan_netdef_is_trivial_compound_itf(self._ptr))
 
+    @property
+    def _devlink_params(self) -> dict:
+        params = {}
+        it = lib._netplan_netdef_new_devlink_params_iter(self._ptr)
+        try:
+            out_key = ffi.new("char**")
+            out_val = ffi.new("char**")
+            while lib._netplan_devlink_params_iter_next(it, out_key, out_val):
+                k = ffi.string(out_key[0]).decode('utf-8')
+                v = ffi.string(out_val[0]).decode('utf-8')
+                params[k] = v
+        finally:
+            lib._netplan_devlink_params_iter_free(it)
+        return params
+
+    @property
+    def _sub_functions(self) -> list:
+        sfs = []
+        it = lib._netplan_netdef_new_sub_function_iter(self._ptr)
+        try:
+            while True:
+                sf_ptr = lib._netplan_sub_function_iter_next(it)
+                if not sf_ptr:
+                    break
+                state_val = sf_ptr.state
+                state_str = None
+                if state_val == lib.NETPLAN_SUBFUNCTION_STATE_ACTIVE:
+                    state_str = 'active'
+                elif state_val == lib.NETPLAN_SUBFUNCTION_STATE_INACTIVE:
+                    state_str = 'inactive'
+
+                hw_addr = ffi.string(sf_ptr.hw_address).decode('utf-8') if sf_ptr.hw_address else None
+                sfs.append(NetplanSubFunction(
+                    sfnum=sf_ptr.sfnum,
+                    hw_address=hw_addr,
+                    state=state_str
+                ))
+        finally:
+            lib._netplan_sub_function_iter_free(it)
+        return sfs
+
 
 class NetDefinitionIterator():
     def __init__(self, np_state, dev_type: str = None):
@@ -278,6 +319,13 @@ class _NetdefSearchDomainIterator:
         if not next_value:
             raise StopIteration
         return ffi.string(next_value).decode('utf-8')
+
+
+@dataclass
+class NetplanSubFunction:
+    sfnum: int
+    hw_address: Optional[str] = None
+    state: Optional[str] = None
 
 
 @dataclass

--- a/src/abi.h
+++ b/src/abi.h
@@ -217,6 +217,18 @@ typedef struct netplan_backend_settings {
 
 typedef struct netplan_vxlan NetplanVxlan;
 
+typedef enum {
+    NETPLAN_SUBFUNCTION_STATE_UNSET = 0,
+    NETPLAN_SUBFUNCTION_STATE_INACTIVE,
+    NETPLAN_SUBFUNCTION_STATE_ACTIVE,
+} NetplanSubFunctionState;
+
+typedef struct {
+    guint32 sfnum;
+    char* hw_address;
+    NetplanSubFunctionState state;
+} NetplanSubFunction;
+
 /* Keep 'struct netplan_net_definition' in a separate header file, to allow for
  * abidiff to consider it "public API" (although it isn't) and notify us about
  * ABI compatibility issues. */
@@ -431,4 +443,10 @@ struct netplan_net_definition {
     NetplanTristate bridge_learning;
 
     NetplanRAOverrides ra_overrides;
+
+    /* netplan-feature: devlink-params */
+    GHashTable* devlink_params;
+
+    /* netplan-feature: sub-functions */
+    GArray* sub_functions;
 };

--- a/src/gen-sriov.c
+++ b/src/gen-sriov.c
@@ -161,9 +161,13 @@ _netplan_state_finish_sriov_generate(const NetplanState* np_state, const char* g
         for (GList* iterator = np_state->netdefs_ordered; iterator; iterator = iterator->next) {
             def = (NetplanNetDefinition*) iterator->data;
             pf = NULL;
-            if (def->sriov_explicit_vf_count < G_MAXUINT || def->sriov_link || def->embedded_switch_mode) {
+            gboolean is_pf_config = (def->sriov_explicit_vf_count < G_MAXUINT ||
+                                     def->embedded_switch_mode ||
+                                     (def->devlink_params && g_hash_table_size(def->devlink_params) > 0) ||
+                                     (def->sub_functions && def->sub_functions->len > 0));
+            if (is_pf_config || def->sriov_link) {
                 any_sriov = TRUE;
-                if (def->sriov_explicit_vf_count < G_MAXUINT || def->embedded_switch_mode)
+                if (is_pf_config)
                     pf = def;
                 else if (def->sriov_link)
                     pf = def->sriov_link;

--- a/src/netplan.c
+++ b/src/netplan.c
@@ -823,6 +823,36 @@ _serialize_yaml(
     YAML_BOOL_TRUE(def, event, emitter, "delay-virtual-functions-rebind",
                    def->sriov_delay_virtual_functions_rebind);
 
+    if (def->devlink_params && g_hash_table_size(def->devlink_params) > 0) {
+        GHashTableIter diter;
+        gpointer dkey, dvalue;
+        YAML_SCALAR_PLAIN(event, emitter, "devlink-params");
+        YAML_MAPPING_OPEN(event, emitter);
+        g_hash_table_iter_init(&diter, def->devlink_params);
+        while (g_hash_table_iter_next(&diter, &dkey, &dvalue)) {
+            YAML_NONNULL_STRING(event, emitter, dkey, dvalue);
+        }
+        YAML_MAPPING_CLOSE(event, emitter);
+    }
+
+    if (def->sub_functions && def->sub_functions->len > 0) {
+        YAML_SCALAR_PLAIN(event, emitter, "sub-functions");
+        YAML_SEQUENCE_OPEN(event, emitter);
+        for (unsigned i = 0; i < def->sub_functions->len; ++i) {
+            NetplanSubFunction *sf = g_array_index(def->sub_functions, NetplanSubFunction*, i);
+            YAML_MAPPING_OPEN(event, emitter);
+            YAML_UINT_0(def, event, emitter, "sfnum", sf->sfnum);
+            YAML_STRING(def, event, emitter, "hw-address", sf->hw_address);
+            if (sf->state == NETPLAN_SUBFUNCTION_STATE_ACTIVE) {
+                YAML_NONNULL_STRING_PLAIN(event, emitter, "state", "active");
+            } else if (sf->state == NETPLAN_SUBFUNCTION_STATE_INACTIVE) {
+                YAML_NONNULL_STRING_PLAIN(event, emitter, "state", "inactive");
+            }
+            YAML_MAPPING_CLOSE(event, emitter);
+        }
+        YAML_SEQUENCE_CLOSE(event, emitter);
+    }
+
     if (def->type == NETPLAN_DEF_TYPE_VETH && def->veth_peer_link)
         YAML_STRING(def, event, emitter, "peer", def->veth_peer_link->id);
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -48,6 +48,7 @@
 #define route_offset(field) GUINT_TO_POINTER(offsetof(NetplanIPRoute, field))
 #define wireguard_peer_offset(field) GUINT_TO_POINTER(offsetof(NetplanWireguardPeer, field))
 #define vxlan_offset(field) GUINT_TO_POINTER(offsetof(NetplanVxlan, field))
+#define sub_function_offset(field) GUINT_TO_POINTER(offsetof(NetplanSubFunction, field))
 
 /* convenience macro to avoid strdup'ing a string into a field if it's already set. */
 #define set_str_if_null(dst, src) { if (dst == NULL) {\
@@ -2727,6 +2728,77 @@ handle_wireguard_peers(NetplanParser* npp, yaml_node_t* node, __unused const voi
     return TRUE;
 }
 
+STATIC gboolean
+handle_sub_function_str(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+{
+    return handle_generic_str(npp, node, npp->current.sub_function, data, error);
+}
+
+STATIC gboolean
+handle_sub_function_guint(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+{
+    return handle_generic_guint(npp, node, npp->current.sub_function, data, error);
+}
+
+STATIC gboolean
+handle_sub_function_mac(NetplanParser* npp, yaml_node_t* node, const void* data, GError** error)
+{
+    if (!_is_valid_macaddress(scalar(node)))
+        return yaml_error(npp, node, error, "Malformed MAC address '%s'", scalar(node));
+    return handle_sub_function_str(npp, node, data, error);
+}
+
+STATIC gboolean
+handle_sub_function_state(NetplanParser* npp, yaml_node_t* node, __unused const void* data, GError** error)
+{
+    if (g_strcmp0(scalar(node), "active") == 0)
+        npp->current.sub_function->state = NETPLAN_SUBFUNCTION_STATE_ACTIVE;
+    else if (g_strcmp0(scalar(node), "inactive") == 0)
+        npp->current.sub_function->state = NETPLAN_SUBFUNCTION_STATE_INACTIVE;
+    else
+        return yaml_error(npp, node, error, "Invalid sub-function state '%s', must be 'active' or 'inactive'", scalar(node));
+    return TRUE;
+}
+
+static const mapping_entry_handler sub_function_handlers[] = {
+    {"sfnum", YAML_SCALAR_NODE, {.generic=handle_sub_function_guint}, sub_function_offset(sfnum)},
+    {"hw-address", YAML_SCALAR_NODE, {.generic=handle_sub_function_mac}, sub_function_offset(hw_address)},
+    {"state", YAML_SCALAR_NODE, {.generic=handle_sub_function_state}, NULL},
+    {NULL}
+};
+
+STATIC gboolean
+handle_sub_functions(NetplanParser* npp, yaml_node_t* node, __unused const void* _, GError** error)
+{
+    if (!npp->current.netdef->sub_functions)
+        npp->current.netdef->sub_functions = g_array_new(FALSE, TRUE, sizeof(NetplanSubFunction*));
+
+    ptrdiff_t item_count = node->data.sequence.items.top - node->data.sequence.items.start;
+    g_assert(item_count >= 0);
+    if (npp->current.netdef->sub_functions->len == (guint)item_count) {
+        g_debug("%s: all sub-functions have already been added", npp->current.netdef->id);
+        return TRUE;
+    }
+
+    for (yaml_node_item_t *i = node->data.sequence.items.start; i < node->data.sequence.items.top; i++) {
+        yaml_node_t *entry = yaml_document_get_node(&npp->doc, *i);
+        assert_type(npp, entry, YAML_MAPPING_NODE);
+
+        g_assert(npp->current.sub_function == NULL);
+        npp->current.sub_function = g_new0(NetplanSubFunction, 1);
+        g_debug("%s: adding new sub-function", npp->current.netdef->id);
+
+        if (!process_mapping(npp, entry, NULL, sub_function_handlers, NULL, error)) {
+            sub_function_clear(&npp->current.sub_function);
+            npp->current.sub_function = NULL;
+            return FALSE;
+        }
+        g_array_append_val(npp->current.netdef->sub_functions, npp->current.sub_function);
+        npp->current.sub_function = NULL;
+    }
+    return TRUE;
+}
+
 /****************************************************
  * Grammar and handlers for network devices
  ****************************************************/
@@ -3025,6 +3097,8 @@ static const mapping_entry_handler ethernet_def_handlers[] = {
     {"embedded-switch-mode", YAML_SCALAR_NODE, {.generic=handle_embedded_switch_mode}, netdef_offset(embedded_switch_mode)},
     {"delay-virtual-functions-rebind", YAML_SCALAR_NODE, {.generic=handle_netdef_bool}, netdef_offset(sriov_delay_virtual_functions_rebind)},
     {"infiniband-mode", YAML_SCALAR_NODE, {.generic=handle_ib_mode}, netdef_offset(ib_mode)},
+    {"devlink-params", YAML_MAPPING_NODE, {.map={.custom=handle_netdef_map}}, netdef_offset(devlink_params)},
+    {"sub-functions", YAML_SEQUENCE_NODE, {.generic=handle_sub_functions}, NULL},
     {NULL}
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -3872,6 +3872,7 @@ netplan_parser_reset(NetplanParser* npp)
 
     access_point_clear(&npp->current.access_point, npp->current.backend);
     wireguard_peer_clear(&npp->current.wireguard_peer);
+    sub_function_clear(&npp->current.sub_function);
     address_options_clear(&npp->current.addr_options);
     route_clear(&npp->current.route);
     ip_rule_clear(&npp->current.ip_rule);

--- a/src/types-internal.h
+++ b/src/types-internal.h
@@ -119,6 +119,17 @@ struct route_iter {
     NetplanNetDefinition* netdef;
 };
 
+struct devlink_params_iter {
+    NetplanNetDefinition* netdef;
+    GHashTableIter iter;
+    gboolean initialized;
+};
+
+struct sub_function_iter {
+    NetplanNetDefinition* netdef;
+    guint index;
+};
+
 typedef struct {
     NetplanWifiMode mode;
     char* ssid;
@@ -236,6 +247,7 @@ struct netplan_parser {
         NetplanIPRoute* route;
         NetplanIPRule* ip_rule;
         NetplanVxlan* vxlan;
+        NetplanSubFunction* sub_function;
         const char *filepath;
 
         /* Plain old data representing the backend for which we are
@@ -332,6 +344,12 @@ ip_rule_clear(NetplanIPRule** rule);
 
 void
 route_clear(NetplanIPRoute** route);
+
+void
+sub_function_clear(NetplanSubFunction** sf);
+
+void
+free_sub_function(void* ptr);
 
 gboolean
 netplan_state_has_nondefault_globals(const NetplanState* np_state);

--- a/src/types.c
+++ b/src/types.c
@@ -281,11 +281,7 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     free_garray_with_destructor(&netdef->ip_rules, free_ip_rules);
     free_garray_with_destructor(&netdef->wireguard_peers, free_wireguard_peer);
     free_garray_with_destructor(&netdef->sub_functions, free_sub_function);
-
-    if (netdef->devlink_params) {
-        g_hash_table_destroy(netdef->devlink_params);
-        netdef->devlink_params = NULL;
-    }
+    free_hashtable_with_destructor(&netdef->devlink_params, g_free);
 
     netdef->linklocal.ipv4 = FALSE;
     netdef->linklocal.ipv6 = TRUE;

--- a/src/types.c
+++ b/src/types.c
@@ -109,15 +109,6 @@ free_sub_function(void* ptr)
     g_free(sf);
 }
 
-void
-sub_function_clear(NetplanSubFunction** sf)
-{
-    if (!sf || !*sf)
-        return;
-    g_free((*sf)->hw_address);
-    FREE_AND_NULLIFY(*sf);
-}
-
 STATIC void
 reset_auth_settings(NetplanAuthenticationSettings* auth)
 {
@@ -519,6 +510,7 @@ access_point_clear(NetplanWifiAccessPoint** ap, NetplanBackend backend)
 }
 
 CLEAR_FROM_FREE(free_wireguard_peer, wireguard_peer_clear, NetplanWireguardPeer);
+CLEAR_FROM_FREE(free_sub_function, sub_function_clear, NetplanSubFunction);
 CLEAR_FROM_FREE(free_ip_rules, ip_rule_clear, NetplanIPRule);
 CLEAR_FROM_FREE(free_route, route_clear, NetplanIPRoute);
 CLEAR_FROM_FREE(free_address_options, address_options_clear, NetplanAddressOptions);

--- a/src/types.c
+++ b/src/types.c
@@ -101,6 +101,23 @@ free_wireguard_peer(void* ptr)
     g_free(wg);
 }
 
+void
+free_sub_function(void* ptr)
+{
+    NetplanSubFunction* sf = ptr;
+    g_free(sf->hw_address);
+    g_free(sf);
+}
+
+void
+sub_function_clear(NetplanSubFunction** sf)
+{
+    if (!sf || !*sf)
+        return;
+    g_free((*sf)->hw_address);
+    FREE_AND_NULLIFY(*sf);
+}
+
 STATIC void
 reset_auth_settings(NetplanAuthenticationSettings* auth)
 {
@@ -263,6 +280,12 @@ reset_netdef(NetplanNetDefinition* netdef, NetplanDefType new_type, NetplanBacke
     free_garray_with_destructor(&netdef->routes, free_route);
     free_garray_with_destructor(&netdef->ip_rules, free_ip_rules);
     free_garray_with_destructor(&netdef->wireguard_peers, free_wireguard_peer);
+    free_garray_with_destructor(&netdef->sub_functions, free_sub_function);
+
+    if (netdef->devlink_params) {
+        g_hash_table_destroy(netdef->devlink_params);
+        netdef->devlink_params = NULL;
+    }
 
     netdef->linklocal.ipv4 = FALSE;
     netdef->linklocal.ipv6 = TRUE;

--- a/src/util-internal.h
+++ b/src/util-internal.h
@@ -199,6 +199,28 @@ _netplan_netdef_pertype_iter_next(struct netdef_pertype_iter* it);
 NETPLAN_INTERNAL void
 _netplan_netdef_pertype_iter_free(struct netdef_pertype_iter* it);
 
+struct devlink_params_iter;
+
+NETPLAN_INTERNAL struct devlink_params_iter*
+_netplan_netdef_new_devlink_params_iter(NetplanNetDefinition* netdef);
+
+NETPLAN_INTERNAL gboolean
+_netplan_devlink_params_iter_next(struct devlink_params_iter* it, const char** out_key, const char** out_val);
+
+NETPLAN_INTERNAL void
+_netplan_devlink_params_iter_free(struct devlink_params_iter* it);
+
+struct sub_function_iter;
+
+NETPLAN_INTERNAL struct sub_function_iter*
+_netplan_netdef_new_sub_function_iter(NetplanNetDefinition* netdef);
+
+NETPLAN_INTERNAL NetplanSubFunction*
+_netplan_sub_function_iter_next(struct sub_function_iter* it);
+
+NETPLAN_INTERNAL void
+_netplan_sub_function_iter_free(struct sub_function_iter* it);
+
 /**
  * @brief   Get the `gateway4` setting of a given @ref NetplanNetDefinition.
  * @details Copies a `NUL`-terminated string into a sized @p out_buffer. If the

--- a/src/util.c
+++ b/src/util.c
@@ -1334,3 +1334,60 @@ _netplan_scrub_systemd_unit_contents(const char* content)
 
     return g_string_free(s, FALSE);
 }
+
+struct devlink_params_iter*
+_netplan_netdef_new_devlink_params_iter(NetplanNetDefinition* netdef)
+{
+    struct devlink_params_iter* it = g_malloc0(sizeof(struct devlink_params_iter));
+    it->netdef = netdef;
+    if (netdef && netdef->devlink_params) {
+        g_hash_table_iter_init(&it->iter, netdef->devlink_params);
+        it->initialized = TRUE;
+    }
+    return it;
+}
+
+gboolean
+_netplan_devlink_params_iter_next(struct devlink_params_iter* it, const char** out_key, const char** out_val)
+{
+    gpointer k = NULL, v = NULL;
+    if (!it || !it->initialized)
+        return FALSE;
+    if (g_hash_table_iter_next(&it->iter, &k, &v)) {
+        if (out_key)
+            *out_key = (const char*)k;
+        if (out_val)
+            *out_val = (const char*)v;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+void
+_netplan_devlink_params_iter_free(struct devlink_params_iter* it)
+{
+    g_free(it);
+}
+
+struct sub_function_iter*
+_netplan_netdef_new_sub_function_iter(NetplanNetDefinition* netdef)
+{
+    struct sub_function_iter* it = g_malloc0(sizeof(struct sub_function_iter));
+    it->netdef = netdef;
+    it->index = 0;
+    return it;
+}
+
+NetplanSubFunction*
+_netplan_sub_function_iter_next(struct sub_function_iter* it)
+{
+    if (it && it->netdef && it->netdef->sub_functions && it->index < it->netdef->sub_functions->len)
+        return g_array_index(it->netdef->sub_functions, NetplanSubFunction*, it->index++);
+    return NULL;
+}
+
+void
+_netplan_sub_function_iter_free(struct sub_function_iter* it)
+{
+    g_free(it);
+}

--- a/src/validation.c
+++ b/src/validation.c
@@ -520,8 +520,8 @@ validate_sriov_rules(const NetplanParser* npp, NetplanNetDefinition* nd, GError*
                 }
             }
         }
-        /* Does it set the eswitch mode? It can be set regardless if the interface has VFs */
-        if (nd->embedded_switch_mode) {
+        /* Does it set the eswitch mode, devlink params, or sub-functions? They can be set regardless if the interface has VFs */
+        if (nd->embedded_switch_mode || (nd->devlink_params && g_hash_table_size(nd->devlink_params) > 0) || (nd->sub_functions && nd->sub_functions->len > 0)) {
             is_sriov_pf = TRUE;
         }
         if (nd->sriov_delay_virtual_functions_rebind && !is_sriov_pf) {

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -167,6 +167,73 @@ test_netplan_parser_sriov_embedded_switch(__unused void** state)
     netplan_state_clear(&np_state);
 }
 
+void
+test_netplan_parser_devlink_params_and_sub_functions(__unused void** state)
+{
+    const char* yaml =
+        "network:\n"
+        "  version: 2\n"
+        "  ethernets:\n"
+        "    eno1:\n"
+        "      devlink-params:\n"
+        "        flow-steering-mode: smfs\n"
+        "        lag-port-select-mode: multi-port-esw\n"
+        "      sub-functions:\n"
+        "        - sfnum: 1\n"
+        "          hw-address: \"00:11:22:33:44:55\"\n"
+        "          state: active\n"
+        "        - sfnum: 2\n"
+        "          hw-address: \"00:11:22:33:44:56\"\n"
+        "          state: inactive\n";
+
+    NetplanState* np_state = load_string_to_netplan_state(yaml);
+    assert_non_null(np_state);
+
+    NetplanNetDefinition* interface = netplan_state_get_netdef(np_state, "eno1");
+    assert_non_null(interface);
+
+    /* Test devlink_params iterator */
+    struct devlink_params_iter* diter = _netplan_netdef_new_devlink_params_iter(interface);
+    assert_non_null(diter);
+    const char* key = NULL;
+    const char* val = NULL;
+    int count = 0;
+    while (_netplan_devlink_params_iter_next(diter, &key, &val)) {
+        assert_non_null(key);
+        assert_non_null(val);
+        if (strcmp(key, "flow-steering-mode") == 0)
+            assert_string_equal(val, "smfs");
+        else if (strcmp(key, "lag-port-select-mode") == 0)
+            assert_string_equal(val, "multi-port-esw");
+        else
+            assert_true(FALSE);
+        count++;
+    }
+    assert_int_equal(count, 2);
+    _netplan_devlink_params_iter_free(diter);
+
+    /* Test sub_functions iterator */
+    struct sub_function_iter* siter = _netplan_netdef_new_sub_function_iter(interface);
+    assert_non_null(siter);
+
+    NetplanSubFunction* sf1 = _netplan_sub_function_iter_next(siter);
+    assert_non_null(sf1);
+    assert_int_equal(sf1->sfnum, 1);
+    assert_string_equal(sf1->hw_address, "00:11:22:33:44:55");
+    assert_int_equal(sf1->state, NETPLAN_SUBFUNCTION_STATE_ACTIVE);
+
+    NetplanSubFunction* sf2 = _netplan_sub_function_iter_next(siter);
+    assert_non_null(sf2);
+    assert_int_equal(sf2->sfnum, 2);
+    assert_string_equal(sf2->hw_address, "00:11:22:33:44:56");
+    assert_int_equal(sf2->state, NETPLAN_SUBFUNCTION_STATE_INACTIVE);
+
+    assert_null(_netplan_sub_function_iter_next(siter));
+    _netplan_sub_function_iter_free(siter);
+
+    netplan_state_clear(&np_state);
+}
+
 /* process_document() shouldn't return a missing interface as error if a previous error happened
  * LP#2000324
  */
@@ -458,6 +525,7 @@ main()
            cmocka_unit_test(test_netplan_parser_interface_has_bond_netdef),
            cmocka_unit_test(test_netplan_parser_interface_has_peer_netdef),
            cmocka_unit_test(test_netplan_parser_sriov_embedded_switch),
+           cmocka_unit_test(test_netplan_parser_devlink_params_and_sub_functions),
            cmocka_unit_test(test_netplan_parser_process_document_proper_error),
            cmocka_unit_test(test_netplan_parser_process_document_missing_interface_error),
            cmocka_unit_test(test_nm_device_backend_is_nm_by_default),

--- a/tests/ctests/test_netplan_parser.c
+++ b/tests/ctests/test_netplan_parser.c
@@ -201,13 +201,13 @@ test_netplan_parser_devlink_params_and_sub_functions(__unused void** state)
     while (_netplan_devlink_params_iter_next(diter, &key, &val)) {
         assert_non_null(key);
         assert_non_null(val);
-        if (strcmp(key, "flow-steering-mode") == 0)
+        if (strcmp(key, "flow-steering-mode") == 0) {
             assert_string_equal(val, "smfs");
-        else if (strcmp(key, "lag-port-select-mode") == 0)
+            count++;
+        } else if (strcmp(key, "lag-port-select-mode") == 0) {
             assert_string_equal(val, "multi-port-esw");
-        else
-            assert_true(FALSE);
-        count++;
+            count++;
+        }
     }
     assert_int_equal(count, 2);
     _netplan_devlink_params_iter_free(diter);
@@ -231,7 +231,81 @@ test_netplan_parser_devlink_params_and_sub_functions(__unused void** state)
     assert_null(_netplan_sub_function_iter_next(siter));
     _netplan_sub_function_iter_free(siter);
 
+    /* Test dumping state to YAML (covers sub-functions YAML emission with active & inactive states) */
+    int outfd = memfd_create("netplan-sf-dump", 0);
+    assert_true(netplan_state_dump_yaml(np_state, outfd, NULL));
+    size_t size = (size_t)lseek(outfd, 0, SEEK_CUR) + 1;
+    char* dumped_yaml = malloc(size);
+    memset(dumped_yaml, 0, size);
+    lseek(outfd, 0, SEEK_SET);
+    ssize_t res = read(outfd, dumped_yaml, size - 1);
+    assert_true(res > 0);
+    assert_non_null(strstr(dumped_yaml, "state: active"));
+    assert_non_null(strstr(dumped_yaml, "state: inactive"));
+    assert_non_null(strstr(dumped_yaml, "sfnum: 1"));
+    assert_non_null(strstr(dumped_yaml, "sfnum: 2"));
+    free(dumped_yaml);
+    close(outfd);
+
     netplan_state_clear(&np_state);
+
+    /* Test re-parsing sub-functions when already added (covers duplicate sequence handling) */
+    NetplanParser* npp = netplan_parser_new();
+    GError* error = NULL;
+    int memfd = memfd_create("test_repeat", 0);
+    ssize_t written = write(memfd, yaml, strlen(yaml));
+    assert_int_equal(written, strlen(yaml));
+    lseek(memfd, 0, SEEK_SET);
+    assert_true(netplan_parser_load_yaml_from_fd(npp, memfd, &error));
+    lseek(memfd, 0, SEEK_SET);
+    assert_true(netplan_parser_load_yaml_from_fd(npp, memfd, &error));
+    close(memfd);
+    netplan_parser_clear(&npp);
+}
+
+void
+test_netplan_parser_sub_functions_invalid(__unused void** state)
+{
+    const char* yaml_bad_mac =
+        "network:\n"
+        "  version: 2\n"
+        "  ethernets:\n"
+        "    eno1:\n"
+        "      sub-functions:\n"
+        "        - sfnum: 1\n"
+        "          hw-address: \"invalid-mac\"\n";
+
+    const char* yaml_bad_state =
+        "network:\n"
+        "  version: 2\n"
+        "  ethernets:\n"
+        "    eno1:\n"
+        "      sub-functions:\n"
+        "        - sfnum: 1\n"
+        "          state: unknown\n";
+
+    NetplanParser* npp = netplan_parser_new();
+    GError* error = NULL;
+    int memfd = memfd_create("test_bad_mac", 0);
+    ssize_t written = write(memfd, yaml_bad_mac, strlen(yaml_bad_mac));
+    assert_int_equal(written, strlen(yaml_bad_mac));
+    lseek(memfd, 0, SEEK_SET);
+    assert_false(netplan_parser_load_yaml_from_fd(npp, memfd, &error));
+    assert_non_null(error);
+    netplan_error_clear(&error);
+    close(memfd);
+    netplan_parser_clear(&npp);
+
+    npp = netplan_parser_new();
+    memfd = memfd_create("test_bad_state", 0);
+    written = write(memfd, yaml_bad_state, strlen(yaml_bad_state));
+    assert_int_equal(written, strlen(yaml_bad_state));
+    lseek(memfd, 0, SEEK_SET);
+    assert_false(netplan_parser_load_yaml_from_fd(npp, memfd, &error));
+    assert_non_null(error);
+    netplan_error_clear(&error);
+    close(memfd);
+    netplan_parser_clear(&npp);
 }
 
 /* process_document() shouldn't return a missing interface as error if a previous error happened
@@ -526,6 +600,7 @@ main()
            cmocka_unit_test(test_netplan_parser_interface_has_peer_netdef),
            cmocka_unit_test(test_netplan_parser_sriov_embedded_switch),
            cmocka_unit_test(test_netplan_parser_devlink_params_and_sub_functions),
+           cmocka_unit_test(test_netplan_parser_sub_functions_invalid),
            cmocka_unit_test(test_netplan_parser_process_document_proper_error),
            cmocka_unit_test(test_netplan_parser_process_document_missing_interface_error),
            cmocka_unit_test(test_nm_device_backend_is_nm_by_default),

--- a/tests/test_sriov.py
+++ b/tests/test_sriov.py
@@ -711,6 +711,40 @@ class TestSRIOV(unittest.TestCase):
         # only one had a hardware vlan
         apply_vlan.assert_called_once_with('enp2', 'enp2s16f1', 'vf1.15', 15)
 
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_param_set')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_get_ports')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_add_sf')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_set_sf_hw_addr')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_set_sf_state')
+    @patch('netplan_cli.cli.sriov._get_pci_slot_name')
+    @patch('netplan_cli.cli.sriov._get_interface_name_for_netdef')
+    @patch('netplan_cli.cli.utils.get_interfaces')
+    def test_apply_devlink_params_and_sub_functions(self, netifs, iface_for_netdef, pci_slot,
+                                                    set_state, set_mac, add_sf, get_ports, param_set):
+        with open(os.path.join(self.workdir.name, "etc/netplan/test.yaml"), 'w') as fd:
+            print('''network:
+  version: 2
+  ethernets:
+    enp3s0f0:
+      devlink-params:
+        flow-steering-mode: smfs
+      sub-functions:
+        - sfnum: 1
+          hw-address: "00:11:22:33:44:55"
+          state: active
+''', file=fd)
+        netifs.return_value = ['enp3s0f0']
+        iface_for_netdef.return_value = 'enp3s0f0'
+        pci_slot.return_value = '0000:03:00.0'
+        get_ports.return_value = {}
+
+        sriov.apply_sriov_config(self.configmanager, rootdir=self.workdir.name)
+
+        param_set.assert_called_once_with('flow-steering-mode', 'smfs')
+        add_sf.assert_called_once_with(port_index=1, sfnum=1)
+        set_mac.assert_called_once_with('pci/0000:03:00.0/1', '00:11:22:33:44:55')
+        set_state.assert_called_once_with('pci/0000:03:00.0/1', 'active')
+
     @patch('netplan_cli.cli.sriov._get_vf_number_per_pf')
     @patch('netplan_cli.cli.sriov._get_virtual_functions')
     @patch('netplan_cli.cli.sriov._get_physical_functions')
@@ -1588,3 +1622,62 @@ ExecStart=/usr/sbin/netplan apply --sriov-only
     engreen:
       embedded-switch-mode: invalid''', expect_fail=True)
         self.assertIn("needs to be 'switchdev' or 'legacy'", err)
+
+    def test_devlink_params_and_sub_functions_service_generation(self):
+        self.generate('''network:
+  version: 2
+  ethernets:
+    enp3s0:
+      devlink-params:
+        flow-steering-mode: smfs
+      sub-functions:
+        - sfnum: 1
+          hw-address: 00:11:22:33:44:55
+          state: active
+''')
+        self.assert_sriov({'apply.service': '''[Unit]
+Description=Apply SR-IOV configuration
+DefaultDependencies=no
+Before=network-pre.target
+After=sys-subsystem-net-devices-enp3s0.device
+
+[Service]
+Type=oneshot
+ExecStartPre=udevadm control --reload
+ExecStartPre=udevadm trigger --action=add --subsystem-match=net
+ExecStartPre=udevadm settle
+ExecStart=/usr/sbin/netplan apply --sriov-only
+'''})
+
+    def test_devlink_params_and_sub_functions_cffi(self):
+        from utils import state_from_yaml
+        state = state_from_yaml(self.workdir.name, '''network:
+  version: 2
+  ethernets:
+    enp3s0:
+      devlink-params:
+        flow-steering-mode: smfs
+        lag-port-select-mode: multi-port-esw
+      sub-functions:
+        - sfnum: 1
+          hw-address: 00:11:22:33:44:55
+          state: active
+        - sfnum: 2
+          hw-address: 00:11:22:33:44:56
+          state: inactive
+''')
+        netdef = state['enp3s0']
+        self.assertEqual(netdef._devlink_params, {
+            'flow-steering-mode': 'smfs',
+            'lag-port-select-mode': 'multi-port-esw',
+        })
+        self.assertEqual(len(netdef._sub_functions), 2)
+        sf1 = netdef._sub_functions[0]
+        self.assertEqual(sf1.sfnum, 1)
+        self.assertEqual(sf1.hw_address, '00:11:22:33:44:55')
+        self.assertEqual(sf1.state, 'active')
+
+        sf2 = netdef._sub_functions[1]
+        self.assertEqual(sf2.sfnum, 2)
+        self.assertEqual(sf2.hw_address, '00:11:22:33:44:56')
+        self.assertEqual(sf2.state, 'inactive')

--- a/tests/test_sriov.py
+++ b/tests/test_sriov.py
@@ -745,6 +745,86 @@ class TestSRIOV(unittest.TestCase):
         set_mac.assert_called_once_with('pci/0000:03:00.0/1', '00:11:22:33:44:55')
         set_state.assert_called_once_with('pci/0000:03:00.0/1', 'active')
 
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_param_set')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_get_ports')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_add_sf')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_set_sf_hw_addr')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_set_sf_state')
+    @patch('netplan_cli.cli.sriov._get_pci_slot_name')
+    @patch('netplan_cli.cli.sriov._get_interface_name_for_netdef')
+    @patch('netplan_cli.cli.utils.get_interfaces')
+    def test_apply_devlink_params_and_sub_functions_existing_sf(self, netifs, iface_for_netdef, pci_slot,
+                                                                set_state, set_mac, add_sf, get_ports, param_set):
+        with open(os.path.join(self.workdir.name, "etc/netplan/test.yaml"), 'w') as fd:
+            print('''network:
+  version: 2
+  ethernets:
+    enp3s0f0:
+      sub-functions:
+        - sfnum: 1
+          hw-address: "00:11:22:33:44:55"
+          state: active
+''', file=fd)
+        netifs.return_value = ['enp3s0f0']
+        iface_for_netdef.return_value = 'enp3s0f0'
+        pci_slot.return_value = '0000:03:00.0'
+        get_ports.return_value = {
+            'pci/0000:03:00.0/5': {
+                'flavour': 'pcisf',
+                'sfnum': 1,
+            },
+            'pci/other:01:00.0/1': {
+                'flavour': 'pcisf',
+                'sfnum': 1,
+            },
+            'pci/0000:03:00.0/9': {
+                'flavour': 'physical',
+            }
+        }
+
+        sriov.apply_sriov_config(self.configmanager, rootdir=self.workdir.name)
+
+        add_sf.assert_not_called()
+        set_mac.assert_called_once_with('pci/0000:03:00.0/5', '00:11:22:33:44:55')
+        set_state.assert_called_once_with('pci/0000:03:00.0/5', 'active')
+
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_param_set')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_get_ports')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_add_sf')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_set_sf_hw_addr')
+    @patch('netplan_cli.cli.sriov.PCIDevice.devlink_set_sf_state')
+    @patch('netplan_cli.cli.sriov._get_pci_slot_name')
+    @patch('netplan_cli.cli.sriov._get_interface_name_for_netdef')
+    @patch('netplan_cli.cli.utils.get_interfaces')
+    def test_apply_devlink_params_and_sub_functions_errors(self, netifs, iface_for_netdef, pci_slot,
+                                                           set_state, set_mac, add_sf, get_ports, param_set):
+        with open(os.path.join(self.workdir.name, "etc/netplan/test.yaml"), 'w') as fd:
+            print('''network:
+  version: 2
+  ethernets:
+    enp3s0f0:
+      devlink-params:
+        flow-steering-mode: smfs
+      sub-functions:
+        - sfnum: 1
+          hw-address: "00:11:22:33:44:55"
+          state: active
+''', file=fd)
+        netifs.return_value = ['enp3s0f0']
+        iface_for_netdef.return_value = 'enp3s0f0'
+        pci_slot.return_value = '0000:03:00.0'
+        get_ports.return_value = {}
+        param_set.side_effect = subprocess.CalledProcessError(1, 'devlink')
+        add_sf.side_effect = subprocess.CalledProcessError(1, 'devlink')
+
+        # Should log warnings and continue without raising
+        sriov.apply_sriov_config(self.configmanager, rootdir=self.workdir.name)
+
+        add_sf.side_effect = None
+        set_mac.side_effect = subprocess.CalledProcessError(1, 'devlink')
+        set_state.side_effect = subprocess.CalledProcessError(1, 'devlink')
+        sriov.apply_sriov_config(self.configmanager, rootdir=self.workdir.name)
+
     @patch('netplan_cli.cli.sriov._get_vf_number_per_pf')
     @patch('netplan_cli.cli.sriov._get_virtual_functions')
     @patch('netplan_cli.cli.sriov._get_physical_functions')
@@ -1393,6 +1473,69 @@ MODALIAS=pci:v00008086d0000156Fsv000017AAsd00002245bc02sc00i00
         self.assertEqual(pcidev.devlink_eswitch_mode(), '__undetermined')
         check_output_mock.assert_has_calls([
             call(['/sbin/devlink', '-j', 'dev', 'eswitch', 'show', 'pci/0000:03:00.0'], stderr=-3),
+        ])
+
+    @patch('shutil.which', return_value='/sbin/devlink')
+    @patch('subprocess.check_call')
+    def test_PCIDevice_devlink_param_set(self, check_call_mock, which_mock):
+        pcidev = sriov.PCIDevice('0000:03:00.0')
+        pcidev.devlink_param_set('flow-steering-mode', 'smfs')
+        check_call_mock.assert_called_once_with([
+            '/sbin/devlink', 'dev', 'param', 'set', 'pci/0000:03:00.0',
+            'name', 'flow_steering_mode', 'value', 'smfs', 'cmode', 'runtime'
+        ])
+
+    @patch('shutil.which', return_value=None)
+    @patch('subprocess.check_output')
+    def test_PCIDevice_devlink_get_ports(self, check_output_mock, which_mock):
+        pcidev = sriov.PCIDevice('0000:03:00.0')
+        check_output_mock.return_value = '{"port":{"pci/0000:03:00.0/1":{"flavour":"pcisf","sfnum":1}}}'
+        ports = pcidev.devlink_get_ports()
+        self.assertEqual(ports, {"pci/0000:03:00.0/1": {"flavour": "pcisf", "sfnum": 1}})
+        check_output_mock.assert_called_once_with([
+            '/sbin/devlink', '-j', 'port', 'show'
+        ], stderr=-3)
+
+    @patch('subprocess.check_output')
+    def test_PCIDevice_devlink_get_ports_called_process_error(self, check_output_mock):
+        pcidev = sriov.PCIDevice('0000:03:00.0')
+        check_output_mock.side_effect = subprocess.CalledProcessError(1, None)
+        self.assertEqual(pcidev.devlink_get_ports(), {})
+
+    @patch('subprocess.check_output')
+    def test_PCIDevice_devlink_get_ports_json_decode_error(self, check_output_mock):
+        pcidev = sriov.PCIDevice('0000:03:00.0')
+        check_output_mock.return_value = 'not valid json'
+        self.assertEqual(pcidev.devlink_get_ports(), {})
+
+    @patch('shutil.which', return_value='/sbin/devlink')
+    @patch('subprocess.check_call')
+    def test_PCIDevice_devlink_add_sf(self, check_call_mock, which_mock):
+        pcidev = sriov.PCIDevice('0000:03:00.0')
+        pcidev.devlink_add_sf(port_index=1, sfnum=1, pfnum=0)
+        check_call_mock.assert_called_once_with([
+            '/sbin/devlink', 'port', 'add', 'pci/0000:03:00.0/1',
+            'flavour', 'pcisf', 'pfnum', '0', 'sfnum', '1'
+        ])
+
+    @patch('shutil.which', return_value='/sbin/devlink')
+    @patch('subprocess.check_call')
+    def test_PCIDevice_devlink_set_sf_hw_addr(self, check_call_mock, which_mock):
+        pcidev = sriov.PCIDevice('0000:03:00.0')
+        pcidev.devlink_set_sf_hw_addr('pci/0000:03:00.0/1', '00:11:22:33:44:55')
+        check_call_mock.assert_called_once_with([
+            '/sbin/devlink', 'port', 'function', 'set', 'pci/0000:03:00.0/1',
+            'hw_addr', '00:11:22:33:44:55'
+        ])
+
+    @patch('shutil.which', return_value='/sbin/devlink')
+    @patch('subprocess.check_call')
+    def test_PCIDevice_devlink_set_sf_state(self, check_call_mock, which_mock):
+        pcidev = sriov.PCIDevice('0000:03:00.0')
+        pcidev.devlink_set_sf_state('pci/0000:03:00.0/1', 'active')
+        check_call_mock.assert_called_once_with([
+            '/sbin/devlink', 'port', 'function', 'set', 'pci/0000:03:00.0/1',
+            'state', 'active'
         ])
 
 


### PR DESCRIPTION
## Description

This PR introduces declarative Netplan support for:
1. **Generic & vendor-specific devlink device parameters** via `devlink-params:` (e.g., `flow_steering_mode: smfs`, `lag_port_select_mode: multi-port-esw`, `enable_roce: true`).
2. **PCIe Sub-Functions (SFs)** via `sub-functions:` (specifying `sfnum`, `hw-address`, and operational `state` `active`/`inactive`).

### Example YAML configuration:
```yaml
network:
  version: 2
  ethernets:
    enp3s0f0np0:
      embedded-switch-mode: switchdev
      devlink-params:
        flow_steering_mode: smfs
      sub-functions:
        - sfnum: 1
          hw-address: 00:11:22:33:44:55
          state: active
        - sfnum: 2
          hw-address: 00:11:22:33:44:56
          state: inactive
```

### Changes Made:
- **C ABI & Libnetplan Core**:
  - Added `devlink_params` (`GHashTable*`) and `sub_functions` (`GArray*`) fields to [`NetplanNetDefinition`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/src/abi.h).
  - Added `NetplanSubFunction` struct and `NetplanSubFunctionState` enum in [`src/abi.h`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/src/abi.h).
  - Added public iterator APIs (`_netplan_netdef_new_devlink_params_iter`, `_netplan_netdef_new_sub_function_iter`) in [`src/util.c`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/src/util.c).
  - Implemented YAML parsing and validation in [`src/parse.c`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/src/parse.c).
  - Implemented YAML serialization in [`src/netplan.c`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/src/netplan.c).
  - Updated SR-IOV generator in [`src/gen-sriov.c`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/src/gen-sriov.c) to generate `netplan-sriov-apply.service` when devlink params or sub-functions are present.
- **Python CFFI & CLI**:
  - Bound new iterators and structs in [`python-cffi/netplan/_build_cffi.py`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/python-cffi/netplan/_build_cffi.py) and [`python-cffi/netplan/netdef.py`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/python-cffi/netplan/netdef.py).
  - Implemented devlink parameter application and SF lifecycle management (`devlink dev param set`, `devlink port add/function set/activate`) in [`netplan_cli/cli/sriov.py`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/netplan_cli/cli/sriov.py).
- **Tests & Documentation**:
  - Added C unit tests in [`tests/ctests/test_netplan_parser.c`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/tests/ctests/test_netplan_parser.c).
  - Added Python unit tests in [`tests/test_sriov.py`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/tests/test_sriov.py).
  - Documented new properties in [`doc/netplan-yaml.md`](file:///home/zarkdav/Documents/src/github.com/canonical/netplan/doc/netplan-yaml.md).
