### PR TITLE
tests: update faker package version

### DIFF
--- a/tests/config_fuzzer/package.json
+++ b/tests/config_fuzzer/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@faker-js/faker": "^8.4.1",
-    "json-schema-faker": "^0.5.6",
+    "json-schema-faker": "^10.5.0",
     "write-yaml-file": "^5.0.0"
   },
   "name": "netplan_fuzzer",


### PR DESCRIPTION
Dependabot alerts indicated that the current faker package version has a vulnerability. It is fixed in the package version >=10.5